### PR TITLE
Force Linux builds to use gnu++98 (C++98 + GNU extensions) mode to be

### DIFF
--- a/main/solenv/gbuild/platform/linux.mk
+++ b/main/solenv/gbuild/platform/linux.mk
@@ -89,6 +89,7 @@ gb_CXXFLAGS := \
 	-fuse-cxa-atexit \
 	-fvisibility-inlines-hidden \
 	-fvisibility=hidden \
+	-std=gnu++98 \
 	-pipe \
 
 ifneq ($(EXTERNAL_WARNINGS_NOT_ERRORS),TRUE)

--- a/main/solenv/inc/unxlng.mk
+++ b/main/solenv/inc/unxlng.mk
@@ -88,7 +88,7 @@ CFLAGSEXCEPTIONS=-fexceptions -fno-enforce-eh-specs
 CFLAGS_NO_EXCEPTIONS=-fno-exceptions
 
 # -fpermissive should be removed as soon as possible
-CFLAGSCXX= -pipe $(ARCH_FLAGS)
+CFLAGSCXX= -pipe $(ARCH_FLAGS) -std=gnu++98
 .IF "$(HAVE_GCC_VISIBILITY_FEATURE)" == "TRUE"
 CFLAGSCXX += -fvisibility-inlines-hidden
 .ENDIF # "$(HAVE_GCC_VISIBILITY_FEATURE)" == "TRUE"


### PR DESCRIPTION
Force Linux builds to use gnu++98 (C++98 + GNU extensions) mode to be
the most compatible with our old code base rather than relying on the
compiler default mode.  Compiling in C++11 or newer mode is very noisy
due to deprecation warnings about our use of std::auto_ptr.  If the
compiler defaults to C++17 mode or newer, the build would be totally
broken because std::auto_ptr is removed from C++17.

There is an unknown amount of porting effort needed to convert to
std::unique_ptr, which has somewhat different semantics and which is
not available before C++11, which would break building with older versions
of gcc which default to gnu++98 mode.

std::shared_ptr, might be an alternative since there is a BOOST
implementation.

This reduction of compiler warnings reduces the size of the build log by
2/3rd when compiling with gcc 6.3.0.