### PR TITLE
Update text_rotate.xhp

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/text_rotate.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/text_rotate.xhp
@@ -32,9 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3151112"><bookmark_value>cells; rotating text</bookmark_value>
-      <bookmark_value>rotating; text in cells</bookmark_value>
-      <bookmark_value>text in cells; writing vertically</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3151112"><bookmark_value>cells; rotating text</bookmark_value><bookmark_value>rotating; text in cells</bookmark_value><bookmark_value>text in cells; writing vertically</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3151112" role="heading" level="1" l10n="U" oldref="1"><variable id="text_rotate"><link href="text/scalc/guide/text_rotate.xhp" name="Rotating Text">Rotating Text</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.