### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/calc_series.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/calc_series.xhp
@@ -32,16 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150769"><bookmark_value>series; calculating</bookmark_value>
-      <bookmark_value>calculating; series</bookmark_value>
-      <bookmark_value>linear series</bookmark_value>
-      <bookmark_value>growth series</bookmark_value>
-      <bookmark_value>date series</bookmark_value>
-      <bookmark_value>powers of 2 calculations</bookmark_value>
-      <bookmark_value>cells; filling automatically</bookmark_value>
-      <bookmark_value>automatic cell filling</bookmark_value>
-      <bookmark_value>AutoFill function</bookmark_value>
-      <bookmark_value>filling;cells, automatically</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150769"><bookmark_value>series; calculating</bookmark_value><bookmark_value>calculating; series</bookmark_value><bookmark_value>linear series</bookmark_value><bookmark_value>growth series</bookmark_value><bookmark_value>date series</bookmark_value><bookmark_value>powers of 2 calculations</bookmark_value><bookmark_value>cells; filling automatically</bookmark_value><bookmark_value>automatic cell filling</bookmark_value><bookmark_value>AutoFill function</bookmark_value><bookmark_value>filling;cells, automatically</bookmark_value>
 </bookmark><comment>mw made "powers of 2;..." a one level entry and changed "AutoFill" entry</comment><comment>MW changed "auto filling cells"</comment>
 <paragraph xml-lang="en-US" id="hd_id3150769" role="heading" level="1" l10n="U" oldref="6"><variable id="calc_series"><link href="text/scalc/guide/calc_series.xhp" name="Automatically Calculating Series">Automatically Filling in Data Based on Adjacent Cells</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
These superfluous whitespace hindered proper translation.