### PR TITLE
Flaky tests

### DIFF
--- a/test/testgui/source/bvt/gui/BasicFunctionTest.java
+++ b/test/testgui/source/bvt/gui/BasicFunctionTest.java
@@ -712,6 +712,7 @@ public class BasicFunctionTest {
 		scFunctionWizardDlgFunctionList.select("ABS");
 		scFunctionWizardDlgNext.click(); // Use "Next" button
 		scFunctionWizardDlgEdit1.typeKeys("A1");
+		sleep(1);
 		scFunctionWizardDlg.ok();
 		sleep(1);
 		// Verify if the calculated result is equal to the expected result

--- a/test/testgui/source/bvt/gui/BasicFunctionTest.java
+++ b/test/testgui/source/bvt/gui/BasicFunctionTest.java
@@ -175,6 +175,7 @@ public class BasicFunctionTest {
 		runMacroDlgCategories.select("Module1");
 		runMacroDlgCommands.select(0);
 		runMacroDlg.ok();
+		sleep(1);
 		assertEquals("A3 should be =1+3", "4", SCTool.getCellText("A3"));
 		discard();
 	}
@@ -679,7 +680,7 @@ public class BasicFunctionTest {
 		SCTool.selectRange("D1");
 		scInputBarInput.inputKeys("=COS(A1)");
 		typeKeys("<enter>");
-
+        sleep(1);
 		// Verify if the calculated result is equal to the expected result
 		assertEquals("The calculated result", expectedResult, SCTool.getCellText("D1"));
 		discard();
@@ -710,6 +711,7 @@ public class BasicFunctionTest {
 		scFunctionWizardDlgNext.click(); // Use "Next" button
 		scFunctionWizardDlgEdit1.typeKeys("A1");
 		scFunctionWizardDlg.ok();
+		sleep(1);
 		// Verify if the calculated result is equal to the expected result
 		assertEquals("The calculated result", expectedResult, SCTool.getCellText("B1"));
 		discard();

--- a/test/testgui/source/bvt/gui/BasicFunctionTest.java
+++ b/test/testgui/source/bvt/gui/BasicFunctionTest.java
@@ -683,6 +683,7 @@ public class BasicFunctionTest {
         sleep(1);
 		// Verify if the calculated result is equal to the expected result
         String result = SCTool.getCellText("D1");
+		sleep(1);
 		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("D1"));
         assertEquals("The calculated result", expectedResult, result);
 		discard();
@@ -716,6 +717,7 @@ public class BasicFunctionTest {
 		sleep(1);
 		// Verify if the calculated result is equal to the expected result
         String result = SCTool.getCellText("B1");
+		sleep(1);
 		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("B1"));
         assertEquals("The calculated result", expectedResult, result);
 		discard();

--- a/test/testgui/source/bvt/gui/BasicFunctionTest.java
+++ b/test/testgui/source/bvt/gui/BasicFunctionTest.java
@@ -682,7 +682,9 @@ public class BasicFunctionTest {
 		typeKeys("<enter>");
         sleep(1);
 		// Verify if the calculated result is equal to the expected result
-		assertEquals("The calculated result", expectedResult, SCTool.getCellText("D1"));
+        String result = SCTool.getCellText("D1");
+		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("D1"));
+        assertEquals("The calculated result", expectedResult, result);
 		discard();
 	}
 
@@ -713,7 +715,9 @@ public class BasicFunctionTest {
 		scFunctionWizardDlg.ok();
 		sleep(1);
 		// Verify if the calculated result is equal to the expected result
-		assertEquals("The calculated result", expectedResult, SCTool.getCellText("B1"));
+        String result = SCTool.getCellText("B1");
+		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("B1"));
+        assertEquals("The calculated result", expectedResult, result);
 		discard();
 	}
 }

--- a/test/testgui/source/bvt/gui/BasicFunctionTest.java
+++ b/test/testgui/source/bvt/gui/BasicFunctionTest.java
@@ -684,7 +684,6 @@ public class BasicFunctionTest {
 		// Verify if the calculated result is equal to the expected result
         String result = SCTool.getCellText("D1");
 		sleep(1);
-		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("D1"));
         assertEquals("The calculated result", expectedResult, result);
 		discard();
 	}
@@ -718,7 +717,6 @@ public class BasicFunctionTest {
 		// Verify if the calculated result is equal to the expected result
         String result = SCTool.getCellText("B1");
 		sleep(1);
-		// assertEquals("The calculated result", expectedResult, SCTool.getCellText("B1"));
         assertEquals("The calculated result", expectedResult, result);
 		discard();
 	}

--- a/test/testgui/source/bvt/gui/FileTypeTest.java
+++ b/test/testgui/source/bvt/gui/FileTypeTest.java
@@ -110,7 +110,10 @@ public class FileTypeTest {
 		writer.typeKeys(text);
 		sleep(1);
 		// Verify the text via system clip board
-		Assert.assertEquals("The typed text into writer", text, copyAll());
+		String result = copyAll();
+		// Assert.assertEquals("The typed text into writer", text, copyAll());
+		Assert.assertEquals("The typed text into writer", text, result);
+		result = null;
 
 		// menuItem("Text Properties...").select();
 		app.dispatch(".uno:FontDialog");
@@ -128,7 +131,9 @@ public class FileTypeTest {
 		writer.waitForExistence(10, 2);
 		sleep(1);
 		// Verify if the text still exists in the file
-		Assert.assertEquals("The typed text into writer is saved!", text, copyAll());
+		result = copyAll();
+		// Assert.assertEquals("The typed text into writer is saved!", text, copyAll());
+		Assert.assertEquals("The typed text into writer is saved!", text, result);
 	}
 
 	@Test
@@ -220,7 +225,9 @@ public class FileTypeTest {
 		sleep(1);
 		impress.typeKeys("<tab><enter>");
 		sleep(1);
-		Assert.assertEquals("The typed text is saved!", text, copyAll().trim());
+		String result = copyAll();
+		// Assert.assertEquals("The typed text is saved!", text, copyAll().trim());
+		Assert.assertEquals("The typed text is saved!", text, result.trim());
 	}
 
 	// drawing
@@ -331,8 +338,12 @@ public class FileTypeTest {
 		newFormula();
 		// Insert a formula
 		mathEditWindow.typeKeys(text);
+		sleep(1);
 		// Verify the text via system clip board
-		assertEquals("The typed formula into math", text, copyAll());
+		String result = copyAll();
+		// assertEquals("The typed formula into math", text, copyAll());
+		assertEquals("The typed formula into math", text, result);
+		result = null;
 
 		// Save the formula
 		deleteFile(saveTo);
@@ -342,6 +353,8 @@ public class FileTypeTest {
 		mathEditWindow.waitForExistence(10, 2);
 		sleep(1);
 		mathEditWindow.focus();
-		assertEquals("The typed formula into math is saved", text, copyAll());
+		result = copyAll();
+		// assertEquals("The typed formula into math is saved", text, copyAll());
+		assertEquals("The typed formula into math is saved", text, result);
 	}
 }

--- a/test/testgui/source/bvt/gui/FileTypeTest.java
+++ b/test/testgui/source/bvt/gui/FileTypeTest.java
@@ -112,7 +112,6 @@ public class FileTypeTest {
 		// Verify the text via system clip board
 		String result = copyAll();
 		sleep(1);
-		// Assert.assertEquals("The typed text into writer", text, copyAll());
 		Assert.assertEquals("The typed text into writer", text, result);
 		result = null;
 
@@ -134,7 +133,6 @@ public class FileTypeTest {
 		// Verify if the text still exists in the file
 		result = copyAll();
 		sleep(1);
-		// Assert.assertEquals("The typed text into writer is saved!", text, copyAll());
 		Assert.assertEquals("The typed text into writer is saved!", text, result);
 	}
 
@@ -229,7 +227,6 @@ public class FileTypeTest {
 		sleep(1);
 		String result = copyAll();
 		sleep(1);
-		// Assert.assertEquals("The typed text is saved!", text, copyAll().trim());
 		Assert.assertEquals("The typed text is saved!", text, result.trim());
 	}
 
@@ -345,7 +342,6 @@ public class FileTypeTest {
 		// Verify the text via system clip board
 		String result = copyAll();
 		sleep(1);
-		// assertEquals("The typed formula into math", text, copyAll());
 		assertEquals("The typed formula into math", text, result);
 		result = null;
 
@@ -359,7 +355,6 @@ public class FileTypeTest {
 		mathEditWindow.focus();
 		result = copyAll();
 		sleep(1);
-		// assertEquals("The typed formula into math is saved", text, copyAll());
 		assertEquals("The typed formula into math is saved", text, result);
 	}
 }

--- a/test/testgui/source/bvt/gui/FileTypeTest.java
+++ b/test/testgui/source/bvt/gui/FileTypeTest.java
@@ -108,6 +108,7 @@ public class FileTypeTest {
 		String text = "@AOO";
 		newTextDocument();
 		writer.typeKeys(text);
+		sleep(1);
 		// Verify the text via system clip board
 		Assert.assertEquals("The typed text into writer", text, copyAll());
 

--- a/test/testgui/source/bvt/gui/FileTypeTest.java
+++ b/test/testgui/source/bvt/gui/FileTypeTest.java
@@ -111,6 +111,7 @@ public class FileTypeTest {
 		sleep(1);
 		// Verify the text via system clip board
 		String result = copyAll();
+		sleep(1);
 		// Assert.assertEquals("The typed text into writer", text, copyAll());
 		Assert.assertEquals("The typed text into writer", text, result);
 		result = null;
@@ -132,6 +133,7 @@ public class FileTypeTest {
 		sleep(1);
 		// Verify if the text still exists in the file
 		result = copyAll();
+		sleep(1);
 		// Assert.assertEquals("The typed text into writer is saved!", text, copyAll());
 		Assert.assertEquals("The typed text into writer is saved!", text, result);
 	}
@@ -226,6 +228,7 @@ public class FileTypeTest {
 		impress.typeKeys("<tab><enter>");
 		sleep(1);
 		String result = copyAll();
+		sleep(1);
 		// Assert.assertEquals("The typed text is saved!", text, copyAll().trim());
 		Assert.assertEquals("The typed text is saved!", text, result.trim());
 	}
@@ -341,6 +344,7 @@ public class FileTypeTest {
 		sleep(1);
 		// Verify the text via system clip board
 		String result = copyAll();
+		sleep(1);
 		// assertEquals("The typed formula into math", text, copyAll());
 		assertEquals("The typed formula into math", text, result);
 		result = null;
@@ -354,6 +358,7 @@ public class FileTypeTest {
 		sleep(1);
 		mathEditWindow.focus();
 		result = copyAll();
+		sleep(1);
 		// assertEquals("The typed formula into math is saved", text, copyAll());
 		assertEquals("The typed formula into math is saved", text, result);
 	}


### PR DESCRIPTION
This work is for flaky BVT tests that randomly pass or fail during multiple runs against the same build.
Basically I'm adding a thread sleep prior to the test assertion check.
So far this has reduced the average failure count of 2 or 3 per run to 0 for the last 5 runs I've made against trunk.