### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/autofilter.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/autofilter.xhp
@@ -32,13 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3156423"><bookmark_value>filters, see also AutoFilter function</bookmark_value>
-      <bookmark_value>AutoFilter function;applying</bookmark_value>
-      <bookmark_value>sheets; filter values</bookmark_value>
-      <bookmark_value>numbers; filter sheets</bookmark_value>
-      <bookmark_value>columns; AutoFilter function</bookmark_value>
-      <bookmark_value>drop-down menus in sheet columns</bookmark_value>
-      <bookmark_value>database ranges; AutoFilter function</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3156423"><bookmark_value>filters, see also AutoFilter function</bookmark_value><bookmark_value>AutoFilter function;applying</bookmark_value><bookmark_value>sheets; filter values</bookmark_value><bookmark_value>numbers; filter sheets</bookmark_value><bookmark_value>columns; AutoFilter function</bookmark_value><bookmark_value>drop-down menus in sheet columns</bookmark_value><bookmark_value>database ranges; AutoFilter function</bookmark_value>
 </bookmark><comment>mw made "drop-down..." a one level entry and added a "see also" reference</comment>
 <paragraph xml-lang="en-US" id="hd_id3156423" role="heading" level="1" l10n="U" oldref="6"><variable id="autofilter"><link href="text/scalc/guide/autofilter.xhp" name="Applying AutoFilter">Applying AutoFilter</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.