### PR TITLE
Removed superfluous whitespace

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cell_protect.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cell_protect.xhp
@@ -81,9 +81,7 @@
       <section id="relatedtopics">
          <embed href="text/scalc/guide/cell_unprotect.xhp#cell_unprotect"/>
          <embed href="text/shared/guide/protection.xhp#protection"/>
-         <paragraph xml-lang="en-US" id="par_idN10B8C" role="paragraph" l10n="NEW">
-            <embedvar href="text/shared/guide/digital_signatures.xhp#digital_signatures"/>
-         </paragraph>
+         <paragraph xml-lang="en-US" id="par_idN10B8C" role="paragraph" l10n="NEW"><embedvar href="text/shared/guide/digital_signatures.xhp#digital_signatures"/></paragraph>
       </section>
    </body>
 </helpdocument>


### PR DESCRIPTION
Removed superfluous whitespace before sentence which disrupted the flow of view and hindered proper translation