### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/background.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/background.xhp
@@ -32,12 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3149346"><bookmark_value>spreadsheets; backgrounds</bookmark_value>
-      <bookmark_value>backgrounds;cell ranges</bookmark_value>
-      <bookmark_value>tables; backgrounds</bookmark_value>
-      <bookmark_value>cells; backgrounds</bookmark_value>
-      <bookmark_value>rows, see also cells</bookmark_value>
-      <bookmark_value>columns, see also cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3149346"><bookmark_value>spreadsheets; backgrounds</bookmark_value><bookmark_value>backgrounds;cell ranges</bookmark_value><bookmark_value>tables; backgrounds</bookmark_value><bookmark_value>cells; backgrounds</bookmark_value><bookmark_value>rows, see also cells</bookmark_value><bookmark_value>columns, see also cells</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3149346" role="heading" level="1" l10n="U" oldref="1"><variable id="background"><link href="text/scalc/guide/background.xhp" name="Defining Background Colors or Background Graphics">Defining Background Colors or Background Graphics</link>
 </variable></paragraph><comment>MW created this file from splitting shared/guide/background.xhp</comment>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.