### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/database_sort.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/database_sort.xhp
@@ -32,9 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3150767"><bookmark_value>database ranges; sorting</bookmark_value>
-      <bookmark_value>sorting; database ranges</bookmark_value>
-      <bookmark_value>data;sorting in databases</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3150767"><bookmark_value>database ranges; sorting</bookmark_value><bookmark_value>sorting; database ranges</bookmark_value><bookmark_value>data;sorting in databases</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3150767" role="heading" level="1" l10n="U"
                  oldref="44"><variable id="database_sort"><link href="text/scalc/guide/database_sort.xhp" name="Sorting Database Ranges">Sorting Data</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.