### PR TITLE
Double spacing

### DIFF
--- a/main/helpcontent2/source/text/shared/02/10040000.xhp
+++ b/main/helpcontent2/source/text/shared/02/10040000.xhp
@@ -39,7 +39,7 @@
   <section id="letzteseite">
   <bookmark xml-lang="en-US" branch="hid/.uno:GoToEndOfDoc" id="bm_id5496308" localize="false"/><!-- HID added by script -->
 <bookmark branch="hid/.uno:GoToEndOfDoc" xml-lang="en-US" id="bm_id3156183"/><bookmark xml-lang="en-US" branch="hid/.uno:LastPage" id="bm_id3306707" localize="false"/><!-- HID added by script -->
-<bookmark branch="hid/.uno:LastPage" xml-lang="en-US" id="bm_id3149119"/><paragraph id="hd_id3154840" role="heading" level="1" oldref="1" l10n="U" xml-lang="en-US"><switchinline select="appl"> <caseinline select="WRITER"><link href="text/shared/02/10040000.xhp" name="To  Document End">To  Document End</link></caseinline> <defaultinline><link href="text/shared/02/10040000.xhp" name="Last Page">Last Page</link></defaultinline> </switchinline></paragraph>
+<bookmark branch="hid/.uno:LastPage" xml-lang="en-US" id="bm_id3149119"/><paragraph id="hd_id3154840" role="heading" level="1" oldref="1" l10n="U" xml-lang="en-US"><switchinline select="appl"> <caseinline select="WRITER"><link href="text/shared/02/10040000.xhp" name="To Document End">To Document End</link></caseinline> <defaultinline><link href="text/shared/02/10040000.xhp" name="Last Page">Last Page</link></defaultinline> </switchinline></paragraph>
   <paragraph l10n="U" xml-lang="en-US" oldref="2" role="paragraph" id="par_id3149716"><ahelp hid=".uno:LastPage" visibility="visible">Moves to the last page of the document.</ahelp> This function is only active when you select the <emph>Page Preview</emph> function on the <emph>File</emph> menu.</paragraph>
   </section>
   <section id="syletzteseite">


### PR DESCRIPTION
Line 42 : Double spacing between "To"  and "Document" (twice).  Corrected