### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/database_define.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/database_define.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3154758"><bookmark_value>tables; database ranges</bookmark_value>
-      <bookmark_value>database ranges; defining</bookmark_value>
-      <bookmark_value>ranges; defining database ranges</bookmark_value>
-      <bookmark_value>defining;database ranges</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3154758"><bookmark_value>tables; database ranges</bookmark_value><bookmark_value>database ranges; defining</bookmark_value><bookmark_value>ranges; defining database ranges</bookmark_value><bookmark_value>defining;database ranges</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3154758" role="heading" level="1" l10n="U"
                  oldref="31"><variable id="database_define"><link href="text/scalc/guide/database_define.xhp" name="Defining Database Ranges">Defining a Database Range</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.