### PR TITLE
pre-commit clean up `.common` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bat|c|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bat|c|common|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|dxp|el|h|hrc|idl|in|ini|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|common|dxp|el|h|hrc|idl|in|ini|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|sh|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: \.(asp|bat|el|hrc|in|ini|m|mm|mod|pas|php|pl|pm|rc|sh|xcs|xdl|xmi|xsd|ya?ml)$
+        files: \.(asp|bat|common|el|hrc|in|ini|m|mm|mod|pas|php|pl|pm|rc|sh|xcs|xdl|xmi|xsd|ya?ml)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/main/accessibility/workben/org/openoffice/accessibility/awb/canvas/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/awb/canvas/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,22 +7,21 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
-JARFILES = jurt.jar unoil.jar ridl.jar 
+JARFILES = jurt.jar unoil.jar ridl.jar
 JAVAFILES = 		\
 	CanvasShape.java  	\
 	Canvas.java        	\
 	MouseObserver.java	\
 	ShapeContainer.java
-

--- a/main/accessibility/workben/org/openoffice/accessibility/awb/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/awb/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,18 +7,18 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 JAVAFILES = 						\
 	AccessibilityWorkBench.java		\
-	HelpWindow.java						
+	HelpWindow.java

--- a/main/accessibility/workben/org/openoffice/accessibility/awb/tree/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/awb/tree/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,19 +7,19 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
-JARFILES = jurt.jar unoil.jar ridl.jar 
+JARFILES = jurt.jar unoil.jar ridl.jar
 JAVAFILES = 						\
 	AccessibilityModel.java \
 	AccessibilityNode.java \

--- a/main/accessibility/workben/org/openoffice/accessibility/awb/view/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/awb/view/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,19 +7,19 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
-JARFILES = jurt.jar unoil.jar ridl.jar 
+JARFILES = jurt.jar unoil.jar ridl.jar
 JAVAFILES = 						\
 	ComponentView.java				\
 	ContextView.java				\

--- a/main/accessibility/workben/org/openoffice/accessibility/awb/view/text/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/awb/view/text/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,19 +7,19 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
-JARFILES = jurt.jar unoil.jar ridl.jar 
+JARFILES = jurt.jar unoil.jar ridl.jar
 JAVAFILES = 					\
 	CaretSpinnerModel.java		\
 	TextActionDialog.java		\

--- a/main/accessibility/workben/org/openoffice/accessibility/misc/makefile.common
+++ b/main/accessibility/workben/org/openoffice/accessibility/misc/makefile.common
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 JARFILES = jurt.jar unoil.jar ridl.jar juh.jar java_uno.jar


### PR DESCRIPTION
Enforce 3 hooks:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace