### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/address_auto.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/address_auto.xhp
@@ -32,17 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3148797"><bookmark_value>automatic addressing in tables</bookmark_value>
-      <bookmark_value>natural language addressing</bookmark_value>
-      <bookmark_value>formulas; using row/column labels</bookmark_value>
-      <bookmark_value>text in cells; as addressing</bookmark_value>
-      <bookmark_value>addressing; automatic</bookmark_value>
-      <bookmark_value>name recognition on/off</bookmark_value>
-      <bookmark_value>row headers;using in formulas</bookmark_value>
-      <bookmark_value>column headers;using in formulas</bookmark_value>
-      <bookmark_value>columns; finding labels automatically</bookmark_value>
-      <bookmark_value>rows; finding labels automatically</bookmark_value>
-      <bookmark_value>recognizing; column and row labels</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3148797"><bookmark_value>automatic addressing in tables</bookmark_value><bookmark_value>natural language addressing</bookmark_value><bookmark_value>formulas; using row/column labels</bookmark_value><bookmark_value>text in cells; as addressing</bookmark_value><bookmark_value>addressing; automatic</bookmark_value><bookmark_value>name recognition on/off</bookmark_value><bookmark_value>row headers;using in formulas</bookmark_value><bookmark_value>column headers;using in formulas</bookmark_value><bookmark_value>columns; finding labels automatically</bookmark_value><bookmark_value>rows; finding labels automatically</bookmark_value><bookmark_value>recognizing; column and row labels</bookmark_value>
 </bookmark><comment>mw changes "names;..." entry to "text in cells;..."</comment><comment>mw inserted three index entries from text/shared/optionen/01060500.xhp. Changed "finding;..." entry to "recognizing;..." entry. Adding (Calc) is no longer necessary in this file.</comment>
 <paragraph xml-lang="en-US" id="hd_id3148797" role="heading" level="1" l10n="U"
                  oldref="20"><variable id="address_auto"><link href="text/scalc/guide/address_auto.xhp" name="Recognizing Names as Addressing">Recognizing Names as Addressing</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.