### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/filters.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/filters.xhp
@@ -32,9 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153896"><bookmark_value>filters; applying/removing</bookmark_value>
-      <bookmark_value>rows;removing/redisplaying with filters</bookmark_value>
-      <bookmark_value>removing;filters</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153896"><bookmark_value>filters; applying/removing</bookmark_value><bookmark_value>rows;removing/redisplaying with filters</bookmark_value><bookmark_value>removing;filters</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3153896" role="heading" level="1" l10n="U"
                  oldref="70"><variable id="filters"><link href="text/scalc/guide/filters.xhp" name="Applying Filters">Applying Filters</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.