### PR TITLE
Enable compilation on Linux systems putting libraries in /lib64 instead of /lib

### DIFF
--- a/main/python/prj/d.lst
+++ b/main/python/prj/d.lst
@@ -83,8 +83,10 @@ mkdir: %_DEST%\lib%_EXT%\python\python2.7\config
 ..\%__SRC%\misc\build\python-inst\bin\python %_DEST%\bin%_EXT%\python
 ..\%__SRC%\misc\build\Python-2.7.18\pyconfig.h %_DEST%\inc%_EXT%\python\pyconfig.h
 ..\%__SRC%\misc\build\python-inst\lib\python2.7\lib-dynload\* %_DEST%\lib%_EXT%\python\lib-dynload\*
+..\%__SRC%\misc\build\python-inst\lib64\python2.7\lib-dynload\* %_DEST%\lib%_EXT%\python\lib-dynload\*
 ..\%__SRC%\misc\build\python-inst\bin\python2.7 %_DEST%\bin%_EXT%\python
 ..\%__SRC%\misc\build\python-inst\lib\libpython2.7.so.1.0 %_DEST%\lib%_EXT%\libpython2.7.so.1.0
+..\%__SRC%\misc\build\python-inst\lib64\libpython2.7.so.1.0 %_DEST%\lib%_EXT%\libpython2.7.so.1.0
 symlink: %_DEST%\lib%_EXT%\libpython2.7.so.1.0 %_DEST%\lib%_EXT%\libpython2.7.so
 
 # MacOS X


### PR DESCRIPTION
Some Linux distributions, such as openSUSE, on x86_64 systems install libraries in directories named "lib64" instead of "lib".

AOO418 and development branches do not compile successfully, because the Python module follows the above convention, being the system default, but the OpenOffice build system does not expect that and does not deliver the `.so` files.

This PR has the purpose to restore compatibility with such Linux distributions.

The only proposed commit so far is for the Python module. I tested it on my openSUSE Leap 15.2 x86_64 system.

In order to be sure that no other module is showing problems, I would like to try replicating an "official release" build, but I could not find any information about it on the Wiki. Pointers would be appreciated.