### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cellstyle_minusvalue.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cellstyle_minusvalue.xhp
@@ -32,11 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3147434"><bookmark_value>negative numbers</bookmark_value>
-      <bookmark_value>numbers; highlighting negative numbers</bookmark_value>
-      <bookmark_value>highlighting;negative numbers</bookmark_value>
-      <bookmark_value>colors;negative numbers</bookmark_value>
-      <bookmark_value>number formats;colors for negative numbers</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3147434"><bookmark_value>negative numbers</bookmark_value><bookmark_value>numbers; highlighting negative numbers</bookmark_value><bookmark_value>highlighting;negative numbers</bookmark_value><bookmark_value>colors;negative numbers</bookmark_value><bookmark_value>number formats;colors for negative numbers</bookmark_value>
 </bookmark><comment>MW made "negative numbers;" a one level entry</comment><comment>MW changed "numbers formats;" and "colors;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3147434" role="heading" level="1" l10n="U"
                  oldref="31"><variable id="cellstyle_minusvalue"><link href="text/scalc/guide/cellstyle_minusvalue.xhp" name="Highlighting Negative Numbers">Highlighting Negative Numbers</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.