### PR TITLE
updated junit url to https for BVT test ant build

### DIFF
--- a/test/build.xml
+++ b/test/build.xml
@@ -27,7 +27,7 @@
 	<property name="junit.home" value="${env.JUNIT_HOME}" />
 	<property name="dist.dir" value="." />
 	<property name="dist.name" value="aoo_test" />
-	<property name="junit.jar.repos" value="http://repo1.maven.org/maven2/junit/junit/4.10/junit-4.10.jar" />
+	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.10/junit-4.10.jar" />
 	
 	<path id="uno.classpath">
 		<fileset dir="${env.OUTDIR}/bin" erroronmissingdir="false">


### PR DESCRIPTION
Ant build can't fetch junit since it requires https now.

501 HTTPS Required.
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required