### PR TITLE
[writerfilter] Add checks for non-empty stacks

### DIFF
--- a/main/writerfilter/source/dmapper/DomainMapperTableManager.cxx
+++ b/main/writerfilter/source/dmapper/DomainMapperTableManager.cxx
@@ -334,13 +334,25 @@ void DomainMapperTableManager::pushStackOfMembers()
 
 void DomainMapperTableManager::popStackOfMembers()
 {
-    m_nCellCounterForCurrentRow.pop();
-    m_nCurrentCellBorderIndex.pop();
-    m_nCurrentHeaderRepeatCount.pop();
-    m_nTableWidthOfCurrentTable.pop();
+    if (!m_nCellCounterForCurrentRow.empty()) {
+        m_nCellCounterForCurrentRow.pop();
+    }
+    if (!m_nCurrentCellBorderIndex.empty()) {
+        m_nCurrentCellBorderIndex.pop();
+    }
+    if (!m_nCurrentHeaderRepeatCount.empty()) {
+        m_nCurrentHeaderRepeatCount.pop();
+    }
+    if (!m_nTableWidthOfCurrentTable.empty()) {
+        m_nTableWidthOfCurrentTable.pop();
+    }
 
-    m_aTableGrid.pop();
-    m_aGridSpans.pop();
+    if (!m_aTableGrid.empty()) {
+        m_aTableGrid.pop();
+    }
+    if (!m_aGridSpans.empty()) {
+        m_aGridSpans.pop();
+    }
 }
 
 

--- a/main/writerfilter/source/dmapper/DomainMapper_Impl.cxx
+++ b/main/writerfilter/source/dmapper/DomainMapper_Impl.cxx
@@ -325,8 +325,10 @@ void    DomainMapper_Impl::PopProperties(ContextType eId)
         m_pLastSectionContext = m_aPropertyStacks[eId].top( );
     }
 
-    m_aPropertyStacks[eId].pop();
-    m_aContextStack.pop();
+    if (!m_aPropertyStacks[eId].empty()) {
+        m_aPropertyStacks[eId].pop();
+        m_aContextStack.pop();
+    }
     if(!m_aContextStack.empty() && !m_aPropertyStacks[m_aContextStack.top()].empty())
 
             m_pTopContext = m_aPropertyStacks[m_aContextStack.top()].top();


### PR DESCRIPTION
This PR tries to address [bug 127952](https://bz.apache.org/ooo/show_bug.cgi?id=127952).

After applying it, the Linux builds should not crash when opening the [file linked by the report](https://www.suny.edu/badfile.docx).

There is a problem for which certain stacks are `pop()`-ed before any `push()` ever happened. This is probably due to a bug in the parser. This PR does not address the parsing bug, but rather tries to avoid it to crash the program.

It should apply as-is to AOO419.