### PR TITLE
Refs #i128505# - testTableBorderLineStyle flaky test

### DIFF
--- a/test/testgui/source/fvt/gui/sw/table/TableGeneral.java
+++ b/test/testgui/source/fvt/gui/sw/table/TableGeneral.java
@@ -194,6 +194,7 @@ public class TableGeneral {
 		swTableSTCSYNC.uncheck();
 		// set left spacing to content
 		swTableSTCLeft.focus();
+		sleep(0.2);
 		typeKeys("<ctrl a>");
 		typeKeys("<delete>");
 		typeKeys("0.5");


### PR DESCRIPTION
testTableBorderLineStyle() was entering 0.55" instead of 0.50" at line 199 because the ctrl-a wasn't selecting all of the cell contents and leaving a 5 in the cell. then when typing in 0.5 it became 0.55 and failing the assertion at line 222. added sleep at 197 to make sure focus is completed before ctrl-a.