### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/value_with_name.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/value_with_name.xhp
@@ -32,19 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3147434"><bookmark_value>cells; defining names</bookmark_value>
-      <bookmark_value>names; defining for cells</bookmark_value>
-      <bookmark_value>values; defining names</bookmark_value>
-      <bookmark_value>constants definition</bookmark_value>
-      <bookmark_value>variables; defining names</bookmark_value>
-      <bookmark_value>cell ranges; defining names</bookmark_value>
-      <bookmark_value>defining;names for cell ranges</bookmark_value>
-      <bookmark_value>formulas; defining names</bookmark_value>
-      <bookmark_value>addressing; by defined names</bookmark_value>
-      <bookmark_value>cell names; defining/addressing</bookmark_value>
-      <bookmark_value>references; by defined names</bookmark_value>
-      <bookmark_value>allowed cell names</bookmark_value>
-      <bookmark_value>renaming;cells</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3147434"><bookmark_value>cells; defining names</bookmark_value><bookmark_value>names; defining for cells</bookmark_value><bookmark_value>values; defining names</bookmark_value><bookmark_value>constants definition</bookmark_value><bookmark_value>variables; defining names</bookmark_value><bookmark_value>cell ranges; defining names</bookmark_value><bookmark_value>defining;names for cell ranges</bookmark_value><bookmark_value>formulas; defining names</bookmark_value><bookmark_value>addressing; by defined names</bookmark_value><bookmark_value>cell names; defining/addressing</bookmark_value><bookmark_value>references; by defined names</bookmark_value><bookmark_value>allowed cell names</bookmark_value<bookmark_value>renaming;cells</bookmark_value>
 </bookmark><comment>mw changed "names;...", "addressing;..." and "references,..."  entries.</comment><comment>mw added "renaming;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3147434" role="heading" level="1" l10n="U" oldref="1"><variable id="value_with_name"><link href="text/scalc/guide/value_with_name.xhp" name="Naming Cells">Naming Cells</link>
 </variable></paragraph>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.