### PR TITLE
Add pre-commit hook gitleaks to check for secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,18 @@ default_stages: [pre-commit, pre-push]
 default_language_version:
   # force all unspecified Python hooks to run python3
   python: python3
-minimum_pre_commit_version: "2.17.0"
+minimum_pre_commit_version: "3.2.0"
 repos:
   - repo: meta
     hooks:
       - id: identity
       - id: check-hooks-apply
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+        name: run gitleaks
+        description: check for secrets with gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
Gitleaks is a tool for detecting secrets like passwords, API keys, and tokens in git repos, files, and more

https://github.com/gitleaks/gitleaks

https://github.com/gitleaks/gitleaks?tab=readme-ov-file#pre-commit

Also bump the `minimum_pre_commit_version: "3.2.0"`