### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/autoformat.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/autoformat.xhp
@@ -32,12 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3155132"><bookmark_value>tables; AutoFormat function</bookmark_value>
-      <bookmark_value>defining;AutoFormat function for tables</bookmark_value>
-      <bookmark_value>AutoFormat function</bookmark_value>
-      <bookmark_value>formats; automatically formatting spreadsheets</bookmark_value>
-      <bookmark_value>automatic formatting in spreadsheets</bookmark_value>
-      <bookmark_value>sheets;AutoFormat function</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3155132"><bookmark_value>tables; AutoFormat function</bookmark_value><bookmark_value>defining;AutoFormat function for tables</bookmark_value><bookmark_value>AutoFormat function</bookmark_value><bookmark_value>formats; automatically formatting spreadsheets</bookmark_value><bookmark_value>automatic formatting in spreadsheets</bookmark_value><bookmark_value>sheets;AutoFormat function</bookmark_value>
 </bookmark><comment>MW deleted "applying;"</comment><comment>MW made "AutoFormat function;" a one level entry</comment>
 <paragraph xml-lang="en-US" id="hd_id3155132" role="heading" level="1" l10n="U"
                  oldref="11"><variable id="autoformat"><link href="text/scalc/guide/autoformat.xhp" name="Using AutoFormat for Tables">Applying Automatic Formatting to a Selected Cell Range</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.