### PR TITLE
Link pthread library when using OpenSSL on Linux

### DIFF
--- a/main/RepositoryExternal.mk
+++ b/main/RepositoryExternal.mk
@@ -390,6 +390,11 @@ $(call gb_LinkTarget_add_libs,$(1),\
 	-lsocket \
 )
 endif
+ifeq ($(OS),LINUX)
+$(call gb_LinkTarget_add_linked_libs,$(1),\
+	pthread \
+)
+endif
 endif
 endef
 


### PR DESCRIPTION
On my openSUSE system some libraries inside modules ucb, oox and possibly others did not link, because symbols from the pthread library could not be resolved.

This is an attempt to include the pthread library when the in-tree OpenSSL is used.

This patch restores the ability to compile AOO... but I am not 100% sure whether it is the correct way to implement it.