### PR TITLE
Update the list of safe extensions

### DIFF
--- a/main/officecfg/registry/data/org/openoffice/Office/Security.xcu
+++ b/main/officecfg/registry/data/org/openoffice/Office/Security.xcu
@@ -764,6 +764,11 @@
 				<value>m4a</value>
 			</prop>
 		</node>
+		<node oor:name="m149" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>mp4</value>
+			</prop>
+		</node>
 	</node>
 	<node oor:name="Hyperlinks">
 		<prop oor:name="Open" oor:type="xs:int">

--- a/main/officecfg/registry/data/org/openoffice/Office/Security.xcu
+++ b/main/officecfg/registry/data/org/openoffice/Office/Security.xcu
@@ -266,7 +266,7 @@
 		</node>
 		<node oor:name="m49" oor:op="replace">
 			<prop oor:name="Extension" oor:type="xs:string">
-				<value>pcx</value>
+				<value>heif</value>
 			</prop>
 		</node>
 		<node oor:name="m50" oor:op="replace">
@@ -767,6 +767,41 @@
 		<node oor:name="m149" oor:op="replace">
 			<prop oor:name="Extension" oor:type="xs:string">
 				<value>mp4</value>
+			</prop>
+		</node>
+		<node oor:name="m150" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>heifs</value>
+			</prop>
+		</node>
+		<node oor:name="m151" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>heic</value>
+			</prop>
+		</node>
+		<node oor:name="m152" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>heics</value>
+			</prop>
+		</node>
+		<node oor:name="m153" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>avci</value>
+			</prop>
+		</node>
+		<node oor:name="m154" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>avcs</value>
+			</prop>
+		</node>
+		<node oor:name="m155" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>avif</value>
+			</prop>
+		</node>
+		<node oor:name="m156" oor:op="replace">
+			<prop oor:name="Extension" oor:type="xs:string">
+				<value>avifs</value>
 			</prop>
 		</node>
 	</node>


### PR DESCRIPTION
The purpose of the extensions branch, and of this PR, is to add any missing entries to the list of "safe" file extensions.

Safe file extensions allow hyperlinks to be opened without asking for user confirmation.

Before this PR, the following extensions are considered safe:
1 123 602 aif aifc asf asx au avi bmp cgm csv dbf dib dif doc docm docx dot dotm dotx dxf emf eps fdf flac gif htm html jfif jif jpe jpeg jpg m1a m3u m4a met mid midi mml moov mov movie mp2 mp3 mpa mpe mpeg mpg odb odf odg odm odp ods odt ogg otg oth otp ots ott pbm pbm pcd pcd pct pcx pcx pdb pdf pgm pict png pot potm potx ppm pps ppt pptm pptx psd psw pxl qt ra ram ras rm rtf sda sdc sdd sdp sds sdw sgf sgl sgv shtml slk smf stc std sti stw svg svm sxc sxd sxg sxi sxm sxp sxw text tga tif tiff txt uof uop uos uot vor wav wb2 wk1 wks wmf wpl xbm xhp xhp xhtml xlc xlm xls xlsb xlsm xlsx xlt xltm xltx xlw xml xpm

The first commit adds mp4 to the above list.