### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/auto_off.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/auto_off.xhp
@@ -32,21 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3149456"><bookmark_value>deactivating; automatic changes</bookmark_value>
-      <bookmark_value>tables; deactivating automatic changes in</bookmark_value>
-      <bookmark_value>AutoInput function on/off</bookmark_value>
-      <bookmark_value>text in cells;AutoInput function</bookmark_value>
-      <bookmark_value>cells; AutoInput function of text</bookmark_value>
-      <bookmark_value>input support in spreadsheets</bookmark_value>
-      <bookmark_value>changing; input in cells</bookmark_value>
-      <bookmark_value>AutoCorrect function;cell contents</bookmark_value>
-      <bookmark_value>cell input;AutoInput function</bookmark_value>
-      <bookmark_value>lowercase letters;AutoInput function (in cells)</bookmark_value>
-      <bookmark_value>capital letters;AutoInput function (in cells)</bookmark_value>
-      <bookmark_value>date formats;avoiding conversion to</bookmark_value>
-      <bookmark_value>number completion on/off</bookmark_value>
-      <bookmark_value>text completion on/off</bookmark_value>
-      <bookmark_value>word completion on/off</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3149456"><bookmark_value>deactivating; automatic changes</bookmark_value><bookmark_value>tables; deactivating automatic changes in</bookmark_value><bookmark_value>AutoInput function on/off</bookmark_value><bookmark_value>text in cells;AutoInput function</bookmark_value><bookmark_value>cells; AutoInput function of text</bookmark_value><bookmark_value>input support in spreadsheets</bookmark_value><bookmark_value>changing; input in cells</bookmark_value><bookmark_value>AutoCorrect function;cell contents</bookmark_value><bookmark_value>cell input;AutoInput function</bookmark_value><bookmark_value>lowercase letters;AutoInput function (in cells)</bookmark_value><bookmark_value>capital letters;AutoInput function (in cells)</bookmark_value><bookmark_value>date formats;avoiding conversion to</bookmark_value><bookmark_value>number completion on/off</bookmark_value><bookmark_value>text completion on/off</bookmark_value><bookmark_value>word completion on/off</bookmark_value>
 </bookmark><comment>mw added one entry</comment>
 <paragraph xml-lang="en-US" id="hd_id3149456" role="heading" level="1" l10n="U" oldref="1"><variable id="auto_off"><link href="text/scalc/guide/auto_off.xhp" name="Deactivating Automatic Changes">Deactivating Automatic Changes</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.