### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/note_insert.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/note_insert.xhp
@@ -32,12 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153968"><bookmark_value>comments; on cells</bookmark_value>
-      <bookmark_value>cells;comments</bookmark_value>
-      <bookmark_value>remarks on cells</bookmark_value>
-      <bookmark_value>formatting;comments on cells</bookmark_value>
-      <bookmark_value>viewing;comments on cells</bookmark_value>
-      <bookmark_value>displaying; comments</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153968"><bookmark_value>comments; on cells</bookmark_value><bookmark_value>cells;comments</bookmark_value><bookmark_value>remarks on cells</bookmark_value><bookmark_value>formatting;comments on cells</bookmark_value><bookmark_value>viewing;comments on cells</bookmark_value><bookmark_value>displaying; comments</bookmark_value>
 </bookmark><comment>MW deleted double index "comments;on cells" and copied "displaying;comments" from shared/optionen/01060100.xhp</comment>
 <paragraph xml-lang="en-US" id="hd_id3153968" role="heading" level="1" l10n="U"
                  oldref="31"><variable id="note_insert"><link href="text/scalc/guide/note_insert.xhp" name="Inserting and Editing Comments">Inserting and Editing Comments</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.