### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cell_enter.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cell_enter.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150868"><bookmark_value>values; inserting in multiple cells</bookmark_value>
-      <bookmark_value>inserting;values</bookmark_value>
-      <bookmark_value>cell ranges;selecting for data entries</bookmark_value>
-      <bookmark_value>areas, see also cell ranges</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150868"><bookmark_value>values; inserting in multiple cells</bookmark_value><bookmark_value>inserting;values</bookmark_value><bookmark_value>cell ranges;selecting for data entries</bookmark_value><bookmark_value>areas, see also cell ranges</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3405255" role="heading" level="1" l10n="NEW"><variable id="cell_enter"><link href="text/scalc/guide/cell_enter.xhp">Entering Values</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.