### PR TITLE
Fix for crashing in exporting PDF with a Noto Serif CJK JP font.

### DIFF
--- a/main/vcl/source/fontsubset/cff.cxx
+++ b/main/vcl/source/fontsubset/cff.cxx
@@ -40,7 +40,7 @@ typedef long long S64;
 
 typedef sal_Int32 GlyphWidth;
 
-typedef float RealType;
+typedef double RealType;
 typedef RealType ValType;
 #include <vector>
 typedef std::vector<ValType> ValVector;


### PR DESCRIPTION
I got a bug report of crashing in exporting PDF with a Noto Serif CJK JP font from my Android user.
This is same bug in PC version:
I confirm this crash with:

OpenOffice 4.1.7
macOS 10.15.6

I fix this problem and send feed back patch.

The attached file is the sample document for crashing with exporting PDF.

[crashing-with-noto-serif-cjk-jp.docx](https://github.com/apache/openoffice/files/5390104/crashing-with-noto-serif-cjk-jp.docx)