### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cellstyle_conditional.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cellstyle_conditional.xhp
@@ -32,15 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3149263"><bookmark_value>conditional formatting; cells</bookmark_value>
-      <bookmark_value>cells; conditional formatting</bookmark_value>
-      <bookmark_value>formatting; conditional formatting</bookmark_value>
-      <bookmark_value>styles;conditional styles</bookmark_value>
-      <bookmark_value>cell formats; conditional</bookmark_value>
-      <bookmark_value>random numbers;examples</bookmark_value>
-      <bookmark_value>cell styles; copying</bookmark_value>
-      <bookmark_value>copying; cell styles</bookmark_value>
-      <bookmark_value>tables; copying cell styles</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3149263"><bookmark_value>conditional formatting; cells</bookmark_value><bookmark_value>cells; conditional formatting</bookmark_value><bookmark_value>formatting; conditional formatting</bookmark_value><bookmark_value>styles;conditional styles</bookmark_value><bookmark_value>cell formats; conditional</bookmark_value><bookmark_value>random numbers;examples</bookmark_value><bookmark_value>cell styles; copying</bookmark_value><bookmark_value>copying; cell styles</bookmark_value><bookmark_value>tables; copying cell styles</bookmark_value>
 </bookmark><comment>mw deleted "formats;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3149263" role="heading" level="1" l10n="U"
                  oldref="24"><variable id="cellstyle_conditional"><link href="text/scalc/guide/cellstyle_conditional.xhp" name="Applying Conditional Formatting">Applying Conditional Formatting</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.