### PR TITLE
Refs #i128455# - updated junit to 4.13.2. 

### DIFF
--- a/test/build.xml
+++ b/test/build.xml
@@ -27,7 +27,7 @@
 	<property name="junit.home" value="${env.JUNIT_HOME}" />
 	<property name="dist.dir" value="." />
 	<property name="dist.name" value="aoo_test" />
-	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" />
+	<property name="junit.jar.repos" value="https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar" />
 	<property name="hamcrest.jar.repos" value="https://repo1.maven.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar" />
 	
 	<path id="uno.classpath">

--- a/test/testcommon/source/org/openoffice/test/common/NamedRequest.java
+++ b/test/testcommon/source/org/openoffice/test/common/NamedRequest.java
@@ -55,7 +55,7 @@ public class NamedRequest extends Request {
 				name = name.substring(0, 128) + "...";
 			}
 		}
-		suite = new Suite(name);
+		suite = new Suite(null, name);
 		return arg;
 	}
 	
@@ -156,9 +156,9 @@ public class NamedRequest extends Request {
 		protected final List<Runner> fRunners = new ArrayList<Runner>();
 
 		protected String name;
-		
-		protected Suite(String name) throws InitializationError {
-			super(null);
+
+		protected Suite(Class<?> testClass, String name) throws InitializationError {
+			super(testClass);
 			this.name = name;
 		}
 


### PR DESCRIPTION
updated NamedRequest inner class Suite constructor to match the signature of the super class ParentRunner that was the only constructor until JUnit 4.13.  Now ParentRunner has a second constructor that made passing a null arg ambiguous.