### PR TITLE
Replace extension .sxw by .odt in example URL notation (.sxw is old)

### DIFF
--- a/main/helpcontent2/source/text/sbasic/shared/00000002.xhp
+++ b/main/helpcontent2/source/text/sbasic/shared/00000002.xhp
@@ -66,7 +66,7 @@ fpe: added sections and sort element</lastedited>
 <emph>protocol</emph>://<emph>host.name</emph>/<emph>path/to/the/file.html</emph>
 </paragraph>
 <paragraph role="paragraph" id="par_id3168612" xml-lang="en-US" l10n="U" oldref="109">The most common usage of URLs is on the internet when specifying web pages. Example for protocols are <emph>http</emph>, <emph>ftp</emph>, or <emph>file</emph>. The <emph>file</emph> protocol specifier is used when referring to a file on the local file system.</paragraph>
-<paragraph role="paragraph" id="par_id3150324" xml-lang="en-US" l10n="U" oldref="110">URL notation does not allow certain special characters to be used. These are either replaced by other characters or encoded. A slash (<emph>/</emph>) is used as a path separator. For example, a file referred to as <emph>C:\My File.sxw</emph> on the local host in "Windows notation" becomes <emph>file:///C|/My%20File.sxw</emph> in URL notation.</paragraph>
+<paragraph role="paragraph" id="par_id3150324" xml-lang="en-US" l10n="U" oldref="110">URL notation does not allow certain special characters to be used. These are either replaced by other characters or encoded. A slash (<emph>/</emph>) is used as a path separator. For example, a file referred to as <emph>C:\My File.odt</emph> on the local host in "Windows notation" becomes <emph>file:///C|/My%20File.odt</emph> in URL notation.</paragraph>
 </section>
 </sort>
 </body>


### PR DESCRIPTION
Line 69:  <emph>C:\My File.sxw</emph> on the local host in "Windows notation" becomes <emph>file:///C|/My%20File.sxw</emph>
              should be changed to
               <emph>C:\My File.odt</emph> on the local host in "Windows notation" becomes <emph>file:///C|/My%20File.odt</emph>