### PR TITLE
Removed whitespace between tags bookmark_value

### DIFF
--- a/main/helpcontent2/source/text/scalc/guide/database_filter.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/database_filter.xhp
@@ -32,10 +32,7 @@
       </topic>
    </meta>
    <body>
-<bookmark xml-lang="en-US" branch="index" id="bm_id3153541"><bookmark_value>cell ranges;applying/removing filters</bookmark_value>
-      <bookmark_value>filtering;cell ranges/database ranges</bookmark_value>
-      <bookmark_value>database ranges;applying/removing filters</bookmark_value>
-      <bookmark_value>removing;cell range filters</bookmark_value>
+<bookmark xml-lang="en-US" branch="index" id="bm_id3153541"><bookmark_value>cell ranges;applying/removing filters</bookmark_value><bookmark_value>filtering;cell ranges/database ranges</bookmark_value><bookmark_value>database ranges;applying/removing filters</bookmark_value><bookmark_value>removing;cell range filters</bookmark_value>
 </bookmark><comment>MW changed "cell ranges," added "removing;" and made one "database ranges;" entry out of two. Same for "filtering;"</comment>
 <paragraph xml-lang="en-US" id="hd_id3153541" role="heading" level="1" l10n="CHG"
                  oldref="47"><variable id="database_filter"><link href="text/scalc/guide/database_filter.xhp" name="Filtering Cell Ranges">Filtering Cell Ranges</link>
@@ -57,8 +54,7 @@
             <paragraph xml-lang="en-US" id="par_id3153143" role="paragraph" l10n="U" oldref="52">The records that match the filter options that you specified are shown.</paragraph>
          </listitem>
       </list>
-      <paragraph xml-lang="en-US" id="par_id3153728" role="heading" level="2" l10n="CHG"
-                 oldref="53">To Apply an AutoFilter to a Cell Range</paragraph>
+      <paragraph xml-lang="en-US" id="par_id3153728" role="heading" level="2" l10n="CHG" oldref="53">To Apply an AutoFilter to a Cell Range</paragraph>
       <list type="ordered">
          <listitem>
             <paragraph xml-lang="en-US" id="par_id3144764" role="listitem" l10n="CHG" oldref="54">Click in a cell range or a database range.</paragraph>

--- a/main/helpcontent2/source/text/scalc/guide/database_sort.xhp
+++ b/main/helpcontent2/source/text/scalc/guide/database_sort.xhp
@@ -33,8 +33,8 @@
    </meta>
    <body>
 <bookmark xml-lang="en-US" branch="index" id="bm_id3150767"><bookmark_value>database ranges; sorting</bookmark_value>
-      <bookmark_value>sorting; database ranges</bookmark_value>
-      <bookmark_value>data;sorting in databases</bookmark_value>
+<bookmark_value>sorting; database ranges</bookmark_value>
+<bookmark_value>data;sorting in databases</bookmark_value>
 </bookmark>
 <paragraph xml-lang="en-US" id="hd_id3150767" role="heading" level="1" l10n="U"
                  oldref="44"><variable id="database_sort"><link href="text/scalc/guide/database_sort.xhp" name="Sorting Database Ranges">Sorting Data</link>


### PR DESCRIPTION
One instance removed which disrupted the flow of view and were probably placed for reasons of readability in the original code files.
This superfluous whitespaces hindered proper translation.