### PR TITLE
pre-commit: auto remove trailing whitespace from `.py` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       - id: mixed-line-ending
         files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|cl|common|dxp|el|h|hrc|idl|in|ini|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|sh|xba|xcs|xdl|xhp|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: \.(asp|bat|cl|common|el|hrc|in|ini|m|mm|mod|pas|php|pl|pm|rc|sh|xba|xcs|xdl|xmi|xsd|ya?ml)$
+        files: \.(asp|bat|cl|common|el|hrc|in|ini|m|mm|mod|pas|php|pl|pm|py|rc|sh|xba|xcs|xdl|xmi|xsd|ya?ml)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/main/desktop/test/deployment/active/active_python.py
+++ b/main/desktop/test/deployment/active/active_python.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 import uno

--- a/main/desktop/test/deployment/passive/passive_python.py
+++ b/main/desktop/test/deployment/passive/passive_python.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 import uno

--- a/main/l10ntools/scripts/tool/const.py
+++ b/main/l10ntools/scripts/tool/const.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 # Pseudo const

--- a/main/l10ntools/scripts/tool/l10ntool.py
+++ b/main/l10ntools/scripts/tool/l10ntool.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 from optparse import OptionParser

--- a/main/l10ntools/scripts/tool/pseudo.py
+++ b/main/l10ntools/scripts/tool/pseudo.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 # to support macosx baseline machines from Cretaceous period

--- a/main/l10ntools/scripts/tool/sdf.py
+++ b/main/l10ntools/scripts/tool/sdf.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 from pseudo import PseudoSet,PseudoOrderedDict

--- a/main/l10ntools/scripts/tool/xhtex.py
+++ b/main/l10ntools/scripts/tool/xhtex.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 from l10ntool import AbstractL10nTool

--- a/main/l10ntools/scripts/tool/xtxex.py
+++ b/main/l10ntools/scripts/tool/xtxex.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 from l10ntool import AbstractL10nTool

--- a/main/pyuno/demo/biblioaccess.py
+++ b/main/pyuno/demo/biblioaccess.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import uno

--- a/main/pyuno/demo/hello_world_comp.py
+++ b/main/pyuno/demo/hello_world_comp.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import uno

--- a/main/pyuno/demo/ooextract.py
+++ b/main/pyuno/demo/ooextract.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import getopt,sys

--- a/main/pyuno/demo/swritercompclient.py
+++ b/main/pyuno/demo/swritercompclient.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 # instantiating

--- a/main/pyuno/source/loader/pythonloader.py
+++ b/main/pyuno/source/loader/pythonloader.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import uno
 import unohelper

--- a/main/pyuno/source/module/uno.py
+++ b/main/pyuno/source/module/uno.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import sys
 
@@ -256,7 +256,7 @@ def _uno_import( name, *optargs, **kwargs ):
         else:
             mod = pyuno.__class__(x)  # How to create a module ??
         d = mod.__dict__
-    
+
     RuntimeException = pyuno.getClass( "com.sun.star.uno.RuntimeException" )
     for x in fromlist:
         if x not in d:

--- a/main/pyuno/source/module/unohelper.py
+++ b/main/pyuno/source/module/unohelper.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import uno
 import pyuno

--- a/main/sc/workben/celltrans/parse.py
+++ b/main/sc/workben/celltrans/parse.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 import sys

--- a/main/scripting/examples/python/Capitalise.py
+++ b/main/scripting/examples/python/Capitalise.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/scripting/examples/python/HelloWorld.py
+++ b/main/scripting/examples/python/HelloWorld.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 # HelloWorld python script for the scripting framework

--- a/main/scripting/source/pyprov/mailmerge.py
+++ b/main/scripting/source/pyprov/mailmerge.py
@@ -120,7 +120,7 @@ class PyMailSMTPService(unohelper.Base, XSmtpService):
             self.server = smtplib.SMTP(server, port,timeout=tout)
         if dbg:
             self.server.set_debuglevel(1)
-        
+
         if dbg:
             out.write("ConnectionType: %s\n" % str(connectiontype))
 

--- a/main/scripting/source/pyprov/officehelper.py
+++ b/main/scripting/source/pyprov/officehelper.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 #

--- a/main/scripting/source/pyprov/pythonscript.py
+++ b/main/scripting/source/pyprov/pythonscript.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 # XScript implementation for python

--- a/main/solenv/bin/pchdelta.py
+++ b/main/solenv/bin/pchdelta.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/solenv/inc/lldb4aoo.py
+++ b/main/solenv/inc/lldb4aoo.py
@@ -109,13 +109,13 @@ def get_pimpl_info( valobj, dict):
 
 
 def getinfo_for_rtl_String( valobj, dict):
-	return ret_strdata_info( valobj, 'refCount', 'length', 'buffer') 
+	return ret_strdata_info( valobj, 'refCount', 'length', 'buffer')
 
 def getinfo_for_rtl_uString( valobj, dict):
-	return ret_strdata_info( valobj, 'refCount', 'length', 'buffer') 
+	return ret_strdata_info( valobj, 'refCount', 'length', 'buffer')
 
 def getinfo_for__ByteStringData( valobj, dict):
-	return ret_strdata_info( valobj, 'mnRefCount', 'mnLen', 'maStr') 
+	return ret_strdata_info( valobj, 'mnRefCount', 'mnLen', 'maStr')
 
 def getinfo_for__UniStringData( valobj, dict):
-	return ret_strdata_info( valobj, 'mnRefCount', 'mnLen', 'maStr') 
+	return ret_strdata_info( valobj, 'mnRefCount', 'mnLen', 'maStr')

--- a/main/testtools/source/bridgetest/pyuno/core.py
+++ b/main/testtools/source/bridgetest/pyuno/core.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import pyuno
 import uno
@@ -69,10 +69,10 @@ def assign( rData, bBool, cChar, nByte, nShort, nUShort, nLong, nULong, nHyper,\
 class PythonTransporter:
     def __init__( self ):
         pass
-    
+
     def transportAny( self, arg ):
         return arg
-        
+
 class TestCase( unittest.TestCase):
 
       def __init__(self,method,ctx):
@@ -81,7 +81,7 @@ class TestCase( unittest.TestCase):
 
       def setUp(self):
          # the testcomponent from the testtools project
-         self.tobj = self.ctx.ServiceManager.createInstanceWithContext( 
+         self.tobj = self.ctx.ServiceManager.createInstanceWithContext(
                                 'com.sun.star.test.bridge.CppTestObject' , self.ctx )
 
          self.tobj.Bool = 1
@@ -123,13 +123,13 @@ class TestCase( unittest.TestCase):
           self.failUnless( self.tobj.Sequence[1] == self.testElement2 , "Sequence2 test")
           self.failUnless( equalsEps( 4.3,self.tobj.Float,0.0001) , "float test" )
           self.failUnless( 4.2 == self.tobj.Double , "double test" )
-          self.failUnless( self.ctx == self.tobj.Interface , 
+          self.failUnless( self.ctx == self.tobj.Interface ,
                           "object identity test with C++ object" )
           self.failUnless( not self.ctx == self.tobj , "object not identical test " )
           self.failUnless( 42 == self.tobj.transportAny( 42 ), "transportAny long" )
           self.failUnless( "woo, this is python" == self.tobj.transportAny( "woo, this is python" ), \
                   "string roundtrip via any test"  )
-           
+
       def testEnum( self ):
           e1 = uno.Enum( "com.sun.star.uno.TypeClass" , "LONG" )
           e2 = uno.Enum( "com.sun.star.uno.TypeClass" , "LONG" )
@@ -164,7 +164,7 @@ class TestCase( unittest.TestCase):
           self.tobj.Bool = uno.Bool(0)
           self.failUnless( not self.tobj.Bool , "bool true attribute test" )
 
-          # new boolean semantic 
+          # new boolean semantic
           self.failUnless( id( self.tobj.transportAny( True ) ) == id(True)  , "boolean preserve test")
           self.failUnless( id( self.tobj.transportAny( False ) ) == id(False) , "boolean preserve test" )
           self.failUnless( id( self.tobj.transportAny(1) ) != id( True ), "boolean preserve test" )
@@ -189,12 +189,12 @@ class TestCase( unittest.TestCase):
           self.failUnless( mystruct == self.tobj.transportAny( mystruct ), "struct roundtrip with any test" )
           my2ndstruct = uno.createUnoStruct( "test.testtools.bridgetest.TestData", \
                       1, 'h', 43, -42,44,42,41,46,47,4.3,4.2,4,"yabadabadoo",self.ctx,"yabadabadoo",())
-          self.failUnless( my2ndstruct == mystruct, "struct non-default ctor test" )                                  
+          self.failUnless( my2ndstruct == mystruct, "struct non-default ctor test" )
       def testUnicode( self ):
           uni = u'\0148'
           self.tobj.String = uni
           self.failUnless( uni == self.tobj.String )
-          
+
 
           self.tobj.String = u'dubidu'
           self.failUnless( u'dubidu' == self.tobj.String , "unicode comparison test")
@@ -231,7 +231,7 @@ class TestCase( unittest.TestCase):
           except unoExc:
                 wasHere = 1
           self.failUnless(wasHere, "exception test 3")
-    
+
           illegalArg = uno.getClass( "com.sun.star.lang.IllegalArgumentException" )
           wasHere = 0
           try:
@@ -246,13 +246,13 @@ class TestCase( unittest.TestCase):
           else:
                 self.failUnless( 0, "except test 5c" )
                 self.failUnless( wasHere, "illegal argument exception test failed" )
-                  
+
       def testInterface(self):
           clazz = uno.getClass( "com.sun.star.lang.XComponent" )
           self.failUnless( "com.sun.star.lang.XComponent" == clazz.__pyunointerface__ )
           self.failUnless( issubclass( clazz, uno.getClass( "com.sun.star.uno.XInterface" ) ) )
           self.tobj.Interface = None
-           
+
 
       def testOutparam( self):
           # outparameter
@@ -279,7 +279,7 @@ class TestCase( unittest.TestCase):
           self.failUnless(myseq == self.tobj.Sequence, "outparam 17 test")
           self.failUnless(my2ndstruct == struct, "outparam 18 test")
 
-# should work, debug on windows, why not    
+# should work, debug on windows, why not
 #    struct, mybool,mychar,mybyte,myshort,myushort,mylong,myulong,myhyper,myuhyper,myfloat,\
 #              mydouble,myenum,mystring,myinterface,myany,myseq,my2ndstruct = self.tobj.setValues2( \
 #             mybool,mychar,mybyte,myshort,myushort,mylong,myulong,myhyper,myuhyper,myfloat,\
@@ -312,8 +312,8 @@ class TestCase( unittest.TestCase):
           except AttributeError:
                  wasHere = 1
           except IllegalArgumentException:
-                 wasHere = 1     
-          self.failUnless( wasHere, "wrong attribute test" )             
+                 wasHere = 1
+          self.failUnless( wasHere, "wrong attribute test" )
 
           IllegalArgumentException = uno.getClass("com.sun.star.lang.IllegalArgumentException" )
           RuntimeException = uno.getClass("com.sun.star.uno.RuntimeException" )
@@ -347,7 +347,7 @@ class TestCase( unittest.TestCase):
           self.failUnless( s == uno.ByteSequence( s ) )
           self.failUnless( s[0] == 'a' )
           self.failUnless( s[1] == 'b' )
-          
+
 
       def testInvoke( self ):
           self.failUnless( 5 == uno.invoke( self.tobj , "transportAny" , (uno.Any("byte", 5),) ) )
@@ -357,5 +357,3 @@ class TestCase( unittest.TestCase):
           mystruct = uno.createUnoStruct(
               "com.sun.star.beans.PropertyValue", "foo",0,uno.Any(t,2),0 )
           mystruct.Value = uno.Any(t, 1)
-          
-          

--- a/main/testtools/source/bridgetest/pyuno/impl.py
+++ b/main/testtools/source/bridgetest/pyuno/impl.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 "tests bridging python implementations of UNO objects"
 import unittest
@@ -33,7 +33,7 @@ class SequenceOutputStream( unohelper.Base, XOutputStream ):
       def __init__( self ):
           self.s = uno.ByteSequence("")
           self.closed = 0
-          
+
       def closeOutput(self):
           self.closed = 1
 
@@ -45,18 +45,18 @@ class SequenceOutputStream( unohelper.Base, XOutputStream ):
 
       def getSequence( self ):
           return self.s
-          
-                  
+
+
 class SequenceInputStream( XInputStream, unohelper.Base ):
       def __init__( self, seq ):
           self.s = seq
           self.nIndex = 0
           self.closed = 0
-          
+
       def closeInput( self):
           self.closed = 1
           self.s = None
-          
+
       def skipBytes( self, nByteCount ):
           if( nByteCount + self.nIndex > len(self.s) ):
               nByteCount = len(self.s) - self.nIndex
@@ -71,18 +71,18 @@ class SequenceInputStream( XInputStream, unohelper.Base ):
           retSeq = uno.ByteSequence(self.s.value[self.nIndex : self.nIndex + nRet ])
           self.nIndex = self.nIndex + nRet
           return nRet, retSeq
-          
+
       def readSomeBytes( self, retSeq , nByteCount ):
           #as we never block !
           return readBytes( retSeq, nByteCount )
-          
+
       def available( self ):
           return len( self.s ) - self.nIndex
 
 class SequenceInputStream2( SequenceInputStream ):
       def __init__( self, seq ):
             SequenceInputStream.__init__( self, seq )
-            
+
 class TestCase(unittest.TestCase):
       def __init__(self,method,ctx):
           unittest.TestCase.__init__(self,method)
@@ -93,7 +93,7 @@ class TestCase(unittest.TestCase):
                            "com.sun.star.test.bridge.CppTestObject",self.ctx)
           self.pipe = self.ctx.ServiceManager.createInstanceWithContext( \
                            "com.sun.star.io.Pipe" , self.ctx )
-                           
+
       def testStandard( self ):
           dataOut = self.ctx.ServiceManager.createInstanceWithContext( \
                         "com.sun.star.io.DataOutputStream", self.ctx )
@@ -105,7 +105,7 @@ class TestCase(unittest.TestCase):
 
           dataInput = self.ctx.ServiceManager.createInstanceWithContext( \
                    "com.sun.star.io.DataInputStream", self.ctx )
-          
+
           dataInput.setInputStream( SequenceInputStream2( streamOut.getSequence() ) )
 
           self.failUnless( 42 == dataInput.readShort() )
@@ -116,12 +116,12 @@ class TestCase(unittest.TestCase):
 class NullDevice:
       def write( self, string ):
             pass
-      
+
 
 class EventListener( unohelper.Base, XEventListener ):
     def __init__( self ):
         self.disposingCalled = False
-        
+
     def disposing( self , eventObject ):
         self.disposingCalled = True
 
@@ -152,7 +152,7 @@ class TestHelperCase( unittest.TestCase ):
             smgr = uno.getComponentContext().ServiceManager.createInstance(
                   "com.sun.star.lang.ServiceManager" )
 
-            # check, whether listeners 
+            # check, whether listeners
             listener = EventListener()
             smgr.addEventListener( listener )
             smgr.dispose()
@@ -166,7 +166,7 @@ class TestHelperCase( unittest.TestCase ):
             smgr.removeEventListener( listener )
             smgr.dispose()
             self.failUnless( not listener.disposingCalled )
-            
+
       def testCurrentContext( self ):
             oldContext = uno.getCurrentContext()
             try:
@@ -176,8 +176,8 @@ class TestHelperCase( unittest.TestCase ):
                   self.failUnless( None == uno.getCurrentContext().getValueByName( "My43" ) )
             finally:
                   uno.setCurrentContext( oldContext )
-          
-            
+
+
 
 def suite( ctx ):
     suite = unittest.TestSuite()
@@ -187,4 +187,3 @@ def suite( ctx ):
     suite.addTest(TestHelperCase( "testListener" ) )
     suite.addTest(TestHelperCase( "testCurrentContext" ) )
     return suite
-                                           

--- a/main/testtools/source/bridgetest/pyuno/importer.py
+++ b/main/testtools/source/bridgetest/pyuno/importer.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import unittest
 import uno
@@ -29,7 +29,7 @@ class ImporterTestCase(unittest.TestCase):
       def __init__(self,method,ctx):
           unittest.TestCase.__init__(self,method)
           self.ctx = ctx
-          
+
       def setUp(self):
           self.tobj = self.ctx.ServiceManager.createInstanceWithContext( \
                            "com.sun.star.test.bridge.CppTestObject",self.ctx)
@@ -37,7 +37,7 @@ class ImporterTestCase(unittest.TestCase):
       def testStandard( self ):
           self.failUnless( IllegalArgumentException != None, "none-test" )
           self.failUnlessRaises( IllegalArgumentException, self.tobj.raiseException, 1,"foo",self.tobj)
-                 
+
           self.failUnless( TWO == uno.Enum( "test.testtools.bridgetest.TestEnum","TWO"), "enum" )
           self.failUnless( UNSIGNED_LONG == uno.Enum( "com.sun.star.uno.TypeClass", "UNSIGNED_LONG" ) )
           self.failUnless( typeOfIllegalArgumentException ==

--- a/main/testtools/source/bridgetest/pyuno/main.py
+++ b/main/testtools/source/bridgetest/pyuno/main.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import uno
 import unohelper
@@ -28,7 +28,7 @@ import os
 import sys
 
 ctx = uno.getComponentContext()
-# needed for the tests 
+# needed for the tests
 unohelper.addComponentsToContext(ctx,ctx,(os.environ["FOO"]+"/cppobj.uno",os.environ["FOO"]+"/bridgetest.uno","streams.uno","bootstrap.uno"),"com.sun.star.loader.SharedLibrary")
 
 unohelper.addComponentsToContext(ctx,ctx,("vnd.openoffice.pymodule:samplecomponent",),"com.sun.star.loader.Python")

--- a/main/testtools/source/bridgetest/pyuno/samplecomponent.py
+++ b/main/testtools/source/bridgetest/pyuno/samplecomponent.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import uno
 import unohelper
@@ -54,8 +54,8 @@ def assign( rData, bBool, cChar, nByte, nShort, nUShort, nLong, nULong, nHyper,\
 class MyRecursiveCall( XRecursiveCall, unohelper.Base ):
       def callRecursivly( xCall, nToCall ):
 	  if nToCall:
-	     xCall.callRecursivly( self, nToCall -1 )	  
-    
+	     xCall.callRecursivly( self, nToCall -1 )
+
 class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
       def __init__(self,ctx):
 	  self.__dict__["callid"] = 0
@@ -66,7 +66,7 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
 
       def raiseException( self, ArgumentPosition, Message, Context ):
 	  raise IllegalArgumentException( Message, Context, ArgumentPosition )
-	
+
       def raiseRuntimeExceptionOneway(self, Message, Context ):
 	  raise RuntimeException( Message, Context )
 
@@ -76,7 +76,7 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
          self.__dict__["data"] = TestDataElements( bBool, cChar, nByte, nShort, nUShort, nLong,
 	                  nULong, nHyper, nUHyper, fFloat, fDouble, eEnum, aStruct, xInterface,
 			  aAny, aSequence )
-         self.__dict__["Struct"] = aStruct			  	     
+         self.__dict__["Struct"] = aStruct
 
       def setValues2( self, bBool, cChar, nByte, nShort, nUShort, nLong, nULong,\
 		      nHyper, nUHyper, fFloat, fDouble, eEnum,		\
@@ -88,13 +88,13 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
 	  return bBool, cChar, nByte, nShort, nUShort, nLong, nULong, nHyper, nUHyper, nULong, \
 	         nHyper, nUHyper, fFloat, fDouble, eEnum, aStruct, xInterface, aAny,	       \
 		 (aSequence[1],aSequence[0]), aStruct
-      						 
+
       def getValues(self, a,b,c,d,e,f,g,h, i,j,k,l,m,n):
 	  v = self.__dict__["data"]
 	  return self.__dict__["Struct"],v.Bool, v.Char, v.Byte, v.Short, v.UShort, v.Long,	\
 	         v.ULong, v.Hyper, v.UHyper, v.Float, v.Double, v.Enum, v.String, v.Interface,	\
 		 v.Any, v.Sequence, self.__dict__["Struct"]
-		 
+
       def call( self, callid, nWaitMUSEC ):
 	  if self.__dict__["callid"] >= callid:
 	     self.__dict__["sequenceBroken"] = 1
@@ -103,7 +103,7 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
 
       def callOneway( self, nCallId, nWaitMUSEC ):
 	  call( nCallId, nWaitMUSEC )
-	  
+
       def sequenceOfCallTestPassed():
 	  return self.__dict__["sequenceBroken"]
 
@@ -119,11 +119,11 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
 		 break
 	  if not found:
 	     raise UnknownPropertyException( "Property "+name+" is unknown", self )
-	     	 
+
       def __setattr__( self, name, value ):
 	  checkExistence( name )
 	  self.__dict__[name] = value
-	  
+
       def __getattr__( self, name ):
 	  checkExistence( name )
 	  return self.__dict__[name]
@@ -138,7 +138,7 @@ class SampleUnoComponent( XBridgeTestBase,XServiceInfo ):
 
 g_ImplementationHelper.addImplementation( \
 	SampleUnoComponent,g_implName,("com.sun.star.test.bridge.PythonTestObject",),)
-	
+
 #g_ImplementationEntries = \
 #    unohelper.ImplementationEntry(				\
 #	      "org.openoffice.comp.SamplePythonComponent",	\

--- a/main/testtools/source/bridgetest/pyuno/testcomp.py
+++ b/main/testtools/source/bridgetest/pyuno/testcomp.py
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 import uno
 import pythonloader

--- a/main/toolkit/src2xml/source/boxer.py
+++ b/main/toolkit/src2xml/source/boxer.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/expression.py
+++ b/main/toolkit/src2xml/source/expression.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/expression_test.py
+++ b/main/toolkit/src2xml/source/expression_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/globals.py
+++ b/main/toolkit/src2xml/source/globals.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import sys

--- a/main/toolkit/src2xml/source/macroexpander_test.py
+++ b/main/toolkit/src2xml/source/macroexpander_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/macroparser.py
+++ b/main/toolkit/src2xml/source/macroparser.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/macroparser_test.py
+++ b/main/toolkit/src2xml/source/macroparser_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import macroparser

--- a/main/toolkit/src2xml/source/src2xml.py
+++ b/main/toolkit/src2xml/source/src2xml.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 

--- a/main/toolkit/src2xml/source/srclexer.py
+++ b/main/toolkit/src2xml/source/srclexer.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import sys, os.path

--- a/main/toolkit/src2xml/source/srcparser.py
+++ b/main/toolkit/src2xml/source/srcparser.py
@@ -1,5 +1,5 @@
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,16 +7,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import sys

--- a/main/ucb/source/ucp/ftp/test.py
+++ b/main/ucb/source/ucp/ftp/test.py
@@ -1,6 +1,6 @@
 #/usr/bin/env python
 # *************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -8,16 +8,16 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 # *************************************************************
 
 import re,os
@@ -36,7 +36,7 @@ def grep(pattern,dirname,names):
 def find(pattern,directory = "."):
 	os.path.walk(directory,grep,re.compile(pattern))
 
-	
+
 if __name__ == "__main__":
 	import sys
 	if len(sys.argv) == 2:


### PR DESCRIPTION
Ran pre-commit locally to clean up the whitespace