### PR TITLE
Possible fix for issue 60859

### DIFF
--- a/main/sd/source/ui/slideshow/slideshowimpl.cxx
+++ b/main/sd/source/ui/slideshow/slideshowimpl.cxx
@@ -238,13 +238,23 @@ AnimationSlideController::AnimationSlideController( Reference< XIndexAccess > xS
 
 void AnimationSlideController::setStartSlideNumber( sal_Int32 nSlideNumber )
 {
-	while( ( !maSlideVisible[nSlideNumber] ) 
-			|| ( nSlideNumber > maSlideVisible.size() ) ) nSlideNumber++;
-
-	if(nSlideNumber > maSlideVisible.size())
-		mnStartSlideNumber = 0;
-	else
-		mnStartSlideNumber = nSlideNumber;
+    mnStartSlideNumber = nSlideNumber;
+    if ( maSlideVisible[mnStartSlideNumber] )
+        return;
+    // Search forward for the first visible slide
+    for ( ; ( (size_t)mnStartSlideNumber < maSlideVisible.size() ) ;
+          mnStartSlideNumber++ ) {
+        if ( maSlideVisible[mnStartSlideNumber] )
+            return;
+    }
+    // Search backward for the first visible slide
+    for (mnStartSlideNumber = nSlideNumber ;
+         ( mnStartSlideNumber >= 0 ) ; mnStartSlideNumber-- ) {
+        if ( maSlideVisible[mnStartSlideNumber] )
+            return;
+    }
+    // No visible slides! Surrender to the request
+    mnStartSlideNumber = nSlideNumber;
 }
 
 sal_Int32 AnimationSlideController::getStartSlideIndex() const

--- a/main/sd/source/ui/slideshow/slideshowimpl.cxx
+++ b/main/sd/source/ui/slideshow/slideshowimpl.cxx
@@ -145,7 +145,7 @@ public:
 public:
 	AnimationSlideController( Reference< XIndexAccess > xSlides, Mode eMode );
 
-	void setStartSlideNumber( sal_Int32 nSlideNumber ) { mnStartSlideNumber = nSlideNumber; }
+	void setStartSlideNumber( sal_Int32 nSlideNumber );
 	sal_Int32 getStartSlideIndex() const;
 
 	sal_Int32 getCurrentSlideNumber() const;
@@ -234,6 +234,17 @@ AnimationSlideController::AnimationSlideController( Reference< XIndexAccess > xS
 {
 	if( mxSlides.is() )
 		mnSlideCount = xSlides->getCount();
+}
+
+void AnimationSlideController::setStartSlideNumber( sal_Int32 nSlideNumber )
+{
+	while( ( !maSlideVisible[nSlideNumber] ) 
+			|| ( nSlideNumber > maSlideVisible.size() ) ) nSlideNumber++;
+
+	if(nSlideNumber > maSlideVisible.size())
+		mnStartSlideNumber = 0;
+	else
+		mnStartSlideNumber = nSlideNumber;
 }
 
 sal_Int32 AnimationSlideController::getStartSlideIndex() const


### PR DESCRIPTION
If 1st slide is hidden and selected, show presentation does start after this.

Thanks to iammisc for this patch
https://bz.apache.org/ooo/show_bug.cgi?id=60859