### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/consolidate.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/consolidate.xhp
@@ -32,12 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150791"><bookmark_value>consolidating data</bookmark_value>
-      <bookmark_value>ranges; combining</bookmark_value>
-      <bookmark_value>combining;cell ranges</bookmark_value>
-      <bookmark_value>tables; combining</bookmark_value>
-      <bookmark_value>data; merging cell ranges</bookmark_value>
-      <bookmark_value>merging;data ranges</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150791"><bookmark_value>consolidating data</bookmark_value><bookmark_value>ranges; combining</bookmark_value><bookmark_value>combining;cell ranges</bookmark_value><bookmark_value>tables; combining</bookmark_value><bookmark_value>data; merging cell ranges</bookmark_value><bookmark_value>merging;data ranges</bookmark_value>
 </bookmark><comment>mw deleted "values;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3150791" role="heading" level="1" l10n="U" oldref="5"><variable id="consolidate"><link href="text/scalc/guide/consolidate.xhp" name="Consolidating Data">Consolidating Data</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.