### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/numbers_text.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/numbers_text.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3145068"><bookmark_value>formats; text as numbers</bookmark_value>
-      <bookmark_value>time format conversion</bookmark_value>
-      <bookmark_value>date formats;conversion</bookmark_value>
-      <bookmark_value>converting;text, into numbers</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3145068"><bookmark_value>formats; text as numbers</bookmark_value><bookmark_value>time format conversion</bookmark_value><bookmark_value>date formats;conversion</bookmark_value><bookmark_value>converting;text, into numbers</bookmark_value>
 </bookmark><comment>mw changed "converting;" and added two index entries</comment>
 <paragraph xml-lang="en-US" id="hd_id0908200901265171" role="heading" level="1" l10n="NEW"><variable id="numbers_text"><link href="text/scalc/guide/numbers_text.xhp" name="Converting Text to Numbers">Converting Text to Numbers</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespace hindered proper translation.