### PR TITLE
Refs #128452 - JUnit and Hamcrest update for test automation

### DIFF
--- a/test/build.xml
+++ b/test/build.xml
@@ -27,7 +27,7 @@
 	<property name="junit.home" value="${env.JUNIT_HOME}" />
 	<property name="dist.dir" value="." />
 	<property name="dist.name" value="aoo_test" />
-	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.10/junit-4.13.2.jar" />
+	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar" />
 	
 	<path id="uno.classpath">
 		<fileset dir="${env.OUTDIR}/bin" erroronmissingdir="false">

--- a/test/build.xml
+++ b/test/build.xml
@@ -27,7 +27,8 @@
 	<property name="junit.home" value="${env.JUNIT_HOME}" />
 	<property name="dist.dir" value="." />
 	<property name="dist.name" value="aoo_test" />
-	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar" />
+	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" />
+	<property name="hamcrest.jar.repos" value="https://repo1.maven.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar" />
 	
 	<path id="uno.classpath">
 		<fileset dir="${env.OUTDIR}/bin" erroronmissingdir="false">
@@ -51,12 +52,20 @@
 			</fileset>
 			<globmapper from="*" to="junit.jar" />
         </copy>
+		<copy todir="lib" >
+			<fileset dir="${junit.home}" erroronmissingdir="false">
+				<include name="hamcrest*.jar" />
+			</fileset>
+			<globmapper from="*" to="hamcrest.jar" />
+		</copy>
 		<available file="lib/junit.jar" property="junit.jar.exists"/>
+		<available file="lib/hamcrest.jar" property="hamcrest.jar.exists"/>
 	</target>
 
 	<target name="prepare.junit" depends="check.junit" unless="junit.jar.exists">
 		<mkdir dir="lib" />
 		<get src="${junit.jar.repos}" dest="lib/junit.jar" skipexisting="true" />
+		<get src="${hamcrest.jar.repos}" dest="lib/hamcrest.jar" skipexisting="true" />
 	</target>
 	
 	<target name="testcommon.init">

--- a/test/build.xml
+++ b/test/build.xml
@@ -27,7 +27,7 @@
 	<property name="junit.home" value="${env.JUNIT_HOME}" />
 	<property name="dist.dir" value="." />
 	<property name="dist.name" value="aoo_test" />
-	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.10/junit-4.10.jar" />
+	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.10/junit-4.13.2.jar" />
 	
 	<path id="uno.classpath">
 		<fileset dir="${env.OUTDIR}/bin" erroronmissingdir="false">

--- a/test/run
+++ b/test/run
@@ -26,4 +26,4 @@ if [ -z "$DISPLAY" ]; then
 fi
 
 BASE=$(cd `dirname "$0"`; pwd)
-eval java -cp \"$BASE/lib/junit.jar:$BASE/testcommon/bin:$BASE/testgui/bin:$BASE/testuno/bin:$BASE/testgui/data:$BASE/testuno/data\" org.openoffice.test.Run -r org.openoffice.test.common.Installer -l org.openoffice.test.common.XMLReporter -l org.openoffice.test.common.ReportUploader \"-Dtestspace=$BASE/testspace\" -Dsingleton=true "$*"
+eval java -cp \"$BASE/lib/junit.jar:$BASE/lib/hamcrest.jar:$BASE/testcommon/bin:$BASE/testgui/bin:$BASE/testuno/bin:$BASE/testgui/data:$BASE/testuno/data\" org.openoffice.test.Run -r org.openoffice.test.common.Installer -l org.openoffice.test.common.XMLReporter -l org.openoffice.test.common.ReportUploader \"-Dtestspace=$BASE/testspace\" -Dsingleton=true "$*"

--- a/test/run.bat
+++ b/test/run.bat
@@ -21,5 +21,5 @@ rem
 rem *************************************************************
 
 set BASE=%~pd0%
-java -cp "%BASE%\lib\junit.jar;%BASE%\testcommon\bin;%BASE%\testgui\bin;%BASE%\testuno\bin;%BASE%\testgui\data;%BASE%\testuno\data" org.openoffice.test.Run -r org.openoffice.test.common.Installer -l org.openoffice.test.common.XMLReporter -l org.openoffice.test.common.ReportUploader "-Dtestspace=%BASE%\testspace" -Dsingleton=true %*
+java -cp "%BASE%\lib\junit.jar;%BASE%\lib\hamcrest.jar;%BASE%\testcommon\bin;%BASE%\testgui\bin;%BASE%\testuno\bin;%BASE%\testgui\data;%BASE%\testuno\data" org.openoffice.test.Run -r org.openoffice.test.common.Installer -l org.openoffice.test.common.XMLReporter -l org.openoffice.test.common.ReportUploader "-Dtestspace=%BASE%\testspace" -Dsingleton=true %*
 


### PR DESCRIPTION
Updates JUnit from 4.10 to 4.12 and Hamcrest from a default of 1.3 to the latest 2.2.
Existing repo copies that have previously built the tests will need to empty or remove the test/lib directory to have the new libraries downloaded because it doesn't get removed during a clean of the tests or the office.