### PR TITLE
Double spacing

### DIFF
--- a/main/helpcontent2/source/text/shared/01/01010203.xhp
+++ b/main/helpcontent2/source/text/shared/01/01010203.xhp
@@ -44,9 +44,9 @@
   <embed href="text/shared/00/00000401.xhp#druckereti"/>
 </section>
   <bookmark branch="hid/sw:RadioButton:TP_LAB_PRT:BTN_PAGE" xml-lang="en-US" id="bm_id3159233"/><paragraph role="heading" level="2" id="hd_id3150713" l10n="U" xml-lang="en-US" oldref="3">Entire Page</paragraph>
-  <paragraph l10n="U" role="paragraph" id="par_id3155355" xml-lang="en-US" oldref="4"><ahelp hid="SW:RADIOBUTTON:TP_LAB_PRT:BTN_PAGE" visibility="visible">Creates a full page of  labels or business cards.</ahelp></paragraph>
+  <paragraph l10n="U" role="paragraph" id="par_id3155355" xml-lang="en-US" oldref="4"><ahelp hid="SW:RADIOBUTTON:TP_LAB_PRT:BTN_PAGE" visibility="visible">Creates a full page of labels or business cards.</ahelp></paragraph>
   <bookmark branch="hid/sw:RadioButton:TP_LAB_PRT:BTN_SINGLE" xml-lang="en-US" id="bm_id3147089"/><paragraph role="heading" level="2" id="hd_id3146958" l10n="U" xml-lang="en-US" oldref="5">Single Label</paragraph>
-  <paragraph l10n="U" role="paragraph" id="par_id3155535" xml-lang="en-US" oldref="6"><ahelp hid="SW:RADIOBUTTON:TP_LAB_PRT:BTN_SINGLE" visibility="visible">Prints a single label or  business card on a page.</ahelp></paragraph>
+  <paragraph l10n="U" role="paragraph" id="par_id3155535" xml-lang="en-US" oldref="6"><ahelp hid="SW:RADIOBUTTON:TP_LAB_PRT:BTN_SINGLE" visibility="visible">Prints a single label or business card on a page.</ahelp></paragraph>
   <bookmark branch="hid/sw:NumericField:TP_LAB_PRT:FLD_COL" xml-lang="en-US" id="bm_id3155338"/><paragraph role="heading" level="2" id="hd_id3148621" l10n="U" xml-lang="en-US" oldref="7">Column</paragraph>
   <paragraph l10n="U" role="paragraph" id="par_id3145345" xml-lang="en-US" oldref="8"><ahelp hid="SW:NUMERICFIELD:TP_LAB_PRT:FLD_COL" visibility="visible">Enter the number of labels or business cards that you want to have in a row on your page.</ahelp></paragraph>
   <bookmark branch="hid/sw:NumericField:TP_LAB_PRT:FLD_ROW" xml-lang="en-US" id="bm_id3150443"/><paragraph role="heading" level="2" id="hd_id3149398" l10n="U" xml-lang="en-US" oldref="9">Row</paragraph>


### PR DESCRIPTION
Line 47  : double spacing between "of" and "labels".  Corrected
Line 49  : double spacing between "or" and "business".  Corrected