### PR TITLE
Fix codespell by recreating the ignored words list

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -224,6 +224,7 @@ assemly
 assigment
 assigne
 assistent
+assocations
 assomption
 asssigned
 asssuming


### PR DESCRIPTION
Ran locally:

`codespell --skip='./extras' . | cut -f2 -d' ' | tr A-Z a-z | sort | uniq > .github/linters/codespell.txt`

The misspelled word is in a patch file.

Was my mistake from a couple of weeks ago.

refs #368 

refs #370 