### PR TITLE
Address bug #126768

### DIFF
--- a/main/vcl/source/glyphs/graphite_layout.cxx
+++ b/main/vcl/source/glyphs/graphite_layout.cxx
@@ -1048,7 +1048,11 @@ void GraphiteLayout::expandOrCondense(ImplLayoutArgs &rArgs)
                     size_t nCharIndex = mvGlyph2Char[i];
                     mvCharDxs[nCharIndex] += nOffset;
                     // adjust char dxs for rest of characters in cluster
-                    while (++nCharIndex < mvGlyph2Char.size())
+                    // Bug #126768: vectors mvGlyph2Char and mvChar2BaseGlyph may have different sizes
+                    size_t nMaxCharIndex = mvGlyph2Char.size();
+                    if ( nMaxCharIndex > mvChar2BaseGlyph.size() )
+                        nMaxCharIndex = mvChar2BaseGlyph.size();
+                    while ( ++nCharIndex < nMaxCharIndex )
                     {
                         int nChar2Base = (mvChar2BaseGlyph[nCharIndex] == -1)? -1 : (int)(mvChar2BaseGlyph[nCharIndex] & GLYPH_INDEX_MASK);
                         if (nChar2Base == -1 || nChar2Base == static_cast<int>(i))

--- a/main/xmloff/source/text/XMLTextFrameContext.cxx
+++ b/main/xmloff/source/text/XMLTextFrameContext.cxx
@@ -1477,17 +1477,17 @@ void XMLTextFrameContext::EndElement()
 {
     /// solve if multiple image child contexts were imported
     /// the winner is returned, if something has yet to be done with it
-    const SvXMLImportContext* pWinner = solveMultipleImages();
+    SvXMLImportContext* pWinner = const_cast< SvXMLImportContext* >( solveMultipleImages() );
 
     // #123261# see if the winner is a XMLTextFrameContext_Impl
-    const XMLTextFrameContext_Impl* pImplWinner = dynamic_cast< const XMLTextFrameContext_Impl* >(pWinner);
+    XMLTextFrameContext_Impl* pImplWinner = dynamic_cast< XMLTextFrameContext_Impl* >(pWinner);
 
     if(pImplWinner)
     {
         // #123261# if yes, set name now, after the winner is identified (setting at each
         // candidate may run into problems due to colliding with efforts in the target to
         // avoid double names, so only set one name at one image and not at each)
-        const_cast< XMLTextFrameContext_Impl* >(pImplWinner)->SetNameForFrameFromPropSet();
+        pImplWinner->SetNameForFrameFromPropSet();
     }
 
     SvXMLImportContext *pContext = &m_xImplContext;
@@ -1496,11 +1496,17 @@ void XMLTextFrameContext::EndElement()
     if( pImpl )
     {
         pImpl->CreateIfNotThere();
-
+    }
         // --> OD 2009-07-22 #i73249#
 //        // alternative text
 //        if( m_sDesc.getLength() )
 //            pImpl->SetDesc( m_sDesc );
+
+    // Bug #126768: set all properties to the winner
+    if ( pImplWinner ) {
+        pImpl = pImplWinner;
+    }
+    if ( pImpl ) {
         // svg:title
         if( m_sTitle.getLength() )
         {


### PR DESCRIPTION
Bug report: https://bz.apache.org/ooo/show_bug.cgi?id=126768

Applying values of the `<svg:title>` and `<svg:desc>` elements was failing due to the type of the `SwXFrame`'s `SwModify::pRegisteredIn` attribute.
A ``winner'' image is set its name successfully. Setting the above values to the same winner image also succeeds.

This PR must be checked against document with images, and hyperlinks as well.