### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/calc_date.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/calc_date.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3146120"><bookmark_value>dates; in cells</bookmark_value>
-      <bookmark_value>times; in cells</bookmark_value>
-      <bookmark_value>cells;date and time formats</bookmark_value>
-      <bookmark_value>current date and time values</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3146120"><bookmark_value>dates; in cells</bookmark_value><bookmark_value>times; in cells</bookmark_value><bookmark_value>cells;date and time formats</bookmark_value><bookmark_value>current date and time values</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3146120" role="heading" level="1" l10n="U"
                  oldref="11"><variable id="calc_date"><link href="text/scalc/guide/calc_date.xhp" name="Calculating With Dates and Times">Calculating With Dates and Times</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
These superfluous whitespace hindered proper translation.