### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cellstyle_by_formula.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cellstyle_by_formula.xhp
@@ -32,11 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3145673"><bookmark_value>formats; assigning by formulas</bookmark_value>
-      <bookmark_value>cell formats; assigning by formulas</bookmark_value>
-      <bookmark_value>STYLE function example</bookmark_value>
-      <bookmark_value>cell styles;assigning by formulas</bookmark_value>
-      <bookmark_value>formulas;assigning cell formats</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3145673"><bookmark_value>formats; assigning by formulas</bookmark_value><bookmark_value>cell formats; assigning by formulas</bookmark_value><bookmark_value>STYLE function example</bookmark_value><bookmark_value>cell styles;assigning by formulas</bookmark_value><bookmark_value>formulas;assigning cell formats</bookmark_value>
 </bookmark><comment>mw deleted "applying;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3145673" role="heading" level="1" l10n="U"
                  oldref="13"><variable id="cellstyle_by_formula"><link href="text/scalc/guide/cellstyle_by_formula.xhp" name="Assigning Formats by Formula">Assigning Formats by Formula</link> 


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.