### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/integer_leading_zero.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/integer_leading_zero.xhp
@@ -32,14 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3147560"><bookmark_value>zero values; entering leading zeros</bookmark_value>
-      <bookmark_value>numbers; with leading zeros</bookmark_value>
-      <bookmark_value>leading zeros</bookmark_value>
-      <bookmark_value>integers with leading zeros</bookmark_value>
-      <bookmark_value>cells; changing text/number formats</bookmark_value>
-      <bookmark_value>formats; changing text/number</bookmark_value>
-      <bookmark_value>text in cells; changing to numbers</bookmark_value>
-      <bookmark_value>converting;text with leading zeros, into numbers</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3147560"><bookmark_value>zero values; entering leading zeros</bookmark_value><bookmark_value>numbers; with leading zeros</bookmark_value><bookmark_value>leading zeros</bookmark_value><bookmark_value>integers with leading zeros</bookmark_value><bookmark_value>cells; changing text/number formats</bookmark_value><bookmark_value>formats; changing text/number</bookmark_value><bookmark_value>text in cells; changing to numbers</bookmark_value><bookmark_value>converting;text with leading zeros, into numbers</bookmark_value>
 </bookmark><comment>UFI: inserted "converting;text to numbers"</comment><comment>mw changed "converting;" and deleted "numbers,changing..."</comment>
 <paragraph xml-lang="en-US" id="hd_id3147560" role="heading" level="1" l10n="U"
                  oldref="67"><variable id="integer_leading_zero"><link href="text/scalc/guide/integer_leading_zero.xhp" name="Entering a Number with Leading Zeros">Entering a Number with Leading Zeros</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.