### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cellreferences.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cellreferences.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3147436"><bookmark_value>sheet references</bookmark_value>
-      <bookmark_value>references; to cells in other sheets/documents</bookmark_value>
-      <bookmark_value>cells; operating in another document</bookmark_value>
-      <bookmark_value>documents;references</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3147436"><bookmark_value>sheet references</bookmark_value><bookmark_value>references; to cells in other sheets/documents</bookmark_value><bookmark_value>cells; operating in another document</bookmark_value><bookmark_value>documents;references</bookmark_value>
 </bookmark><comment>mw made "sheet references;" a one level entry</comment><comment>MW changed "references;" and added "documents;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3147436" role="heading" level="1" l10n="CHG"
                  oldref="9"><variable id="cellreferences"><link href="text/scalc/guide/cellreferences.xhp" name="Referencing Other Sheets">Referencing Other Sheets</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.