### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/mark_cells.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/mark_cells.xhp
@@ -32,12 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153361"><bookmark_value>cells; selecting</bookmark_value>
-      <bookmark_value>marking cells</bookmark_value>
-      <bookmark_value>selecting;cells</bookmark_value>
-      <bookmark_value>multiple cells selection</bookmark_value>
-      <bookmark_value>selection modes in spreadsheets</bookmark_value>
-      <bookmark_value>tables; selecting ranges</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153361"><bookmark_value>cells; selecting</bookmark_value><bookmark_value>marking cells</bookmark_value><bookmark_value>selecting;cells</bookmark_value><bookmark_value>multiple cells selection</bookmark_value><bookmark_value>selection modes in spreadsheets</bookmark_value><bookmark_value>tables; selecting ranges</bookmark_value>
 </bookmark><comment>mw changed "selection modes..."</comment>
 <paragraph xml-lang="en-US" id="hd_id3153361" role="heading" level="1" l10n="U" oldref="1"><variable id="mark_cells"><link href="text/scalc/guide/mark_cells.xhp" name="Selecting Multiple Cells">Selecting Multiple Cells</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.