### PR TITLE
Removed whitespace bewteen tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/02/06030000.xhp
+++ b/main/helpcontent2/source/text/scalc/02/06030000.xhp
@@ -33,10 +33,7 @@
    </meta>
    <body>
       <section id="summe">
-<bookmark xml-lang="en-US" branch="index" id="bm_id3157909"><bookmark_value>functions;sum function icon</bookmark_value>
-         <bookmark_value>formula bar;sum function</bookmark_value>
-         <bookmark_value>sum icon</bookmark_value>
-         <bookmark_value>AutoSum button, see sum icon</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3157909"><bookmark_value>functions;sum function icon</bookmark_value><bookmark_value>formula bar;sum function</bookmark_value><bookmark_value>sum icon</bookmark_value><bookmark_value>AutoSum button, see sum icon</bookmark_value>
 </bookmark>
 <bookmark xml-lang="en-US" branch="hid/SC_HID_INSWIN_SUMME" id="bm_id3151384" localize="false"/><comment>MW inserted a cross-reference</comment>
 <paragraph xml-lang="en-US" id="hd_id3157909" role="heading" level="1" l10n="U" oldref="1"><link href="text/scalc/02/06030000.xhp" name="Sum">Sum</link></paragraph>


### PR DESCRIPTION
Several instances removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
These superfluous whitespaces hindered proper translation.