### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/text_numbers.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/text_numbers.xhp
@@ -32,11 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3145068"><bookmark_value>numbers;entering as text</bookmark_value>
-      <bookmark_value>text formats; for numbers</bookmark_value>
-      <bookmark_value>formats; numbers as text</bookmark_value>
-      <bookmark_value>cell formats; text/numbers</bookmark_value>
-      <bookmark_value>formatting;numbers as text</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3145068"><bookmark_value>numbers;entering as text</bookmark_value><bookmark_value>text formats; for numbers</bookmark_value><bookmark_value>formats; numbers as text</bookmark_value><bookmark_value>cell formats; text/numbers</bookmark_value><bookmark_value>formatting;numbers as text</bookmark_value>
 </bookmark><comment>mw deleted "numbers; entering without..." and changed "numbers;as text"</comment>
 <paragraph xml-lang="en-US" id="hd_id3145068" role="heading" level="1" l10n="U"
                  oldref="46"><variable id="text_numbers"><link href="text/scalc/guide/text_numbers.xhp" name="Formatting Numbers as Text">Formatting Numbers as Text</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.