### PR TITLE
Update GetProductName function

### DIFF
--- a/main/wizards/source/tools/Misc.xba
+++ b/main/wizards/source/tools/Misc.xba
@@ -133,7 +133,7 @@ Dim sProdName as String
 	oProdNameAccess = GetRegistryKeyContent(&quot;org.openoffice.Setup/Product&quot;)
 	sProdName = oProdNameAccess.getByName(&quot;ooName&quot;)
 	sVersion = oProdNameAccess.getByName(&quot;ooSetupVersion&quot;)
-	GetProductName = sProdName &amp; sVersion
+	GetProductName = sProdName &amp; &quot; &quot; &amp; sVersion
 End Function
 
 


### PR DESCRIPTION
Modify GetProductInfo function
Actually returns Product Name and Build version in one string
Example: OpenOffice4.1.7
Adding a space between these to split in two strings
Now: OpenOffice 4.1.7