### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cell_protect.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cell_protect.xhp
@@ -32,15 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3146119"><bookmark_value>protecting;cells and sheets</bookmark_value>
-      <bookmark_value>cells; protecting</bookmark_value>
-      <bookmark_value>cell protection; enabling</bookmark_value>
-      <bookmark_value>sheets; protecting</bookmark_value>
-      <bookmark_value>documents; protecting</bookmark_value>
-      <bookmark_value>cells; hiding for printing</bookmark_value>
-      <bookmark_value>changing; sheet protection</bookmark_value>
-      <bookmark_value>hiding;formulas</bookmark_value>
-      <bookmark_value>formulas;hiding</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3146119"><bookmark_value>protecting;cells and sheets</bookmark_value><bookmark_value>cells; protecting</bookmark_value><bookmark_value>cell protection; enabling</bookmark_value><bookmark_value>sheets; protecting</bookmark_value><bookmark_value>documents; protecting</bookmark_value><bookmark_value>cells; hiding for printing</bookmark_value><bookmark_value>changing; sheet protection</bookmark_value><bookmark_value>hiding;formulas</bookmark_value><bookmark_value>formulas;hiding</bookmark_value>
 </bookmark><comment>MW transferred "modifying;..." and "changing;..." into one index entry</comment>
 <paragraph xml-lang="en-US" id="hd_id3146119" role="heading" level="1" l10n="U" oldref="5"><variable id="cell_protect"><link href="text/scalc/guide/cell_protect.xhp" name="Protecting Cells from Changes">Protecting Cells from Changes</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.