### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/borders.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/borders.xhp
@@ -32,9 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3457441"><bookmark_value>cells;borders</bookmark_value>
-      <bookmark_value>line arrangements with cells</bookmark_value>
-      <bookmark_value>borders;cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3457441"><bookmark_value>cells;borders</bookmark_value><bookmark_value>line arrangements with cells</bookmark_value><bookmark_value>borders;cells</bookmark_value>
 </bookmark><comment>MW made "line arrangement;" a one level entry</comment>
 <paragraph xml-lang="en-US" id="hd_id4544816" role="heading" level="1" l10n="NEW"><variable id="borders"><link href="text/scalc/guide/borders.xhp">User Defined Borders in Cells</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.