### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/table_cellmerge.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/table_cellmerge.xhp
@@ -32,11 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3147240"><bookmark_value>cells; merging/unmerging</bookmark_value>
-      <bookmark_value>tables; merging cells</bookmark_value>
-      <bookmark_value>cell merges</bookmark_value>
-      <bookmark_value>unmerging cells</bookmark_value>
-      <bookmark_value>merging;cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3147240"><bookmark_value>cells; merging/unmerging</bookmark_value><bookmark_value>tables; merging cells</bookmark_value><bookmark_value>cell merges</bookmark_value><bookmark_value>unmerging cells</bookmark_value><bookmark_value>merging;cells</bookmark_value>
 </bookmark><comment>MW made "cell merges;..." a one level entry</comment>
 <paragraph xml-lang="en-US" id="hd_id8005005" role="heading" level="1" l10n="NEW"><variable id="table_cellmerge"><link href="text/scalc/guide/table_cellmerge.xhp" name="Merging and Unmerging Cells">Merging and Unmerging Cells</link>
 </variable><comment>mw created this file out of the shared guide "table_cellmerge.xhp", see also bug #63021</comment></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.