### PR TITLE
Fix build when configured with --without-fonts

### DIFF
--- a/main/scp2/source/ooo/file_font_ooo.scp
+++ b/main/scp2/source/ooo/file_font_ooo.scp
@@ -94,6 +94,17 @@ STD_FONT_FILE( gid_File_Fnt_Caladea_Bold, Caladea-Bold.ttf, Caladea Bold)
 STD_FONT_FILE( gid_File_Fnt_Caladea_Italic, Caladea-Italic.ttf, Caladea Italic)
 STD_FONT_FILE( gid_File_Fnt_Caladea_BoldItalic, Caladea-BoldItalic.ttf, Caladea Bold Italic)
 
+// fontconfig updates to allow proper use of local fonts
+
+#ifdef UNX
+File gid_File_FcLocal_Conf
+    Dir = gid_Dir_Fonts_Truetype;
+    USER_FILE_BODY;
+//  Styles = ();
+    Name = "fc_local.conf";
+End
+#endif
+
 #endif // WITH_CATA_FONTS
 
 
@@ -121,13 +132,3 @@ STD_FONT_FILE( gid_File_Fnt_GentiumBookBasicBoldItalic, GenBkBasBI.ttf, Gentium 
 
 #endif // WITH_CATB_FONTS
 
-// fontconfig updates to allow proper use of local fonts
-
-#ifdef UNX
-File gid_File_FcLocal_Conf
-    Dir = gid_Dir_Fonts_Truetype;
-    USER_FILE_BODY;
-//  Styles = ();
-    Name = "fc_local.conf";
-End
-#endif


### PR DESCRIPTION
Packaging breaks when the --without-fonts option is passed to
configure because the fc_local.conf file is missing.

This seems to have been caused by a mismerge when cherry picking
commits from AOO42X.