### PR TITLE
Clean $OUTPATH directories as well as $INPATH

### DIFF
--- a/main/makefile.rc
+++ b/main/makefile.rc
@@ -60,11 +60,15 @@ distclean .PHONY: clean
 
 clean .PHONY:
 	@test -n "$(INPATH)" || (echo Build environment not set; exit 1)
+	@test -n "$(OUTPATH)" || (echo Build environment not set; exit 1)
 	-rm -rf */$(INPATH)
+	-rm -rf */$(OUTPATH)
 	-rm -rf solver/*/$(INPATH)
+	-rm -rf solver/*/$(OUTPATH)
 	-rm -rf solenv/inc/reporevision.lst
 .IF "$(ADDITIONAL_REPOSITORIES)"!=""
 	-rm -rf $(foreach,f,$(ADDITIONAL_REPOSITORIES) $f/*/$(INPATH))
+	-rm -rf $(foreach,f,$(ADDITIONAL_REPOSITORIES) $f/*/$(OUTPATH))
 .ENDIF
 .IF "$(BUILD_DMAKE)"!="NO"
 	-echo cleaning up dmake...


### PR DESCRIPTION
It is possible that `$OUTPATH` directories are left by previous compilation attempts.

A proof that `$OUTPATH` directories are used is the Perl script `solenv/bin/download_external_dependencies.pl` that looks for executables with "special handling" (i.e. dmake and epm) in `$SOLARENV/$OUTPATH`.