### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/rename_table.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/rename_table.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150398"><bookmark_value>renaming;sheets</bookmark_value>
-      <bookmark_value>sheet tabs;renaming</bookmark_value>
-      <bookmark_value>tables;renaming</bookmark_value>
-      <bookmark_value>names; sheets</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150398"><bookmark_value>renaming;sheets</bookmark_value><bookmark_value>sheet tabs;renaming</bookmark_value><bookmark_value>tables;renaming</bookmark_value><bookmark_value>names; sheets</bookmark_value>
 </bookmark><comment>mw made "renaming sheets" a two level entry.</comment>
 <paragraph xml-lang="en-US" id="hd_id3150398" role="heading" level="1" l10n="U"
                  oldref="11"><variable id="rename_table"><link href="text/scalc/guide/rename_table.xhp" name="Renaming Sheets">Renaming Sheets</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.