### PR TITLE
pre-commit clean ups for `.el` and `.pas` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bat|c|cxx|dxp|h|hrc|hxx|idl|in|ini|java|md|mk|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bat|c|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|md|mk|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|dxp|h|hrc|idl|in|ini|md|mk|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$
+        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|dxp|el|h|hrc|idl|in|ini|md|mk|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$
       - id: trailing-whitespace
-        files: \.(asp|bat|ini|php|pl|rc|sh|xcs|xdl|xmi|xsd|ya?ml)$
+        files: \.(asp|bat|el|ini|pas|php|pl|rc|sh|xcs|xdl|xmi|xsd|ya?ml)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/main/odk/examples/OLE/delphi/InsertTables/SampleCode.pas
+++ b/main/odk/examples/OLE/delphi/InsertTables/SampleCode.pas
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 {***********************************************************************
  *
  *  The Contents of this file are made available subject to the terms of
  *  the BSD license.
- *  
+ *
  *  Copyright 2000, 2010 Oracle and/or its affiliates.
  *  All rights reserved.
  *
@@ -50,7 +50,7 @@
  *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
  *  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
  *  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *     
+ *
  *************************************************************************}
 unit SampleCode;
 
@@ -410,5 +410,3 @@ begin
 end;
 
 end.
-
-

--- a/main/odk/examples/OLE/delphi/InsertTables/SampleUI.pas
+++ b/main/odk/examples/OLE/delphi/InsertTables/SampleUI.pas
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 {***********************************************************************
  *
  *  The Contents of this file are made available subject to the terms of
  *  the BSD license.
- *  
+ *
  *  Copyright 2000, 2010 Oracle and/or its affiliates.
  *  All rights reserved.
  *
@@ -50,7 +50,7 @@
  *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
  *  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
  *  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *     
+ *
  *************************************************************************}
 unit SampleUI;
 

--- a/main/writerfilter/source/doctok/xmigen.el
+++ b/main/writerfilter/source/doctok/xmigen.el
@@ -19,7 +19,7 @@
   (insert "        </UML:TaggedValue.type>\n")
   (insert "      </UML:TaggedValue>\n")
   (insert "    </UML:ModelElement.taggedValue>\n"))
-  
+
 (defun insert-uml-attribute (type name offset bits mask shift comment attrid)
   (insert "<UML:Classifier.feature>\n")
   (insert "  <UML:Attribute name=\"" name "\">\n")
@@ -119,7 +119,7 @@
   (insert "</UML:Generalization>\n"))
 
 (defun insert-uml-sprm (name sprmcode kind)
-  (insert-uml-class-begin name) 
+  (insert-uml-class-begin name)
   (insert-uml-stereotype "ww8sprm")
   (insert-uml-taggedvalue sprmcode "sprmcode")
   (insert-uml-taggedvalue (concat "rtf:" name) "sprmid")


### PR DESCRIPTION
Enforced 3 hooks:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace