### PR TITLE
Update 05200100.xhp : par_id was disabled

### DIFF
--- a/main/helpcontent2/source/text/shared/01/05200100.xhp
+++ b/main/helpcontent2/source/text/shared/01/05200100.xhp
@@ -103,7 +103,7 @@
 <paragraph role="paragraph" id="par_id3154583" xml-lang="en-US" l10n=""><ahelp hid="SVX:LISTBOX:RID_SVXPAGE_LINE:LB_EDGE_STYLE">Select the shape to be used at the corners of the line. In case of a small angle between lines, a mitered shape is replaced with a beveled shape.</ahelp></paragraph>
 <bookmark xml-lang="en-US" branch="hid/cui:ListBox:RID_SVXPAGE_LINE:LB_CAP_STYLE" id="bm_id3154584" localize="false" />
 <paragraph role="heading" id="hd_id3154585" xml-lang="en-US" level="3" l10n="">Cap style</paragraph>
-<paragraph role="paragraph" nil="par_id3154586" xml-lang="en-US" l10n=""><ahelp hid="SVX:LISTBOX:RID_SVXPAGE_LINE:LB_CAP_STYLE">Select the style of the line end caps. The caps are added to inner dashes as well.</ahelp></paragraph>
+<paragraph role="paragraph" id="par_id3154586" xml-lang="en-US" l10n=""><ahelp hid="SVX:LISTBOX:RID_SVXPAGE_LINE:LB_CAP_STYLE">Select the style of the line end caps. The caps are added to inner dashes as well.</ahelp></paragraph>
 <embed href="text/shared/00/00000001.xhp#vorschau"/>
 </body>
 </helpdocument>


### PR DESCRIPTION
par_id "par_id3154586"  was disabled by changing "id" to "nil".

Reverted back to field "id"