### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/datapilot_deletetable.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/datapilot_deletetable.xhp
@@ -32,8 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153726"><bookmark_value>pivot table function; deleting tables</bookmark_value>
-      <bookmark_value>deleting;pivot tables</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153726"><bookmark_value>pivot table function; deleting tables</bookmark_value><bookmark_value>deleting;pivot tables</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3153726" role="heading" level="1" l10n="U" oldref="31"><variable id="datapilot_deletetable"><link href="text/scalc/guide/datapilot_deletetable.xhp" name="Deleting Pivot Tables">Deleting Pivot Tables</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.