### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/multitables.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/multitables.xhp
@@ -32,13 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3154759"><bookmark_value>sheets; inserting</bookmark_value>
-      <bookmark_value>inserting; sheets</bookmark_value>
-      <bookmark_value>sheets; selecting multiple</bookmark_value>
-      <bookmark_value>appending sheets</bookmark_value>
-      <bookmark_value>selecting;multiple sheets</bookmark_value>
-      <bookmark_value>multiple sheets</bookmark_value>
-      <bookmark_value>calculating;multiple sheets</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3154759"><bookmark_value>sheets; inserting</bookmark_value><bookmark_value>inserting; sheets</bookmark_value><bookmark_value>sheets; selecting multiple</bookmark_value><bookmark_value>appending sheets</bookmark_value><bookmark_value>selecting;multiple sheets</bookmark_value><bookmark_value>multiple sheets</bookmark_value><bookmark_value>calculating;multiple sheets</bookmark_value>
 </bookmark><comment>MW moved "sheets;simultaneous.." to edit_multitables.xhp, transferred 2 entries from there and added "calculating;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3154759" role="heading" level="1" l10n="U" oldref="9"><variable id="multitables"><link href="text/scalc/guide/multitables.xhp" name="Applying Multiple Sheets">Applying Multiple Sheets</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.