### PR TITLE
Proposed fix for Issue 60217

### DIFF
--- a/main/sw/source/ui/fldui/changedb.cxx
+++ b/main/sw/source/ui/fldui/changedb.cxx
@@ -327,7 +327,7 @@ IMPL_LINK( SwChangeDBDlg, TreeSelectHdl, SvTreeListBox *, EMPTYARG )
 }
 
 /*--------------------------------------------------------------------
-	Description: transfrom Datenbasename for screen
+	Description: transform Datenbasename for screen
  --------------------------------------------------------------------*/
 
 void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)

--- a/main/sw/source/ui/fldui/changedb.cxx
+++ b/main/sw/source/ui/fldui/changedb.cxx
@@ -327,14 +327,16 @@ IMPL_LINK( SwChangeDBDlg, TreeSelectHdl, SvTreeListBox *, EMPTYARG )
 }
 
 /*--------------------------------------------------------------------
-	Beschreibung: Datenbankname fuer Anzeige wandeln
+	Description: transfrom Datenbasename for screen
  --------------------------------------------------------------------*/
 
 void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)
 {
-	String sTmp(rDBData.sDataSource);
 	String sName;
-	sTmp += '.';
+	String sTmp(rDBData.sDataSource);
+	if (rDBData.sDataSource.is() and rDBData.sCommand.is()) {
+		sTmp += '.';
+	}
 	sTmp += (String)rDBData.sCommand;
 
 	for (sal_uInt16 i = 0; i < sTmp.Len(); i++)

--- a/main/sw/source/ui/fldui/changedb.cxx
+++ b/main/sw/source/ui/fldui/changedb.cxx
@@ -334,7 +334,7 @@ void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)
 {
 	String sName;
 	String sTmp(rDBData.sDataSource);
-	if (rDBData.sDataSource.is() and rDBData.sCommand.is()) {
+	if (!rDBData.sDataSource.isEmpty() && !rDBData.sCommand.isEmpty()) {
 		sTmp += '.';
 	}
 	sTmp += (String)rDBData.sCommand;

--- a/main/sw/source/ui/fldui/changedb.cxx
+++ b/main/sw/source/ui/fldui/changedb.cxx
@@ -327,7 +327,7 @@ IMPL_LINK( SwChangeDBDlg, TreeSelectHdl, SvTreeListBox *, EMPTYARG )
 }
 
 /*--------------------------------------------------------------------
-	Description: transform Datenbasename for screen
+	Description: transform databasename for screen
  --------------------------------------------------------------------*/
 
 void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)

--- a/main/sw/source/ui/fldui/changedb.cxx
+++ b/main/sw/source/ui/fldui/changedb.cxx
@@ -334,7 +334,7 @@ void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)
 {
 	String sName;
 	String sTmp(rDBData.sDataSource);
-	if (rDBData.sDataSource.is() and rDBData.sCommand.is()) {
+	if (rDBData.sDataSource.is() && rDBData.sCommand.is()) {
 		sTmp += '.';
 	}
 	sTmp += (String)rDBData.sCommand;


### PR DESCRIPTION
I have added the if clause, with the expectation it fullfills the goal czeslav formulated in comment 9

> 1. Truncated string
> It was fixed in version 3.0.0
> (cf. the attached file "juxtaVER.jpeg")
> 
> 
> 2. A spurious colon
> ralphie, [comment #4](https://bz.apache.org/ooo/show_bug.cgi?id=60217#c4)
> > Furthermore, if there is no database selected, there is
> > a spurious colon after this sentence, see:
> > 
> > http://www.pangea.at/%7eralph/datenbank-austauschen.png
> 
> If no database is selected, there is a colon after the "sentence".
> And the program unnecessarily displays a dot character.
> (cf. the attached file "Period.jpg").
> 
> 
> the source file: changedb.cxx
> http://openoffice-vm1-he-de.apache.org/xref/trunk/main/sw/source/ui/fldui/changedb.cxx?r=efeef26f#333
> 
> 333 void SwChangeDBDlg::ShowDBName(const SwDBData& rDBData)
> 334  {
> 335     String sTmp(rDBData.sDataSource);
> 336     String sName;
> 337     sTmp += '.';
> 338     sTmp += (String)rDBData.sCommand;
> 339
> 340     for (sal_uInt16 i = 0; i < sTmp.Len(); i++)
> 341     {
> 342             sName += sTmp.GetChar(i);
> 343             if (sTmp.GetChar(i) == '~')
> 344             sName += '~';
> 345     }
> 346  
> 347     aDocDBNameFT.SetText(sName);
> 348  }
> 
> 
> Look at the lines 335 - 338
> I am not a software developer...
> but if the properties "sDataSource" and "sCommand" are empty
> then the programm should set the "sName" variable to empty
> otherwise proceed as usual.


Did not build the PR. Needs testing, but can be a base of discussion.