### PR TITLE
Ensure compatibility with GNU Make 4.4

### DIFF
--- a/main/solenv/gbuild/Package.mk
+++ b/main/solenv/gbuild/Package.mk
@@ -24,7 +24,7 @@
 
 # PackagePart class
 
-define gb_PackagePart_deliver_destination =
+define gb_PackagePart_deliver_destination
 $(1)/% :
 	$$(call gb_Deliver_deliver,$$<,$$@)
 

--- a/main/solenv/gbuild/Package.mk
+++ b/main/solenv/gbuild/Package.mk
@@ -24,8 +24,15 @@
 
 # PackagePart class
 
-$(foreach destination,$(call gb_PackagePart_get_destinations), $(destination)/%) :
-	$(call gb_Deliver_deliver,$<,$@)
+define gb_PackagePart_deliver_destination =
+$(1)/% :
+	$$(call gb_Deliver_deliver,$$<,$$@)
+
+endef
+
+$(foreach destination,$(call gb_PackagePart_get_destinations),$(eval $(call gb_PackagePart_deliver_destination,$(destination))))
+
+
 
 define gb_PackagePart_PackagePart
 $(OUTDIR)/$(1) : $(2)
@@ -41,7 +48,7 @@ $(call gb_Package_get_clean_target,%) :
 	$(call gb_Output_announce,$*,$(false),PKG,2)
 	RESPONSEFILE=$(call var2file,$(shell $(gb_MKTEMP)),500,$(FILES)) \
 	&& cat $${RESPONSEFILE} | xargs rm -f \
- 	&& rm -f $${RESPONSEFILE}
+	&& rm -f $${RESPONSEFILE}
 
 $(call gb_Package_get_preparation_target,%) :
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
Make >= 4.4 is today's default on Cygwin.

Once approved, these edits shall be applied to AOO41X as well.

Please squash these commits when merging this PR.