### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cell_unprotect.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cell_unprotect.xhp
@@ -32,9 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153252"><bookmark_value>cell protection; unprotecting</bookmark_value>
-      <bookmark_value>protecting; unprotecting cells</bookmark_value>
-      <bookmark_value>unprotecting cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153252"><bookmark_value>cell protection; unprotecting</bookmark_value><bookmark_value>protecting; unprotecting cells</bookmark_value><bookmark_value>unprotecting cells</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3153252" role="heading" level="1" l10n="U"
                  oldref="14"><variable id="cell_unprotect"><link href="text/scalc/guide/cell_unprotect.xhp" name="Unprotecting Cells">Unprotecting Cells</link> 


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.