### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/cellcopy.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/cellcopy.xhp
@@ -32,15 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150440"><bookmark_value>cells; copying/deleting/formatting/moving</bookmark_value>
-      <bookmark_value>rows;visible and invisible</bookmark_value>
-      <bookmark_value>copying; visible cells only</bookmark_value>
-      <bookmark_value>formatting;visible cells only</bookmark_value>
-      <bookmark_value>moving;visible cells only</bookmark_value>
-      <bookmark_value>deleting;visible cells only</bookmark_value>
-      <bookmark_value>invisible cells</bookmark_value>
-      <bookmark_value>filters;copying visible cells only</bookmark_value>
-      <bookmark_value>hidden cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150440"><bookmark_value>cells; copying/deleting/formatting/moving</bookmark_value><bookmark_value>rows;visible and invisible</bookmark_value><bookmark_value>copying; visible cells only</bookmark_value><bookmark_value>formatting;visible cells only</bookmark_value><bookmark_value>moving;visible cells only</bookmark_value><bookmark_value>deleting;visible cells only</bookmark_value><bookmark_value>invisible cells</bookmark_value><bookmark_value>filters;copying visible cells only</bookmark_value><bookmark_value>hidden cells</bookmark_value>
 </bookmark><comment>mw changed "cells;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3150440" role="heading" level="1" l10n="U" oldref="1"><variable id="cellcopy"><link href="text/scalc/guide/cellcopy.xhp" name="Only Copy Visible Cells">Only Copy Visible Cells</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.