### PR TITLE
pre-commit whitespace clean up for `.m4` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bat|c|cl|common|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bat|c|cl|common|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|md|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|cl|common|dxp|el|h|hrc|idl|in|ini|m|md|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: ^main/.*\.(c|h)xx$|^main/.*\.java$|\.(asp|c|cl|common|dxp|el|h|hrc|idl|in|ini|m|m4|md|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: (m|M)akefile$|\.(asp|bat|c|cl|common|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asp|bat|c|cl|common|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|mk|mm|mod|pas|php|pl|pm|py|rc|rdf|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/main/aclocal.m4
+++ b/main/aclocal.m4
@@ -13,7 +13,7 @@
 
 # pkg.m4 - Macros to locate and utilise pkg-config.            -*- Autoconf -*-
 # serial 1 (pkg-config-0.24)
-# 
+#
 # Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -136,7 +136,7 @@ if test $pkg_failed = yes; then
         _PKG_SHORT_ERRORS_SUPPORTED
         if test $_pkg_short_errors_supported = yes; then
 	        $1[]_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "$2" 2>&1`
-        else 
+        else
 	        $1[]_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "$2" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
@@ -392,4 +392,3 @@ AC_DEFUN([AM_RUN_LOG],
    ac_status=$?
    echo "$as_me:$LINENO: \$? = $ac_status" >&AS_MESSAGE_LOG_FD
    (exit $ac_status); }])
-


### PR DESCRIPTION
Enforced 3 hooks for `.m4` files:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace