### PR TITLE
Avoid "dmake clean" to wipe out the whole tree

### DIFF
--- a/main/makefile.rc
+++ b/main/makefile.rc
@@ -59,6 +59,7 @@ distclean .PHONY: clean
 
 
 clean .PHONY:
+	@test -n "$(INPATH)" || (echo Build environment not set; exit 1)
 	-rm -rf */$(INPATH)
 	-rm -rf solver/*/$(INPATH)
 .IF "$(ADDITIONAL_REPOSITORIES)"!=""


### PR DESCRIPTION
As per a recent thread on the dev@ mailing list, the "dmake clean" command may wipe out the whole source tree, if the build environment was not set by sourcing the appropriate `.Env` script.

This PR has the purpose to fix the problem, assuming that if the build environment is not set, then the "dmake clean" command must not do anything.