### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/dbase_files.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/dbase_files.xhp
@@ -32,11 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id1226844"><bookmark_value>exporting;spreadsheets to dBASE</bookmark_value>
-      <bookmark_value>importing;dBASE files</bookmark_value>
-      <bookmark_value>dBASE import/export</bookmark_value>
-      <bookmark_value>spreadsheets; importing from/exporting to dBASE files</bookmark_value>
-      <bookmark_value>tables in databases;importing dBASE files</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id1226844"><bookmark_value>exporting;spreadsheets to dBASE</bookmark_value><bookmark_value>importing;dBASE files</bookmark_value><bookmark_value>dBASE import/export</bookmark_value><bookmark_value>spreadsheets; importing from/exporting to dBASE files</bookmark_value><bookmark_value>tables in databases;importing dBASE files</bookmark_value>
 </bookmark><comment>mw changed "database tables;" to "tables in databases;" and reduced "spreadsheets;" from two to one entry</comment>
 <paragraph xml-lang="en-US" id="par_idN10738" role="heading" level="1" l10n="NEW"><variable id="dbase_files"><link href="text/scalc/guide/dbase_files.xhp">Importing and Exporting dBASE Files</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.