### PR TITLE
Double spacing

### DIFF
--- a/main/helpcontent2/source/text/shared/01/05290300.xhp
+++ b/main/helpcontent2/source/text/shared/01/05290300.xhp
@@ -43,7 +43,7 @@
   <section id="howtoget">
   <embed href="text/shared/00/00040502.xhp#adngte"/>
 </section>
-  <paragraph xml-lang="en-US" role="tip" id="par_id3157991" l10n="U" oldref="3">To select an individual object in a group,  hold down <switchinline select="sys"> <caseinline select="MAC">Command</caseinline> <defaultinline>Ctrl</defaultinline> </switchinline>, and then click the object.</paragraph>
+  <paragraph xml-lang="en-US" role="tip" id="par_id3157991" l10n="U" oldref="3">To select an individual object in a group, hold down <switchinline select="sys"> <caseinline select="MAC">Command</caseinline> <defaultinline>Ctrl</defaultinline> </switchinline>, and then click the object.</paragraph>
   <section id="relatedtopics">
   <paragraph l10n="C" role="paragraph" id="par_id3153049" xml-lang="en-US" oldref=""><link href="text/shared/01/05290000.xhp" name="Groups">Groups</link></paragraph>
   <paragraph l10n="C" role="paragraph" id="par_id3148548" xml-lang="en-US" oldref=""><link href="text/shared/01/05290400.xhp" name="Exit Group">Exit Group</link></paragraph>


### PR DESCRIPTION
Line 46 : Double spacing between "group," and "hold".  Corrected