### PR TITLE
Remove use of pthread_mutexattr_setkind_np due to compile errors

### DIFF
--- a/main/sal/osl/unx/mutex.c
+++ b/main/sal/osl/unx/mutex.c
@@ -30,9 +30,11 @@
 #include <stdlib.h>
 
 #if defined LINUX /* bad hack */
+#if !defined(__USE_XOPEN2K8)
 int pthread_mutexattr_setkind_np(pthread_mutexattr_t *, int);
 #define pthread_mutexattr_settype pthread_mutexattr_setkind_np
 #define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+#endif
 #endif
 
 /*


### PR DESCRIPTION
This is intended as an informative notification, since I have no idea how to actually create a bugzilla account.

The code being removed here causes a compilation issue on Ubuntu Jammy Jellyfish. (undefined reference to `pthread_mutexattr_setkind_np`) The best I can tell, https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/2003146 explains this somewhat.

This workaround likely hasn't been necessary for the past 20 years, if glibc "converted to git" repositories are any indication (see for instance https://github.com/lattera/glibc/blob/d82e4c7bb231c9e0f835bd46467563ac3b56cebe/linuxthreads/sysdeps/pthread/pthread.h ).

And indeed, anyone who would be attempting to run OpenOffice on such a system would likely encounter issues with the other varied libraries in use.

Unfortunately other compilation issues prevented me from performing a full test, but osl mutex tests pass at least.