### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/format_value.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/format_value.xhp
@@ -32,16 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3145367"><bookmark_value>numbers;formatting decimals</bookmark_value>
-      <bookmark_value>formats; numbers in tables</bookmark_value>
-      <bookmark_value>tables; number formats</bookmark_value>
-      <bookmark_value>defaults; number formats in spreadsheets</bookmark_value>
-      <bookmark_value>decimal places;formatting numbers</bookmark_value>
-      <bookmark_value>formatting;numbers with decimals</bookmark_value>
-      <bookmark_value>formatting;adding/deleting decimal places</bookmark_value>
-      <bookmark_value>number formats; adding/deleting decimal places in cells</bookmark_value>
-      <bookmark_value>deleting; decimal places</bookmark_value>
-      <bookmark_value>decimal places; adding/deleting</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3145367"><bookmark_value>numbers;formatting decimals</bookmark_value><bookmark_value>formats; numbers in tables</bookmark_value><bookmark_value>tables; number formats</bookmark_value><bookmark_value>defaults; number formats in spreadsheets</bookmark_value><bookmark_value>decimal places;formatting numbers</bookmark_value><bookmark_value>formatting;numbers with decimals</bookmark_value><bookmark_value>formatting;adding/deleting decimal places</bookmark_value><bookmark_value>number formats; adding/deleting decimal places in cells</bookmark_value><bookmark_value>deleting; decimal places</bookmark_value><bookmark_value>decimal places; adding/deleting</bookmark_value>
 </bookmark><comment>mw changed "numbers;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3145367" role="heading" level="1" l10n="U" oldref="4"><variable id="format_value"><link href="text/scalc/guide/format_value.xhp" name="Formatting Numbers With Decimals">Formatting Numbers With Decimals</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.