### PR TITLE
Changed helptext after resolved problem.

### DIFF
--- a/main/helpcontent2/source/text/shared/01/02100001.xhp
+++ b/main/helpcontent2/source/text/shared/01/02100001.xhp
@@ -284,7 +284,7 @@
                <paragraph xml-lang="en-US" id="par_id3153726" role="tablecontent" l10n="U" oldref="218">[:space:]</paragraph>
             </tablecell>
             <tablecell>
-               <paragraph xml-lang="en-US" id="par_id3150961" role="tablecontent" l10n="CHG" oldref="219">Represents a space character (but not other whitespace characters).<comment>UFI: see #i41706#</comment></paragraph>
+               <paragraph xml-lang="en-US" id="par_id3150961" role="tablecontent" l10n="CHG" oldref="219">Represents a whitespace character.</paragraph>
             </tablecell>
          </tablerow>
          <tablerow>


### PR DESCRIPTION
[:space:] should represent any whitespace character in regular expressions.
However, in the older, before OOo 3.4, it did not find the tab \t.

Now it does due to changing the regexp engine since 3.4