### PR TITLE
Remove unused(?) code

### DIFF
--- a/main/svx/inc/svx/svdglue.hxx
+++ b/main/svx/inc/svx/svdglue.hxx
@@ -95,7 +95,6 @@ public:
 	void         SetHorzAlign(sal_uInt16 nAlg)                  { nAlign=(nAlign&0xFF00)|(nAlg&0x00FF); }
 	sal_uInt16       GetVertAlign() const                       { return nAlign&0xFF00; }
 	void         SetVertAlign(sal_uInt16 nAlg)                  { nAlign=(nAlign&0x00FF)|(nAlg&0xFF00); }
-	void         Draw(OutputDevice& rOut, const SdrObject* pObj) const;
 	FASTBOOL     IsHit(const Point& rPnt, const OutputDevice& rOut, const SdrObject* pObj) const;
 	void         Invalidate(Window& rWin, const SdrObject* pObj) const;
 	Point        GetAbsolutePos(const SdrObject& rObj) const;

--- a/main/svx/source/svdraw/svdglue.cxx
+++ b/main/svx/source/svdraw/svdglue.cxx
@@ -247,45 +247,6 @@ void SdrGluePoint::Shear(const Point& rRef, long /*nWink*/, double tn, FASTBOOL 
 	if (pObj!=NULL) SetAbsolutePos(aPt,*pObj); else SetPos(aPt);
 }
 
-// Unused code?!
-void SdrGluePoint::Draw(OutputDevice& rOut, const SdrObject* pObj) const
-{
-	Color aBackPenColor(COL_WHITE);
-	Color aForePenColor(COL_LIGHTBLUE);
-
-	bool bMapMerk=rOut.IsMapModeEnabled();
-	Point aPt(pObj!=NULL ? GetAbsolutePos(*pObj) : GetPos());
-	aPt=rOut.LogicToPixel(aPt);
-	rOut.EnableMapMode(sal_False);
-	long x=aPt.X(),y=aPt.Y(); // Groesse erstmal fest auf 7 Pixel
-
-	rOut.SetLineColor( aBackPenColor );
-	rOut.DrawLine(Point(x-2,y-3),Point(x+3,y+2));
-	rOut.DrawLine(Point(x-3,y-2),Point(x+2,y+3));
-	rOut.DrawLine(Point(x-3,y+2),Point(x+2,y-3));
-	rOut.DrawLine(Point(x-2,y+3),Point(x+3,y-2));
-	
-	if (bNoPercent) 
-	{
-		switch (GetHorzAlign()) 
-		{
-			case SDRHORZALIGN_LEFT  : rOut.DrawLine(Point(x-3,y-1),Point(x-3,y+1)); break;
-			case SDRHORZALIGN_RIGHT : rOut.DrawLine(Point(x+3,y-1),Point(x+3,y+1)); break;
-		}
-
-		switch (GetVertAlign()) 
-		{
-			case SDRVERTALIGN_TOP   : rOut.DrawLine(Point(x-1,y-3),Point(x+1,y-3)); break;
-			case SDRVERTALIGN_BOTTOM: rOut.DrawLine(Point(x-1,y+3),Point(x+1,y+3)); break;
-		}
-	}
-
-	rOut.SetLineColor( aForePenColor );
-	rOut.DrawLine(Point(x-2,y-2),Point(x+2,y+2));
-	rOut.DrawLine(Point(x-2,y+2),Point(x+2,y-2));
-	rOut.EnableMapMode(bMapMerk);
-}
-
 void SdrGluePoint::Invalidate(Window& rWin, const SdrObject* pObj) const
 {
 	bool bMapMerk=rWin.IsMapModeEnabled();


### PR DESCRIPTION
Gluepoint is actually generated here:
https://github.com/apache/openoffice/blob/trunk/main/svx/source/sdr/primitive2d/sdrprimitivetools.cxx#L80

This part looks like a leftover for me.

"SdrGluePoint::Draw" is only to be found in this file and nowhere else: http://opengrok.openoffice.org/search?project=trunk&full=%22SdrGluePoint%3A%3ADraw%22

Any opinions?