### PR TITLE
Address bug #126680

### DIFF
--- a/main/i18npool/inc/transliterationImpl.hxx
+++ b/main/i18npool/inc/transliterationImpl.hxx
@@ -121,15 +121,6 @@ private:
     com::sun::star::uno::Reference< XLocaleData > localedata;
     com::sun::star::uno::Reference< com::sun::star::i18n::XExtendedTransliteration > caseignore;
 
-    /** structure to cache the last transliteration body used. */
-    struct TransBody
-    {
-        ::osl::Mutex mutex;
-        ::rtl::OUString Name;
-        ::com::sun::star::uno::Reference< ::com::sun::star::i18n::XExtendedTransliteration > Body;
-    };
-    static TransBody lastTransBody;
-
     virtual sal_Bool SAL_CALL loadModuleByName( const rtl::OUString& implName, 
         com::sun::star::uno::Reference<com::sun::star::i18n::XExtendedTransliteration> & body, const com::sun::star::lang::Locale& rLocale) 
         throw(com::sun::star::uno::RuntimeException);

--- a/main/i18npool/source/transliteration/transliterationImpl.cxx
+++ b/main/i18npool/source/transliteration/transliterationImpl.cxx
@@ -144,8 +144,6 @@ static struct TMlist {
   {(TransliterationModules)0, (TransliterationModulesNew)0,  NULL}
 };
 
-TransliterationImpl::TransBody TransliterationImpl::lastTransBody;
-
 // Constructor/Destructor
 TransliterationImpl::TransliterationImpl(const Reference <XMultiServiceFactory>& xMSF) : xSMgr(xMSF)
 {
@@ -591,15 +589,6 @@ TransliterationImpl::clear()
 void TransliterationImpl::loadBody( OUString &implName, Reference<XExtendedTransliteration>& body ) 
     throw (RuntimeException)
 {
-    ::osl::MutexGuard guard(lastTransBody.mutex);
-
-    if (implName.equals(lastTransBody.Name))
-    {
-        // Use the cached body instead of going through the expensive looping again.
-        body = lastTransBody.Body;
-        return;
-    }
-
     Reference< XContentEnumerationAccess > xEnumAccess( xSMgr, UNO_QUERY );
     Reference< XEnumeration > xEnum(xEnumAccess->createContentEnumeration(
                                     OUString::createFromAscii(TRLT_SERVICELNAME_L10N)));
@@ -616,8 +605,6 @@ void TransliterationImpl::loadBody( OUString &implName, Reference<XExtendedTrans
                             a = xI->queryInterface(::getCppuType((
                                         const Reference<XExtendedTransliteration>*)0));
                             a >>= body;
-                            lastTransBody.Name = implName;
-                            lastTransBody.Body = body;
                             return;
                         }
                     }


### PR DESCRIPTION
The purpose of this branch is to fix bug #126680.
All information is on the bug report:
https://bz.apache.org/ooo/show_bug.cgi?id=126680

Instances of com.sun.star.i18n.Transliteration.l10n are cached and sometimes (!!) treated as singletons.
But they may be modified by the callers. This means that one caller may see its instance unexpectedly modified by another caller.

It _may_ be possible to keep some kind of caching, like for variable `Reference< XSingleServiceFactory > xFactory`. As I am not sure this would work, I am just removing any caching. In fact, it has to be demonstrated how many times this code is called, throughout a normal usage session of AOO.