### PR TITLE
Compatibility with GNU Make 4.4 (slideshow module)

### DIFF
--- a/main/slideshow/Library_slideshow.mk
+++ b/main/slideshow/Library_slideshow.mk
@@ -41,6 +41,24 @@ $(eval $(call gb_Library_add_linked_libs,slideshow,\
 	$(gb_STDLIBS) \
 ))
 
+# Necessary for building slideshowimpl
+$(eval $(call gb_Library_set_include,slideshow,\
+        $$(INCLUDE) \
+	-I$(SRCDIR)/slideshow/source/inc \
+	-I$(SRCDIR)/slideshow/inc/pch \
+))
+
+# Necessary for building slideshowimpl
+$(eval $(call gb_Library_add_defs,sildeshow,\
+	-DBOOST_SPIRIT_USE_OLD_NAMESPACE \
+))
+
+# Necessary for building slideshowimpl
+$(eval $(call gb_Library_add_api,slideshow,\
+	offapi \
+	udkapi \
+))
+
 $(eval $(call gb_Library_add_linked_static_libs,slideshow,\
 	sldshw_s \
 ))


### PR DESCRIPTION
Make 4.4 seems to ignore the parameters given for object slideshowimpl for static library "sldshw_s". We request the object file here too, so we indicate the parameters (again) here.