### PR TITLE
Fix to get the version string right in the About dialog

### DIFF
--- a/main/cui/source/dialogs/about.cxx
+++ b/main/cui/source/dialogs/about.cxx
@@ -502,14 +502,14 @@ const rtl::OUString AboutDialog::GetBuildId() const
     // For better readability, strip the duplicate ProductMajor ("340").
     if ( sProductSource.getLength() )
     {
-        sal_Int32 versionLength = sProductSource.getLength() - 3;
+        sal_Int32 nMajorLength = sProductSource.getLength() - 3;
         bool bMatchingUPD =
                 ( sProductSource.getLength() >= 3 )
-            &&  ( sBuildId.getLength() >= versionLength )
-            &&  ( sProductSource.copy( 3 ) == sBuildId.copy( 0, versionLength ) );
+            &&  ( sBuildId.getLength() >= nMajorLength )
+            &&  ( sProductSource.copy( 3 ) == sBuildId.copy( 0, nMajorLength ) );
         OSL_ENSURE( bMatchingUPD, "BUILDID and ProductSource do not match in their UPD" );
         if ( bMatchingUPD )
-            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - versionLength );
+            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - nMajorLength );
 
         // prepend the product source
         sBuildIdBuff.insert( 0, sProductSource );

--- a/main/cui/source/dialogs/about.cxx
+++ b/main/cui/source/dialogs/about.cxx
@@ -505,10 +505,10 @@ const rtl::OUString AboutDialog::GetBuildId() const
         bool bMatchingUPD =
                 ( sProductSource.getLength() >= 3 )
             &&  ( sBuildId.getLength() >= 3 )
-            &&  ( sProductSource.copy( sProductSource.getLength() - 3 ) == sBuildId.copy( 0, 3 ) );
+            &&  ( sProductSource.copy( sProductSource.getLength() - 4 ) == sBuildId.copy( 0, 4 ) );
         OSL_ENSURE( bMatchingUPD, "BUILDID and ProductSource do not match in their UPD" );
         if ( bMatchingUPD )
-            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - 3 );
+            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - 4 );
 
         // prepend the product source
         sBuildIdBuff.insert( 0, sProductSource );

--- a/main/cui/source/dialogs/about.cxx
+++ b/main/cui/source/dialogs/about.cxx
@@ -502,13 +502,14 @@ const rtl::OUString AboutDialog::GetBuildId() const
     // For better readability, strip the duplicate ProductMajor ("340").
     if ( sProductSource.getLength() )
     {
+        sal_Int32 versionLength = sProductSource.getLength() - 3;
         bool bMatchingUPD =
                 ( sProductSource.getLength() >= 3 )
-            &&  ( sBuildId.getLength() >= 3 )
-            &&  ( sProductSource.copy( sProductSource.getLength() - 4 ) == sBuildId.copy( 0, 4 ) );
+            &&  ( sBuildId.getLength() >= versionLength )
+            &&  ( sProductSource.copy( 3 ) == sBuildId.copy( 0, versionLength ) );
         OSL_ENSURE( bMatchingUPD, "BUILDID and ProductSource do not match in their UPD" );
         if ( bMatchingUPD )
-            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - 4 );
+            sProductSource = sProductSource.copy( 0, sProductSource.getLength() - versionLength );
 
         // prepend the product source
         sBuildIdBuff.insert( 0, sProductSource );


### PR DESCRIPTION
This is not really a good solution. But we can use it until someone else has a better idea.