### PR TITLE
Double spacing

### DIFF
--- a/main/helpcontent2/source/text/shared/explorer/database/menufilesave.xhp
+++ b/main/helpcontent2/source/text/shared/explorer/database/menufilesave.xhp
@@ -37,7 +37,7 @@
 </meta>
 <body>
 <paragraph role="heading" id="par_idN10547" xml-lang="en-US" level="1" l10n="NEW">Save</paragraph>
-<paragraph role="paragraph" id="par_idN1054B" xml-lang="en-US" l10n="NEW">In this dialog, you can specify the position and name of a form <comment>UFI: spec says also for report, but reports can be created only by Wizard and are autosaved there</comment><comment>UFI: spec says also for query, cannot verify</comment> that you save within a <link href="text/shared/explorer/database/dabadoc.xhp">database file</link>. The dialog opens automatically when you save a form the first time.<comment>UFI: no chance to open the dialog a second time</comment></paragraph>
+<paragraph role="paragraph" id="par_idN1054B" xml-lang="en-US" l10n="NEW">In this dialog, you can specify the position and name of a form <comment>UFI: spec says also for report, but reports can be created only by Wizard and are autosaved there</comment><comment>UFI: spec says also for query, cannot verify</comment>that you save within a <link href="text/shared/explorer/database/dabadoc.xhp">database file</link>. The dialog opens automatically when you save a form the first time.<comment>UFI: no chance to open the dialog a second time</comment></paragraph>
 <bookmark xml-lang="en-US" branch="hid/dbaccess:ImageButton:DLG_COLLECTION_VIEW:BTN_EXPLORERFILE_NEWFOLDER" id="bm_id2862636" localize="false"/>
 <paragraph role="heading" id="par_idN10564" xml-lang="en-US" level="2" l10n="NEW">Create New Directory</paragraph>
 <paragraph role="paragraph" id="par_idN10568" xml-lang="en-US" l10n="NEW"><ahelp hid=".">Click to create a new folder within the database file.</ahelp></paragraph>


### PR DESCRIPTION
Line 40 : Probably due to insertion of a <comment>UFI there was a double spacing in the display of the original Help file.
               In the display of the Help page a double spacing was generated between "form" and "that". 
               Corrected by removing the space between the last </comment> and "that"