### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/csv_formula.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/csv_formula.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153726"><bookmark_value>csv files;formulas</bookmark_value>
-      <bookmark_value>formulas; importing/exporting as csv files</bookmark_value>
-      <bookmark_value>exporting;formulas as csv files</bookmark_value>
-      <bookmark_value>importing;csv files with formulas</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153726"><bookmark_value>csv files;formulas</bookmark_value><bookmark_value>formulas; importing/exporting as csv files</bookmark_value><bookmark_value>exporting;formulas as csv files</bookmark_value><bookmark_value>importing;csv files with formulas</bookmark_value>
 </bookmark><comment>mw deleted "inserting;", copied 4 index entries to scalc/guide/csv_files.xhp, changed "csv files;" and "formulas;" and added 2 index entries</comment>
 <paragraph xml-lang="en-US" id="hd_id3153726" role="heading" level="1" l10n="U" oldref="1"><variable id="csv_formula"><link href="text/scalc/guide/csv_formula.xhp" name="Importing and Exporting Text Files">Importing and Exporting CSV Text Files with Formulas</link>
 </variable></paragraph>


### PR DESCRIPTION
Several instances removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
These superfluous whitespace hindered proper translation.