### PR TITLE
Fix TestFormulaDocs to run against AOO41X, make parameterized, and fix late screenshots

### DIFF
--- a/test/testuno/source/fvt/uno/sc/formula/TestFormulaDocs.java
+++ b/test/testuno/source/fvt/uno/sc/formula/TestFormulaDocs.java
@@ -105,7 +105,7 @@ public class TestFormulaDocs {
 	// FIXME: only needs a timeout for running tests against AOO41X due to fixes for i112383 and i117960 present in trunk
 	// haven't been backported to AOO41X yet and causes these tests to hang on an error dialog.
 	@Test(timeout = 15000)
-	public void testOneDoc( String filename) throws Exception {
+	public void testOneDoc() throws Exception {
 		// open the spreadsheet document
 		String sample = Testspace.prepareData(filename);
 		// enable macros


### PR DESCRIPTION
updated TestFormulaDocs test to be a parameterized test to better see which document failed.
Fixed late screenshots on failures.
Added timeout for dialog hangs when running tests against AOO41X branch due to some BASIC bug fixes for i112383 [1] and it's commit [2] and i117960 [3] and it's commit [4] not being back-ported to AOO41X.

[1] https://bz.apache.org/ooo/show_bug.cgi?id=112383
[2] https://github.com/apache/openoffice/commit/323c350123d05cd9f450aebd421b7bfa74c331d2

[3] https://bz.apache.org/ooo/show_bug.cgi?id=117960
[4] https://github.com/apache/openoffice/commit/725d867363770a4c47c4b3c6dbe1f359c296604a