### PR TITLE
pre-commit whitespace clean up for cpp files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bat|c|cl|cmd|common|component|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: \.(asp|c|cl|cmd|common|component|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asp|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: (m|M)akefile$|\.(asp|bat|c|cl|cmd|common|component|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asp|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|m|m4|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/main/crashrep/source/win32/base64.cpp
+++ b/main/crashrep/source/win32/base64.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,20 +7,20 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
- 
+
 #include <stdio.h>
 #include <string.h>
 #include "base64.h"
@@ -45,7 +45,7 @@ extern "C" size_t base64_encode( FILE *fin, FILE *fout )
 
 		if ( nBytes )
 		{
-			unsigned long value = 
+			unsigned long value =
 				((unsigned long)in_buffer[0]) << 16 |
 				((unsigned long)in_buffer[1]) << 8 |
 				((unsigned long)in_buffer[2]) << 0;

--- a/main/desktop/win32/source/QuickStart/QuickStart.cpp
+++ b/main/desktop/win32/source/QuickStart/QuickStart.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // QuickStart.cpp : Defines the entry point for the application.
@@ -49,8 +49,8 @@ HINSTANCE hInst;								// current instance
 TCHAR szTitle[MAX_LOADSTRING];					// The title bar text
 TCHAR szWindowClass[MAX_LOADSTRING];			// The title bar text
 
-TCHAR szExitString[MAX_LOADSTRING];			    
-TCHAR szTooltipString[MAX_LOADSTRING];			
+TCHAR szExitString[MAX_LOADSTRING];
+TCHAR szTooltipString[MAX_LOADSTRING];
 
 // Forward declarations of functions included in this code module:
 ATOM				MyRegisterClass(HINSTANCE hInstance);
@@ -68,7 +68,7 @@ bool launchSoffice( )
 {
     if ( !SofficeRuns() )
     {
-        // UINT ret = WinExec( "h:\\office60.630b\\program\\swriter.exe -bean", SW_SHOW );  
+        // UINT ret = WinExec( "h:\\office60.630b\\program\\swriter.exe -bean", SW_SHOW );
         char filename[_MAX_PATH + 1];
 
 		filename[_MAX_PATH] = 0;
@@ -108,29 +108,29 @@ void NotifyListener( HWND hWnd )
 
     if( !hIconActive )
     {
-        hIconActive = (HICON)LoadImage( GetModuleHandle( NULL ), MAKEINTRESOURCE( ICON_ACTIVE ), 
+        hIconActive = (HICON)LoadImage( GetModuleHandle( NULL ), MAKEINTRESOURCE( ICON_ACTIVE ),
             IMAGE_ICON, GetSystemMetrics( SM_CXSMICON ), GetSystemMetrics( SM_CYSMICON ),
             LR_DEFAULTCOLOR | LR_SHARED );
 
-/*        hIconInActive = (HICON)LoadImage( GetModuleHandle( NULL ), MAKEINTRESOURCE( ICON_INACTIVE ), 
+/*        hIconInActive = (HICON)LoadImage( GetModuleHandle( NULL ), MAKEINTRESOURCE( ICON_INACTIVE ),
             IMAGE_ICON, GetSystemMetrics( SM_CXSMICON ), GetSystemMetrics( SM_CYSMICON ),
             LR_DEFAULTCOLOR | LR_SHARED );
             */
     }
 
     NOTIFYICONDATA nid;
-    nid.cbSize = sizeof(NOTIFYICONDATA); 
-    nid.hWnd   = hWnd; 
-    nid.uID    = IDM_QUICKSTART; 
+    nid.cbSize = sizeof(NOTIFYICONDATA);
+    nid.hWnd   = hWnd;
+    nid.uID    = IDM_QUICKSTART;
 	nid.szTip[elementsof(nid.szTip) - 1] = 0;
 //    nid.hIcon = bTerminateVeto ? hIconActive : hIconInActive;
-//    strncpy(nid.szTip, bTerminateVeto ? STRING_QUICKSTARTACTIVE : STRING_QUICKSTARTINACTIVE, elementsof(nid.szTip) - 1 ); 
+//    strncpy(nid.szTip, bTerminateVeto ? STRING_QUICKSTARTACTIVE : STRING_QUICKSTARTINACTIVE, elementsof(nid.szTip) - 1 );
     nid.hIcon = hIconActive;
-    strncpy(nid.szTip, szTooltipString, elementsof(nid.szTip) - 1); 
-    nid.uFlags = NIF_TIP|NIF_ICON; 
+    strncpy(nid.szTip, szTooltipString, elementsof(nid.szTip) - 1);
+    nid.uFlags = NIF_TIP|NIF_ICON;
 
     // update systray
-    Shell_NotifyIcon( NIM_MODIFY, &nid );	
+    Shell_NotifyIcon( NIM_MODIFY, &nid );
     //CheckMenuItem( popupMenu, IDM_QUICKSTART, bTerminateVeto ? MF_CHECKED : MF_UNCHECKED );
 
     // notify listener
@@ -181,7 +181,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	MyRegisterClass(hInstance);
 
 	// Perform application initialization:
-	if (!InitInstance (hInstance, nCmdShow)) 
+	if (!InitInstance (hInstance, nCmdShow))
 	{
 		return FALSE;
 	}
@@ -189,9 +189,9 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 	hAccelTable = LoadAccelerators(hInstance, (LPCTSTR)IDC_QUICKSTART);
 
 	// Main message loop:
-	while (GetMessage(&msg, NULL, 0, 0)) 
+	while (GetMessage(&msg, NULL, 0, 0))
 	{
-		if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg)) 
+		if (!TranslateAccelerator(msg.hwnd, hAccelTable, &msg))
 		{
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);
@@ -220,7 +220,7 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 {
 	WNDCLASSEX wcex;
 
-	wcex.cbSize = sizeof(WNDCLASSEX); 
+	wcex.cbSize = sizeof(WNDCLASSEX);
 
 	wcex.style			= CS_HREDRAW | CS_VREDRAW;
 	wcex.lpfnWndProc	= (WNDPROC)WndProc;
@@ -280,7 +280,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 //
 LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    switch (message) 
+    switch (message)
 	{
         case WM_CREATE:
         {
@@ -294,62 +294,62 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
             // Add my items
             MENUITEMINFO mi;
-            mi.cbSize = sizeof(MENUITEMINFO); 
-            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID; 
-            mi.fType=MFT_STRING; 
-            mi.fState=MFS_ENABLED|MFS_DEFAULT; 
-            mi.wID = IDM_QUICKSTART; 
-            mi.hSubMenu=NULL; 
-            mi.hbmpChecked=NULL; 
-            mi.hbmpUnchecked=NULL; 
-            mi.dwItemData=NULL; 
-            mi.dwTypeData = "QuickStart"; 
+            mi.cbSize = sizeof(MENUITEMINFO);
+            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID;
+            mi.fType=MFT_STRING;
+            mi.fState=MFS_ENABLED|MFS_DEFAULT;
+            mi.wID = IDM_QUICKSTART;
+            mi.hSubMenu=NULL;
+            mi.hbmpChecked=NULL;
+            mi.hbmpUnchecked=NULL;
+            mi.dwItemData=NULL;
+            mi.dwTypeData = "QuickStart";
             mi.cch = strlen(mi.dwTypeData);
 //            InsertMenuItem(popupMenu, count++, TRUE, &mi);
 
-            mi.cbSize = sizeof(MENUITEMINFO); 
-            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID; 
-            mi.fType=MFT_STRING; 
-            mi.fState=MFS_ENABLED; 
-            mi.wID = IDM_ABOUT; 
-            mi.hSubMenu=NULL; 
-            mi.hbmpChecked=NULL; 
-            mi.hbmpUnchecked=NULL; 
-            mi.dwItemData=NULL; 
-            mi.dwTypeData = "Info..."; 
+            mi.cbSize = sizeof(MENUITEMINFO);
+            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID;
+            mi.fType=MFT_STRING;
+            mi.fState=MFS_ENABLED;
+            mi.wID = IDM_ABOUT;
+            mi.hSubMenu=NULL;
+            mi.hbmpChecked=NULL;
+            mi.hbmpUnchecked=NULL;
+            mi.dwItemData=NULL;
+            mi.dwTypeData = "Info...";
             mi.cch = strlen(mi.dwTypeData);
 //            InsertMenuItem(popupMenu, count++, TRUE, &mi);
 
-            mi.cbSize = sizeof(MENUITEMINFO); 
+            mi.cbSize = sizeof(MENUITEMINFO);
             mi.fMask=MIIM_TYPE;
-            mi.fType=MFT_SEPARATOR; 
-            mi.hSubMenu=NULL; 
-            mi.hbmpChecked=NULL; 
-            mi.hbmpUnchecked=NULL; 
-            mi.dwItemData=NULL; 
+            mi.fType=MFT_SEPARATOR;
+            mi.hSubMenu=NULL;
+            mi.hbmpChecked=NULL;
+            mi.hbmpUnchecked=NULL;
+            mi.dwItemData=NULL;
 //            InsertMenuItem(popupMenu, count++, TRUE, &mi);
 
-            mi.cbSize = sizeof(MENUITEMINFO); 
-            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID; 
-            mi.fType=MFT_STRING; 
-            mi.fState=MFS_ENABLED; 
-            mi.wID = IDM_EXIT; 
-            mi.hSubMenu=NULL; 
-            mi.hbmpChecked=NULL; 
-            mi.hbmpUnchecked=NULL; 
-            mi.dwItemData=NULL; 
-            mi.dwTypeData = szExitString; 
+            mi.cbSize = sizeof(MENUITEMINFO);
+            mi.fMask=MIIM_TYPE|MIIM_STATE|MIIM_ID;
+            mi.fType=MFT_STRING;
+            mi.fState=MFS_ENABLED;
+            mi.wID = IDM_EXIT;
+            mi.hSubMenu=NULL;
+            mi.hbmpChecked=NULL;
+            mi.hbmpUnchecked=NULL;
+            mi.dwItemData=NULL;
+            mi.dwTypeData = szExitString;
             mi.cch = strlen(mi.dwTypeData);
             InsertMenuItem(popupMenu, count++, TRUE, &mi);
 
             // add taskbar icon
             NOTIFYICONDATA nid;
-            nid.cbSize = sizeof(NOTIFYICONDATA); 
-            nid.hWnd   = hWnd; 
-            nid.uID    = IDM_QUICKSTART; 
-            nid.uFlags = NIF_MESSAGE; 
-            nid.uCallbackMessage=MY_TASKBAR_NOTIFICATION; 
-            Shell_NotifyIcon(NIM_ADD, &nid);	
+            nid.cbSize = sizeof(NOTIFYICONDATA);
+            nid.hWnd   = hWnd;
+            nid.uID    = IDM_QUICKSTART;
+            nid.uFlags = NIF_MESSAGE;
+            nid.uCallbackMessage=MY_TASKBAR_NOTIFICATION;
+            Shell_NotifyIcon(NIM_ADD, &nid);
 
             // and update state
             NotifyListener( hWnd );
@@ -358,7 +358,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             SetTimer(hWnd, UPDATE_TIMER, 3000, NULL);
         }
         break;
-        
+
         case MY_TASKBAR_NOTIFICATION: // message from taskbar
             switch(lParam)
             {
@@ -369,13 +369,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                     break;
                     */
 
-                case WM_LBUTTONDOWN: 
-                case WM_RBUTTONDOWN: 
+                case WM_LBUTTONDOWN:
+                case WM_RBUTTONDOWN:
                 {
                     POINT pt;
                     GetCursorPos(&pt);
                     SetForegroundWindow( hWnd );
-                    int m = TrackPopupMenuEx(popupMenu, TPM_RETURNCMD|TPM_LEFTALIGN|TPM_RIGHTBUTTON, 
+                    int m = TrackPopupMenuEx(popupMenu, TPM_RETURNCMD|TPM_LEFTALIGN|TPM_RIGHTBUTTON,
                         pt.x, pt.y, hWnd, NULL);
                     // BUGFIX: See Q135788 (PRB: Menus for Notification Icons Don't Work Correctly)
                     PostMessage(hWnd, NULL, 0, 0);
@@ -411,10 +411,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
             // delete taskbar icon
             NOTIFYICONDATA nid;
-            nid.cbSize=sizeof(NOTIFYICONDATA); 
-            nid.hWnd = hWnd; 
-            nid.uID = IDM_QUICKSTART; 
-            Shell_NotifyIcon(NIM_DELETE, &nid);	
+            nid.cbSize=sizeof(NOTIFYICONDATA);
+            nid.hWnd = hWnd;
+            nid.uID = IDM_QUICKSTART;
+            Shell_NotifyIcon(NIM_DELETE, &nid);
 
 			PostQuitMessage(0);
 			break;
@@ -433,7 +433,7 @@ LRESULT CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM)
 				return TRUE;
 
 		case WM_COMMAND:
-			if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) 
+			if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL)
 			{
 				EndDialog(hDlg, LOWORD(wParam));
 				return TRUE;

--- a/main/extensions/source/activex/main/SOActionsApproval.cpp
+++ b/main/extensions/source/activex/main/SOActionsApproval.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // SOActionsApproval.cpp : Implementation of CHelpApp and DLL registration.
@@ -31,7 +31,7 @@
 
 STDMETHODIMP SOActionsApproval::InterfaceSupportsErrorInfo(REFIID riid)
 {
-	static const IID* arr[] = 
+	static const IID* arr[] =
 	{
 		&IID_ISOActionsApproval,
 	};
@@ -47,4 +47,3 @@ STDMETHODIMP SOActionsApproval::InterfaceSupportsErrorInfo(REFIID riid)
 	}
 	return S_FALSE;
 }
-

--- a/main/extensions/source/activex/main/SOActiveX.cpp
+++ b/main/extensions/source/activex/main/SOActiveX.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // SOActiveX.cpp : Implementation of CSOActiveX
@@ -280,7 +280,7 @@ HRESULT CSOActiveX::TerminateOffice()
 	hr = ExecuteFunc( pdispChildren, L"queryFrames", &nFlag, 1, &aFrames );
     if ( SUCCEEDED( hr ) )
     {
-		if ( ( aFrames.vt == ( VT_ARRAY | VT_DISPATCH ) || aFrames.vt == ( VT_ARRAY | VT_VARIANT ) ) 
+		if ( ( aFrames.vt == ( VT_ARRAY | VT_DISPATCH ) || aFrames.vt == ( VT_ARRAY | VT_VARIANT ) )
           && ( !aFrames.parray || aFrames.parray->cDims == 1 && aFrames.parray->rgsabound[0].cElements == 0 ) )
         {
             // there is no frames open
@@ -289,7 +289,7 @@ HRESULT CSOActiveX::TerminateOffice()
 	        hr = ExecuteFunc( pdispDesktop, L"terminate", NULL, 0, &dummyResult );
         }
     }
-    
+
     return hr;
 }
 
@@ -392,7 +392,7 @@ STDMETHODIMP CSOActiveX::Load( LPPROPERTYBAG pPropBag, LPERRORLOG /*pErrorLog*/ 
 	hr = CBindStatusCallback<CSOActiveX>::Download( this, &CSOActiveX::CallbackCreateXInputStream, mCurFileUrl, m_spClientSite, FALSE );
 	if ( hr == MK_S_ASYNCHRONOUS )
 		hr = S_OK;
-	
+
 	if ( !SUCCEEDED( hr ) )
 	{
 		// trigger initialization without stream
@@ -594,7 +594,7 @@ HRESULT CSOActiveX::CreateFrameOldWay( HWND hwnd, int width, int height )
 		long nInitInd = 0;
 		CComVariant pFrameVariant( mpDispFrame );
 		SafeArrayPutElement( pInitVals, &nInitInd, &pFrameVariant );
-		
+
 		// the second sequence element
 		nInitInd = 1;
 		CComVariant pStrArr( 1L );
@@ -739,7 +739,7 @@ void CSOActiveX::CallbackCreateXInputStream( CBindStatusCallback<CSOActiveX>* /*
 		if( SUCCEEDED( hr ) && mpDispTempFile )
 		{
 			SAFEARRAY FAR* pDataArray = SafeArrayCreateVector( VT_I1, 0, dwSize );
-	
+
 			if ( pDataArray )
 			{
 				hr = SafeArrayLock( pDataArray );
@@ -971,7 +971,7 @@ HRESULT CSOActiveX::OnDrawAdvanced( ATL_DRAWINFO& di )
 	if ( mbDrawLocked )
 		return S_OK;
 	LockingGuard aGuard( mbDrawLocked );
-	
+
     if( m_spInPlaceSite && mCurFileUrl && mbReadyForActivation )
     {
     	HWND hwnd;
@@ -1169,4 +1169,3 @@ HRESULT CSOActiveX::GetURL( const OLECHAR* url,
 
 
 // ---------------------------------------------------------------------------
-

--- a/main/extensions/source/activex/main/SOComWindowPeer.cpp
+++ b/main/extensions/source/activex/main/SOComWindowPeer.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // SOComWindowPeer.cpp : Implementation of CHelpApp and DLL registration.
@@ -30,7 +30,7 @@
 
 STDMETHODIMP SOComWindowPeer::InterfaceSupportsErrorInfo(REFIID riid)
 {
-	static const IID* arr[] = 
+	static const IID* arr[] =
 	{
 		&IID_ISOComWindowPeer,
 	};
@@ -46,4 +46,3 @@ STDMETHODIMP SOComWindowPeer::InterfaceSupportsErrorInfo(REFIID riid)
 	}
 	return S_FALSE;
 }
-

--- a/main/extensions/source/activex/main/SODispatchInterceptor.cpp
+++ b/main/extensions/source/activex/main/SODispatchInterceptor.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // SODispatchInterceptor.cpp : Implementation of CHelpApp and DLL registration.
@@ -33,7 +33,7 @@
 
 STDMETHODIMP SODispatchInterceptor::InterfaceSupportsErrorInfo(REFIID riid)
 {
-    static const IID* arr[] = 
+    static const IID* arr[] =
     {
         &IID_ISODispatchInterceptor,
     };
@@ -91,7 +91,7 @@ STDMETHODIMP SODispatchInterceptor::queryDispatch( IDispatch FAR* aURL,
         aArgs[0] = CComVariant( nSearchFlags );
         aArgs[1] = CComVariant( aTargetFrameName );
         aArgs[2] = CComVariant( aURL );
-        
+
         hr = ExecuteFunc( m_xSlave, L"queryDispatch", aArgs, 3, &aResult );
         if( !SUCCEEDED( hr ) || aResult.vt != VT_DISPATCH || aResult.pdispVal == NULL )
         {
@@ -111,9 +111,9 @@ STDMETHODIMP SODispatchInterceptor::queryDispatch( IDispatch FAR* aURL,
 
 STDMETHODIMP SODispatchInterceptor::queryDispatches( SAFEARRAY FAR* aDescripts, SAFEARRAY FAR* FAR* retVal)
 {
-    if ( !aDescripts || !retVal || SafeArrayGetDim( aDescripts ) != 1 ) 
+    if ( !aDescripts || !retVal || SafeArrayGetDim( aDescripts ) != 1 )
         return E_FAIL;
-    
+
     long nLB, nUB;
 
     HRESULT hr = SafeArrayGetLBound( aDescripts, 1, &nLB );
@@ -148,7 +148,7 @@ STDMETHODIMP SODispatchInterceptor::queryDispatches( SAFEARRAY FAR* aDescripts, 
     return S_OK;
 }
 
-        
+
 STDMETHODIMP SODispatchInterceptor::dispatch( IDispatch FAR* aURL, SAFEARRAY FAR* aArgs)
 {
     // get url from aURL
@@ -205,19 +205,19 @@ STDMETHODIMP SODispatchInterceptor::dispatch( IDispatch FAR* aURL, SAFEARRAY FAR
 
     return S_OK;
 }
-        
+
 STDMETHODIMP SODispatchInterceptor::addStatusListener( IDispatch FAR* /*xControl*/, IDispatch FAR* /*aURL*/)
 {
     // not implemented
     return S_OK;
 }
-       
+
 STDMETHODIMP SODispatchInterceptor::removeStatusListener( IDispatch FAR* /*xControl*/, IDispatch FAR* /*aURL*/)
 {
     // not implemented
     return S_OK;
 }
-       
+
 STDMETHODIMP SODispatchInterceptor::getInterceptedURLs( SAFEARRAY FAR* FAR* pVal )
 {
     *pVal = SafeArrayCreateVector( VT_BSTR, 0, 3 );
@@ -239,5 +239,3 @@ STDMETHODIMP SODispatchInterceptor::getInterceptedURLs( SAFEARRAY FAR* FAR* pVal
 
     return S_OK;
 }
-
-

--- a/main/extensions/source/activex/main/so_activex.cpp
+++ b/main/extensions/source/activex/main/so_activex.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // so_activex.cpp : Implementation of DLL Exports.
 
 
 // Note: Proxy/Stub Information
-//      To build a separate proxy/stub DLL, 
+//      To build a separate proxy/stub DLL,
 //      run nmake -f so_activexps.mk in the project directory.
 
 #include "stdio.h"
@@ -50,7 +50,7 @@ END_OBJECT_MAP()
 #define X32_LIB_NAME "so_activex.dll"
 
 // 06.11.2009 tkr: to provide windows xp as build systems for mingw we need to define KEY_WOW64_64KEY
-// in mingw 3.13 KEY_WOW64_64KEY isn't available < Win2003 systems. 
+// in mingw 3.13 KEY_WOW64_64KEY isn't available < Win2003 systems.
 // Also defined in setup_native\source\win32\customactions\reg64\reg64.cxx,source\win32\customactions\shellextensions\shellextensions.cxx and
 // extensions\source\activex\main\so_activex.cpp
 #ifndef KEY_WOW64_64KEY
@@ -73,7 +73,7 @@ const BOOL bX64 = FALSE;
 
 // 10.11.2009 tkr: MinGW doesn't know anything about RegDeleteKeyExA if WINVER < 0x0502.
 extern "C" {
-WINADVAPI LONG WINAPI RegDeleteKeyExA(HKEY,LPCSTR,REGSAM,DWORD); 
+WINADVAPI LONG WINAPI RegDeleteKeyExA(HKEY,LPCSTR,REGSAM,DWORD);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -122,14 +122,14 @@ const char* aFileExt[] = { ".vor",
 const char* aMimeType[] = {
                           "application/vnd.stardivision.writer",
 
-                          "application/vnd.stardivision.chart", 
+                          "application/vnd.stardivision.chart",
                           "application/vnd.stardivision.draw",
                           "application/vnd.stardivision.impress",
                           "application/vnd.stardivision.impress-packed",
                           "application/vnd.stardivision.calc",
                           "application/vnd.stardivision.writer",
                           "application/vnd.stardivision.math",
-    
+
                           MIMETYPE_VND_SUN_XML_WRITER_TEMPLATE_ASCII,
                           MIMETYPE_VND_SUN_XML_CALC_TEMPLATE_ASCII,
                           MIMETYPE_VND_SUN_XML_IMPRESS_TEMPLATE_ASCII,
@@ -184,27 +184,27 @@ const char* aLocalPrefix = "Software\\Classes\\";
 BOOL createKey( HKEY hkey,
                 const char* aKeyToCreate,
 		REGSAM nKeyAccess,
-                const char* aValue = NULL, 
-                const char* aChildName = NULL, 
+                const char* aValue = NULL,
+                const char* aChildName = NULL,
                 const char* aChildValue = NULL )
 {
     HKEY hkey1;
-    
-    return ( ERROR_SUCCESS == RegCreateKeyExA( hkey, aKeyToCreate, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey1 , NULL ) 
-           && ( !aValue || ERROR_SUCCESS == RegSetValueExA( hkey1, 
-                                                           "", 
-                                                           0, 
-                                                           REG_SZ, 
-                                                           (const BYTE*)aValue, 
+
+    return ( ERROR_SUCCESS == RegCreateKeyExA( hkey, aKeyToCreate, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey1 , NULL )
+           && ( !aValue || ERROR_SUCCESS == RegSetValueExA( hkey1,
+                                                           "",
+                                                           0,
+                                                           REG_SZ,
+                                                           (const BYTE*)aValue,
                                                            strlen( aValue ) ) )
-           && ( !aChildName || ERROR_SUCCESS == RegSetValueExA( hkey1, 
-                                                               aChildName, 
-                                                               0, 
-                                                               REG_SZ, 
-                                                               (const BYTE*)aChildValue, 
+           && ( !aChildName || ERROR_SUCCESS == RegSetValueExA( hkey1,
+                                                               aChildName,
+                                                               0,
+                                                               REG_SZ,
+                                                               (const BYTE*)aChildValue,
                                                                strlen( aChildValue ) ) )
            && ERROR_SUCCESS == RegCloseKey( hkey1 ) );
-    
+
 }
 
 STDAPI DllUnregisterServerNative( int nMode, BOOL bForAllUsers, BOOL bFor64Bit );
@@ -224,7 +224,7 @@ STDAPI DllRegisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAc
     char pActiveXPath[1124];
     char pActiveXPath101[1124];
 
-    
+
     // In case SO7 is installed for this user he can have local registry entries that will prevent him from
     // using SO8 ActiveX control. The fix is just to clean up the local entries related to ActiveX control.
     // Unfortunately it can be done only for the user who installs the office.
@@ -242,7 +242,7 @@ STDAPI DllRegisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAc
 
         {
             wsprintfA( aSubKey, "%sCLSID\\%s", aPrefix, aClassID );
-            aResult = 
+            aResult =
                 ( ERROR_SUCCESS == RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey , NULL )
                     && ERROR_SUCCESS == RegSetValueExA( hkey, "", 0, REG_SZ, (const BYTE*)"SOActiveX Class", 17 )
                     && createKey( hkey, "Control", nKeyAccess )
@@ -311,22 +311,22 @@ STDAPI DllRegisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAc
         {
             wsprintfA( aSubKey, "%sMIME\\DataBase\\Content Type\\%s", aPrefix, aMimeType[ind] );
             if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL )
-//              || ERROR_SUCCESS != RegSetValueExA(hkey, "Extension", 0, REG_SZ, 
+//              || ERROR_SUCCESS != RegSetValueExA(hkey, "Extension", 0, REG_SZ,
 //                 (const BYTE *)aFileExt[ind], strlen( aFileExt[ind] ) )
               || ERROR_SUCCESS != RegSetValueExA(hkey, "CLSID", 0, REG_SZ,
                  (const BYTE *)aClassID, strlen(aClassID)) )
                     aResult = FALSE;
-    
-            if( hkey )    
+
+            if( hkey )
                 RegCloseKey(hkey),hkey= NULL;
 
 /*
             wsprintfA( aSubKey, "%s%s", aPrefix, aFileExt[ind] );
-            if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL ) 
+            if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL )
               || ERROR_SUCCESS != RegSetValueExA(hkey, "Content Type", 0, REG_SZ,
                  (const BYTE *)aMimeType[ind], strlen( aMimeType[ind] ) ) )
                     aResult = FALSE;
-            if( hkey )    
+            if( hkey )
                 RegCloseKey(hkey),hkey= NULL;
 */
         }
@@ -340,7 +340,7 @@ STDAPI DllRegisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAc
                wsprintfA( aSubKey, "EnableFullPage\\%s", aFileExt[ind] );
                if ( ERROR_SUCCESS != RegCreateKeyExA( hkey, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey1 , NULL ) )
                    aResult = FALSE;
-    
+
             if ( hkey1 )
                    RegCloseKey(hkey1),hkey1= NULL;
          }
@@ -395,7 +395,7 @@ STDAPI DllUnregisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKey
     BOOL        fErr = FALSE;
     char aSubKey[513];
     const char*    aPrefix = aLocalPrefix; // bForAllUsers ? "" : aLocalPrefix;
-    
+
     for( int ind = 0; ind < SUPPORTED_EXT_NUM; ind++ )
     {
         if( nForModes[ind] & nMode )
@@ -408,7 +408,7 @@ STDAPI DllUnregisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKey
             {
                 if ( ERROR_SUCCESS != RegDeleteValue( hkey, "CLSID" ) )
                     fErr = TRUE;
-    
+
                 if ( ERROR_SUCCESS != RegQueryInfoKey(  hkey, NULL, NULL, NULL,
                                                     &nSubKeys, NULL, NULL,
                                                     &nValues, NULL, NULL, NULL, NULL ) )
@@ -416,14 +416,14 @@ STDAPI DllUnregisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKey
                     RegCloseKey( hkey ), hkey = NULL;
                     fErr = TRUE;
                 }
-                else 
+                else
                 {
                     RegCloseKey( hkey ), hkey = NULL;
                     if ( !nSubKeys && !nValues )
                         DeleteKeyTree( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, nKeyAccess );
                 }
             }
-    
+
                wsprintfA( aSubKey, "%s%s", aPrefix, aFileExt[ind] );
                if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL ) )
                 fErr = TRUE;
@@ -436,7 +436,7 @@ STDAPI DllUnregisterServerNative_Impl( int nMode, BOOL bForAllUsers, REGSAM nKey
                     RegCloseKey( hkey ), hkey = NULL;
                     fErr = TRUE;
                 }
-                else 
+                else
                 {
                     RegCloseKey( hkey ), hkey = NULL;
                     if ( !nSubKeys && !nValues )
@@ -492,12 +492,12 @@ STDAPI DllUnregisterServerNative( int nMode, BOOL bForAllUsers, BOOL bFor64Bit )
 
 #define SUPPORTED_MSEXT_NUM 7
 const char* aMSFileExt[] = { ".dot", ".doc", ".xlt", ".xls", ".pot", ".ppt", ".pps" };
-const char* aMSMimeType[] = { "application/msword", 
-                          "application/msword", 
-                          "application/msexcell", 
-                          "application/msexcell", 
-                          "application/mspowerpoint", 
-                          "application/mspowerpoint", 
+const char* aMSMimeType[] = { "application/msword",
+                          "application/msword",
+                          "application/msexcell",
+                          "application/msexcell",
+                          "application/mspowerpoint",
+                          "application/mspowerpoint",
                           "application/mspowerpoint" };
 const int nForMSModes[] = { 1, 1, 2, 2, 4, 4, 4 };
 
@@ -524,22 +524,22 @@ STDAPI DllRegisterServerDoc_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAcces
         {
                wsprintfA( aSubKey, "%sMIME\\DataBase\\Content Type\\%s", aPrefix, aMSMimeType[ind] );
                if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL )
-               || ERROR_SUCCESS != RegSetValueExA(hkey, "Extension", 0, REG_SZ, 
+               || ERROR_SUCCESS != RegSetValueExA(hkey, "Extension", 0, REG_SZ,
                    (const BYTE *)aMSFileExt[ind], strlen( aMSFileExt[ind] ) )
                || ERROR_SUCCESS != RegSetValueExA(hkey, "CLSID", 0, REG_SZ,
                    (const BYTE *)aClassID, strlen(aClassID)) )
                        aResult = FALSE;
-    
-               if( hkey )    
+
+               if( hkey )
                    RegCloseKey(hkey),hkey= NULL;
-    
+
                wsprintfA( aSubKey, "%s%s", aPrefix, aMSFileExt[ind] );
-               if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL ) 
+               if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL )
                || ERROR_SUCCESS != RegSetValueExA(hkey, "Content Type", 0, REG_SZ,
                    (const BYTE *)aMSMimeType[ind], strlen( aMSMimeType[ind] ) ) )
                        aResult = FALSE;
-    
-               if( hkey )    
+
+               if( hkey )
                    RegCloseKey(hkey),hkey= NULL;
         }
     }
@@ -592,13 +592,13 @@ STDAPI DllUnregisterServerDoc_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAcc
     BOOL        fErr = FALSE;
     char aSubKey[513];
     const char*    aPrefix = aLocalPrefix; // bForAllUsers ? "" : aLocalPrefix;
-    
+
       for( int ind = 0; ind < SUPPORTED_MSEXT_NUM; ind++ )
        {
         if( nForMSModes[ind] & nMode )
         {
             DWORD nSubKeys = 0, nValues = 0;
-        
+
                wsprintfA( aSubKey, "%sMIME\\DataBase\\Content Type\\%s", aPrefix, aMSMimeType[ind] );
                if ( ERROR_SUCCESS != RegCreateKeyExA( bForAllUsers ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, aSubKey, 0, NULL, REG_OPTION_NON_VOLATILE, nKeyAccess, NULL, &hkey, NULL ) )
                 fErr = TRUE;
@@ -617,7 +617,7 @@ STDAPI DllUnregisterServerDoc_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAcc
                     RegCloseKey( hkey ), hkey = NULL;
                     fErr = TRUE;
                 }
-                else 
+                else
                 {
                     RegCloseKey( hkey ), hkey = NULL;
                     if ( !nSubKeys && !nValues )
@@ -640,7 +640,7 @@ STDAPI DllUnregisterServerDoc_Impl( int nMode, BOOL bForAllUsers, REGSAM nKeyAcc
                     RegCloseKey( hkey ), hkey = NULL;
                     fErr = TRUE;
                 }
-                else 
+                else
                 {
                     RegCloseKey( hkey ), hkey = NULL;
                     if ( !nSubKeys && !nValues )
@@ -708,4 +708,3 @@ STDAPI DllUnregisterServer( void )
     DllUnregisterServerDoc( 63, TRUE, bX64 );
     return DllUnregisterServerNative( 63, TRUE, bX64 );
 }
-

--- a/main/extensions/test/ole/AxTestComponents/AxTestComponents.cpp
+++ b/main/extensions/test/ole/AxTestComponents/AxTestComponents.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
 
 
 // Note: Proxy/Stub Information
-//      To build a separate proxy/stub DLL, 
+//      To build a separate proxy/stub DLL,
 //      run nmake -f AxTestComponentsps.mk in the project directory.
 
 #include "stdafx.h"
@@ -93,4 +93,4 @@ STDAPI DllUnregisterServer(void)
 }
 
 
-//VT_I4 size_t V_ERROR VARIANT VARIANT_FALSE CComVariant FADF_EMBEDDED    
+//VT_I4 size_t V_ERROR VARIANT VARIANT_FALSE CComVariant FADF_EMBEDDED

--- a/main/extensions/test/ole/AxTestComponents/Basic.cpp
+++ b/main/extensions/test/ole/AxTestComponents/Basic.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,7 +28,7 @@
 
 /////////////////////////////////////////////////////////////////////////////
 // CBasic
-CBasic::CBasic():	m_cPrpByte(0),m_nPrpShort(0),m_lPrpLong(0),m_fPrpFloat(0), m_dPrpDouble(0),m_PrpArray(0), 
+CBasic::CBasic():	m_cPrpByte(0),m_nPrpShort(0),m_lPrpLong(0),m_fPrpFloat(0), m_dPrpDouble(0),m_PrpArray(0),
 m_safearray(NULL), m_bool(VARIANT_FALSE),
 m_arByte(0), m_arShort(0), m_arLong(0), m_arString(0), m_arVariant(0), m_arFloat(0),
 m_arDouble(0), m_arObject(0), m_arByteDim2(0), m_date(0.), m_scode(0)
@@ -99,7 +99,7 @@ STDMETHODIMP CBasic::inDouble(double val)
 
 STDMETHODIMP CBasic::inVariant(VARIANT val)
 {
-	m_var1 = val;	
+	m_var1 = val;
 	return S_OK;
 }
 
@@ -206,7 +206,7 @@ STDMETHODIMP CBasic::inoutArray(LPSAFEARRAY *val)
 
 STDMETHODIMP CBasic::inoutObject(IDispatch **val)
 {
-	CComPtr<IDispatch> disp = *val;	
+	CComPtr<IDispatch> disp = *val;
 	if (*val)
 		(*val)->Release();
 	*val = m_obj;
@@ -280,7 +280,7 @@ STDMETHODIMP CBasic::outObject(IDispatch* *val)
 	*val = m_obj;
 	if (m_obj)
 		(*val)->AddRef();
-	
+
 	return S_OK;
 }
 
@@ -435,7 +435,7 @@ STDMETHODIMP CBasic::put_prpObject(IDispatch *newVal)
 	return S_OK;
 }
 
-STDMETHODIMP CBasic::mixed1( 
+STDMETHODIMP CBasic::mixed1(
             /* [out][in] */ unsigned char *aChar,
 			/* [out][in] */ float *aFloat,
             /* [out][in] */ VARIANT *aVar)
@@ -533,13 +533,13 @@ void CBasic::printArray( LPSAFEARRAY val, BSTR message, VARTYPE type)
 	hr= SafeArrayGetLBound( val, 1, &lbound);
 	hr= SafeArrayGetUBound( val, 1, &ubound);
 	long length= ubound - lbound +1;
-	
+
 	CComVariant varElement;
 	char buf[1024];
 	sprintf( buf,"%s", W2A(message));
 
 	for( long i= 0; i < length ; i++)
-	{	
+	{
 		char tmp[1024];
 		long data=0;
 		CComVariant var;
@@ -569,7 +569,7 @@ void CBasic::printArray( LPSAFEARRAY val, BSTR message, VARTYPE type)
 			sprintf( tmp, "%f \n", *(double*) &data);
 			break;
 		case VT_DISPATCH:
-			// we assume the objects are instances of this component and have the 
+			// we assume the objects are instances of this component and have the
 			// property prpString set.
 			hr= SafeArrayGetElement( val, &i, (void*)&data);
 			IDispatch* pdisp= ( IDispatch*) data;
@@ -586,8 +586,8 @@ void CBasic::printArray( LPSAFEARRAY val, BSTR message, VARTYPE type)
 
 		strcat( buf, tmp);
 	}
-	MessageBox( NULL, _T(A2T(buf)), _T("AxTestComponents.Basic"), MB_OK);	
-	
+	MessageBox( NULL, _T(A2T(buf)), _T("AxTestComponents.Basic"), MB_OK);
+
 }
 // V_ERROR OLECHAR VARIANT VT_UI1
 
@@ -761,7 +761,7 @@ STDMETHODIMP CBasic::inMulDimArrayByte(LPSAFEARRAY val)
 // 3-dimensionales array
 STDMETHODIMP CBasic::inMulDimArrayByte2(LPSAFEARRAY val)
 {
-	
+
 	// TODO: Add your implementation code here
 	//printMulArray( val, VT_UI1);
 	return S_OK;
@@ -825,7 +825,7 @@ void CBasic::printMulArray( SAFEARRAY* val, VARTYPE type)
 
 		}
 
-		
+
 	}
 	else if( dims == 3 )
 	{
@@ -917,12 +917,12 @@ STDMETHODIMP CBasic::optional3(/*[in, optional]*/ VARIANT* val1,/*[in, optional]
 {
 	//if (val1->vt != VT_ERROR)
 		m_var1 = *val1;
-		
+
 	//if (val2->vt != VT_ERROR)
 		m_var2 = *val2;
 	return S_OK;
 }
-	
+
 STDMETHODIMP CBasic::optional4(/*[in, out, optional]*/ VARIANT* val1,
 							   /*[in, out, optional]*/ VARIANT* val2)
 {
@@ -1002,7 +1002,7 @@ STDMETHODIMP CBasic::varargfunc1(/*[in]*/ long val1,/*[in]*/ LPSAFEARRAY val2)
 	if (FAILED(hr = SafeArrayCopy(val2, & m_safearray)))
 	{
 		if (hr != E_INVALIDARG)
-			return hr;	
+			return hr;
 	}
 	return S_OK;
 }
@@ -1183,7 +1183,7 @@ STDMETHODIMP CBasic::get_prpRefLong(long* pVal)
 
 STDMETHODIMP CBasic::putref_prpRefLong(long* newVal)
 {
-	m_long = * newVal;	
+	m_long = * newVal;
 	return S_OK;
 }
 
@@ -1238,7 +1238,7 @@ STDMETHODIMP CBasic::optional7(VARIANT* val1, VARIANT* val2, VARIANT* val3, VARI
 		return hr;
 	if (FAILED(hr = VariantCopy(val4, & m_var4)))
 		return hr;
-	
+
 	return S_OK;
 }
 

--- a/main/extensions/test/ole/AxTestComponents/Foo.cpp
+++ b/main/extensions/test/ole/AxTestComponents/Foo.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/extensions/test/ole/EventListenerSample/EventListener/EventListener.cpp
+++ b/main/extensions/test/ole/EventListenerSample/EventListener/EventListener.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // EventListener.cpp : Implementation of DLL Exports.
 
 
 // Note: Proxy/Stub Information
-//      To build a separate proxy/stub DLL, 
+//      To build a separate proxy/stub DLL,
 //      run nmake -f EventListenerps.mk in the project directory.
 
 #include "stdafx.h"
@@ -89,5 +89,3 @@ STDAPI DllUnregisterServer(void)
 {
     return _Module.UnregisterServer(TRUE);
 }
-
-

--- a/main/extensions/test/ole/EventListenerSample/EventListener/EvtListener.cpp
+++ b/main/extensions/test/ole/EventListenerSample/EventListener/EvtListener.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // EvtListener.cpp : Implementierung von CEvtListener

--- a/main/extensions/test/ole/MfcControl/MfcControl.cpp
+++ b/main/extensions/test/ole/MfcControl/MfcControl.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // MfcControl.cpp : Implementation of CMfcControlApp and DLL registration.

--- a/main/extensions/test/ole/MfcControl/MfcControlCtl.cpp
+++ b/main/extensions/test/ole/MfcControl/MfcControlCtl.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // MfcControlCtl.cpp : Implementation of the CMfcControlCtrl ActiveX Control class.
@@ -216,7 +216,7 @@ void CMfcControlCtrl::OnResetState()
 // CMfcControlCtrl message handlers
 
 
-short CMfcControlCtrl::inShort(short val) 
+short CMfcControlCtrl::inShort(short val)
 {
 	char buf[256];
 	sprintf( buf, "inByte: value= %d", val);
@@ -224,7 +224,7 @@ short CMfcControlCtrl::inShort(short val)
 	return val+1;
 }
 
-long CMfcControlCtrl::inLong(long val) 
+long CMfcControlCtrl::inLong(long val)
 {
 	char buf[256];
 	sprintf( buf, "inLong: value= %d", val);
@@ -232,7 +232,7 @@ long CMfcControlCtrl::inLong(long val)
 	return val+1;
 }
 
-BSTR CMfcControlCtrl::inString(BSTR* val) 
+BSTR CMfcControlCtrl::inString(BSTR* val)
 {
 	CString strResult;
 	strResult= *val;
@@ -243,7 +243,7 @@ BSTR CMfcControlCtrl::inString(BSTR* val)
 	return strResult.AllocSysString();
 }
 
-float CMfcControlCtrl::inFloat(float val) 
+float CMfcControlCtrl::inFloat(float val)
 {
 	char buf[256];
 	sprintf( buf, "inFloat: value= %f", val);
@@ -251,7 +251,7 @@ float CMfcControlCtrl::inFloat(float val)
 	return val+1;
 }
 
-double CMfcControlCtrl::inDouble(double val) 
+double CMfcControlCtrl::inDouble(double val)
 {
 	char buf[256];
 	sprintf( buf, "inDouble: value= %g", val);
@@ -259,7 +259,7 @@ double CMfcControlCtrl::inDouble(double val)
 	return val+1;
 }
 
-VARIANT CMfcControlCtrl::inVariant(const VARIANT FAR& val) 
+VARIANT CMfcControlCtrl::inVariant(const VARIANT FAR& val)
 {
 	VARIANT vaResult;
 	VariantInit(&vaResult);
@@ -274,7 +274,7 @@ VARIANT CMfcControlCtrl::inVariant(const VARIANT FAR& val)
 	return _variant_t( L" a string from CMfcControlCtrl::inVariant");
 }
 
-LPDISPATCH CMfcControlCtrl::inObject(LPDISPATCH val) 
+LPDISPATCH CMfcControlCtrl::inObject(LPDISPATCH val)
 {
 	char buf[256];
 	_bstr_t bstr;
@@ -298,44 +298,44 @@ LPDISPATCH CMfcControlCtrl::inObject(LPDISPATCH val)
 }
 
 
-void CMfcControlCtrl::outShort(short* val) 
+void CMfcControlCtrl::outShort(short* val)
 {
 	*val= 123;
 }
 
-void CMfcControlCtrl::outLong(long* val) 
+void CMfcControlCtrl::outLong(long* val)
 {
 	*val= 1234;
 }
 
-void CMfcControlCtrl::outString(BSTR FAR* val) 
+void CMfcControlCtrl::outString(BSTR FAR* val)
 {
-	*val= SysAllocString(L"A string from CMfcControlCtrl::outString ");             
+	*val= SysAllocString(L"A string from CMfcControlCtrl::outString ");
 }
 
-void CMfcControlCtrl::outFloat(float* val) 
+void CMfcControlCtrl::outFloat(float* val)
 {
 	*val= 3.14f;
 }
 
-void CMfcControlCtrl::outDouble(double* val) 
+void CMfcControlCtrl::outDouble(double* val)
 {
 	*val= 3.145;
 }
 
-void CMfcControlCtrl::outVariant(VARIANT FAR* val) 
+void CMfcControlCtrl::outVariant(VARIANT FAR* val)
 {
 	VariantInit( val);
 	val->vt= VT_BSTR;
 	val->bstrVal= SysAllocString( L"a string in a VARIANT");
 }
 
-void CMfcControlCtrl::outObject(LPDISPATCH FAR* val) 
+void CMfcControlCtrl::outObject(LPDISPATCH FAR* val)
 {
 	//{BFE10EBE-8584-11D4-005004526AB4}
 	HRESULT hr= S_OK;
 	CLSID clsTestControl;
-	hr= CLSIDFromProgID( L"AxTestComponents.Basic", &clsTestControl); 
+	hr= CLSIDFromProgID( L"AxTestComponents.Basic", &clsTestControl);
 
 	IDispatch* pDisp= NULL;
 	hr=	CoCreateInstance( clsTestControl, NULL, CLSCTX_ALL, __uuidof(IDispatch), (void**)&pDisp);

--- a/main/extensions/test/ole/MfcControl/MfcControlPpg.cpp
+++ b/main/extensions/test/ole/MfcControl/MfcControlPpg.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // MfcControlPpg.cpp : Implementation of the CMfcControlPropPage property page class.

--- a/main/extensions/test/ole/MfcControl/StdAfx.cpp
+++ b/main/extensions/test/ole/MfcControl/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // stdafx.cpp : source file that includes just the standard includes

--- a/main/extensions/test/ole/unoTocomCalls/Test/StdAfx.cpp
+++ b/main/extensions/test/ole/unoTocomCalls/Test/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,4 +28,3 @@
 
 // TODO: reference any additional headers you need in STDAFX.H
 // and not in this file
-

--- a/main/extensions/test/ole/unoTocomCalls/Test/Test.cpp
+++ b/main/extensions/test/ole/unoTocomCalls/Test/Test.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 		return -1;
 	}
 
-	
+
 	_Module.Init( ObjectMap, GetModuleHandle( NULL));
 
 	if( FAILED(hr=doTest()))
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
 	_Module.Term();
 	CoUninitialize();
 
-	
+
 	return 0;
 }
 
@@ -144,11 +144,11 @@ HRESULT doTest()
 	hr= oletest.Invoke2(L"testInterface", &param1, &param2);
 
 	// XCallback::outSeqByte
-	// Does not work currently because Sequences are always converted to 
+	// Does not work currently because Sequences are always converted to
 	// SAFEARRAY( VARIANT)
 	//	param2= 32;
 	//	hr= oletest.Invoke2(L"testInterface", &param1, &param2);
-	
+
 	//######################################################################
 	//	in / out parameters
 	//######################################################################
@@ -239,4 +239,3 @@ HRESULT doTest()
 	return hr;
 }
 // VARIANT CComVariant VT_UNKNOWN VT_DISPATCH V_UI1 CComDispatchDriver WINAPI
- 

--- a/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/Callback.cpp
+++ b/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/Callback.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -38,7 +38,7 @@ STDMETHODIMP CCallback::func1()
 STDMETHODIMP CCallback::returnInterface(IDispatch **ppdisp)
 {
 	if( ! ppdisp)
-		return E_POINTER;	
+		return E_POINTER;
 	CComPtr<IDispatch> spDisp;
 	spDisp.CoCreateInstance( L"XCallback_Impl.Simple");
 	*ppdisp= spDisp;
@@ -50,7 +50,7 @@ STDMETHODIMP CCallback::outInterface(IDispatch **ppdisp)
 {
 //	return S_OK;
 	if( ! ppdisp)
-		return E_POINTER;	
+		return E_POINTER;
 	CComPtr<IDispatch> spDisp;
 	spDisp.CoCreateInstance( L"XCallback_Impl.Simple");
 	*ppdisp= spDisp;
@@ -71,7 +71,7 @@ STDMETHODIMP CCallback::outValuesMixed(long val, long *pval, BSTR string)
 }
 
 
-STDMETHODIMP CCallback::outValuesAll( 
+STDMETHODIMP CCallback::outValuesAll(
             /* [out] */ IDispatch __RPC_FAR *__RPC_FAR *ppdisp,
             /* [out] */ IDispatch __RPC_FAR *__RPC_FAR *ppSimpleStruct,
             /* [out] */ long __RPC_FAR *aSimpleEnum,
@@ -112,7 +112,7 @@ STDMETHODIMP CCallback::outValuesAll(
 
 STDMETHODIMP CCallback::outStruct(IDispatch **outStruct)
 {
-//	return S_OK;	
+//	return S_OK;
 	if( !outStruct)
 		return E_POINTER;
 	HRESULT hr= E_FAIL;
@@ -125,14 +125,14 @@ STDMETHODIMP CCallback::outStruct(IDispatch **outStruct)
 		CComVariant param1(L"com.sun.star.reflection.CoreReflection");
 		CComVariant varRet;
 		hr= manager.Invoke1( L"createInstance", &param1, &varRet);
-		
+
 		CComDispatchDriver reflection( varRet.pdispVal);
 		param1= L"oletest.SimpleStruct";
 		varRet.Clear();
 		hr= reflection.Invoke1( L"forName", &param1, &varRet);
 
 		CComDispatchDriver classSimpleStruct( varRet.pdispVal);
-		
+
 		CComPtr<IDispatch> dispStruct;
 		param1.vt= VT_DISPATCH | VT_BYREF;
 		param1.ppdispVal= &dispStruct;
@@ -167,7 +167,7 @@ STDMETHODIMP CCallback::outSeqAny(LPSAFEARRAY* outSeq)
 	var[1]=L" variant 1";
 	var[2]=L"variant 2";
 	for( long i=0; i<3; i++)
-	{	
+	{
 		SafeArrayPutElement( pArr, &i, (void*)&var[i]);
 	}
 
@@ -327,7 +327,7 @@ STDMETHODIMP CCallback::inoutSeqAny(LPSAFEARRAY *pArray)
 		var.Clear();
 		hr= SafeArrayGetElement( *pArray, &i, (void*)&var);
 	}
-	
+
 	SafeArrayDestroy( *pArray);
 
 	outSeqAny( pArray);
@@ -363,7 +363,7 @@ STDMETHODIMP CCallback::inoutChar(short *inoutVal)
 		return E_POINTER;
 	USES_CONVERSION;
 	char buff[256];
-	sprintf( buff, "character value: %C", *inoutVal); 
+	sprintf( buff, "character value: %C", *inoutVal);
 	MessageBox( NULL, A2T(buff), _T("XCallback_Impl.Callback"), MB_OK);
 	*inoutVal= L'B';
 	return S_OK;
@@ -421,7 +421,7 @@ STDMETHODIMP CCallback::inoutLong(long* inoutVal)
 	return S_OK;
 }
 
-STDMETHODIMP CCallback::inoutValuesAll( 
+STDMETHODIMP CCallback::inoutValuesAll(
             /* [out][in] */ IDispatch __RPC_FAR *__RPC_FAR *aXSimple,
             /* [out][in] */ IDispatch __RPC_FAR *__RPC_FAR *aStruct,
             /* [out][in] */ long __RPC_FAR *aEnum,
@@ -452,7 +452,7 @@ STDMETHODIMP CCallback::inoutValuesAll(
 
 	return S_OK;
 }
- 
+
 
 STDMETHODIMP CCallback::inValues(short aChar, long aLong, BSTR aString)
 {
@@ -499,10 +499,8 @@ STDMETHODIMP CCallback::inSeqXEventListener( LPSAFEARRAY listeners, LPSAFEARRAY 
 			CComDispatchDriver disp( varListener.pdispVal);
 			hr= disp.Invoke1(L"disposing", &varEvent);
 		}
-		
+
 	}
 
 	return S_OK;
 }
-
-

--- a/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/Simple.cpp
+++ b/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/Simple.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -73,4 +73,3 @@ STDMETHODIMP CSimple::get__implementedInterfaces(LPSAFEARRAY *pVal)
 	*pVal= pArr;
 	return S_OK;
 }
-

--- a/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/XCallback_Impl.cpp
+++ b/main/extensions/test/ole/unoTocomCalls/XCallback_Impl/XCallback_Impl.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -24,7 +24,7 @@
 
 
 // Note: Proxy/Stub Information
-//      To build a separate proxy/stub DLL, 
+//      To build a separate proxy/stub DLL,
 //      run nmake -f XCallback_Implps.mk in the project directory.
 
 #include "stdafx.h"
@@ -92,6 +92,3 @@ STDAPI DllUnregisterServer(void)
 {
     return _Module.UnregisterServer(TRUE);
 }
-
-
-

--- a/main/icc/source/create_sRGB_profile/create_sRGB_profile.cpp
+++ b/main/icc/source/create_sRGB_profile/create_sRGB_profile.cpp
@@ -2,10 +2,10 @@
  *
  *  Apache OpenOffice - a multi-platform office productivity suite
  *
-  
+
   Derived by beppec56@openoffice.org from various examples
   in SampleICC library, the original copyright retained.
- 
+
   Copyright:  © see below
 */
 
@@ -13,7 +13,7 @@
  * The ICC Software License, Version 0.1
  *
  *
- * Copyright (c) 2003-2006 The International Color Consortium. All rights 
+ * Copyright (c) 2003-2006 The International Color Consortium. All rights
  * reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -21,7 +21,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -29,7 +29,7 @@
  *    distribution.
  *
  * 3. The end-user documentation included with the redistribution,
- *    if any, must include the following acknowledgment:  
+ *    if any, must include the following acknowledgment:
  *       "This product includes software developed by the
  *        The International Color Consortium (www.color.org)"
  *    Alternately, this acknowledgment may appear in the software itself,
@@ -57,17 +57,17 @@
  * ====================================================================
  *
  * This software consists of voluntary contributions made by many
- * individuals on behalf of the The International Color Consortium. 
+ * individuals on behalf of the The International Color Consortium.
  *
  *
  * Membership in the ICC is encouraged when this software is used for
- * commercial purposes. 
+ * commercial purposes.
  *
- *  
+ *
  * For more information on The International Color Consortium, please
  * see <http://www.color.org/>.
- *  
- * 
+ *
+ *
  */
 
 #include <math.h>
@@ -186,9 +186,9 @@ void dumpTag(FILE *outfile, CIccProfile *pIcc, icTagSignature sig)
 
     if (pTag)
     {
-        fprintf(outfile, "\nContents of %s tag (%s)\n", Fmt.GetTagSigName(sig), icGetSig(buf, sig)); 
+        fprintf(outfile, "\nContents of %s tag (%s)\n", Fmt.GetTagSigName(sig), icGetSig(buf, sig));
         fprintf(outfile,"Type:   ");
-        
+
         if (pTag->IsArrayType())  fprintf(outfile, "Array of ");
 
         fprintf(outfile, "%s\n", Fmt.GetTagTypeSigName(pTag->GetType()));
@@ -253,7 +253,7 @@ void dumpProfile(FILE *outfile, const char * profileName)
         for (n=0, i=pIcc->m_Tags->begin(); i!=pIcc->m_Tags->end(); i++, n++)
         {
             fprintf(outfile,"%25s  %s  %8ld\t%8ld\n", Fmt.GetTagSigName(i->TagInfo.sig),
-                    icGetSig(buf, i->TagInfo.sig, false), 
+                    icGetSig(buf, i->TagInfo.sig, false),
                     i->TagInfo.offset, i->TagInfo.size);
         }
 
@@ -295,7 +295,7 @@ int main(int argc, char* argv[])
 
         // Required tags for a three-component matrix-based display profile, as laid
         // out by specification ICC.1:1998-09 (clause 6.3)  are:
-        //   
+        //
         //   copyrightTag
         //   profileDescriptionTag
         //   redMatrixColumnTag
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
         // viewingConditionsTag
         // luminanceTag
         // measurementTag
-        // 
+        //
         // are optionals, added for completeness
 
         // the element below are sorted in the same order as
@@ -365,7 +365,7 @@ int main(int argc, char* argv[])
         (*whitePointTag)[0].X = icDtoF(0.9505);
         (*whitePointTag)[0].Y = icDtoF(1.0);
         (*whitePointTag)[0].Z = icDtoF(1.0891);
-        profile.AttachTag(icSigMediaWhitePointTag, whitePointTag);        
+        profile.AttachTag(icSigMediaWhitePointTag, whitePointTag);
 
         //device signature (technologytag)
         CIccTagSignature* deviceSign = new CIccTagSignature;
@@ -396,11 +396,11 @@ int main(int argc, char* argv[])
 
         // viewingConditionsTag
         CIccTagViewingConditions* viewingConditionsTag = new  CIccTagViewingConditions;
-        // Illuminant tristimulus value        
+        // Illuminant tristimulus value
         (*viewingConditionsTag).m_XYZIllum.X = icDtoF(19.6445);
         (*viewingConditionsTag).m_XYZIllum.Y = icDtoF(20.3718);
         (*viewingConditionsTag).m_XYZIllum.Z = icDtoF(16.8089);
-        // surround tristimulus value        
+        // surround tristimulus value
         (*viewingConditionsTag).m_XYZSurround.X = icDtoF(3.9289);
         (*viewingConditionsTag).m_XYZSurround.Y = icDtoF(4.0744);
         (*viewingConditionsTag).m_XYZSurround.Z = icDtoF(3.3618);
@@ -430,10 +430,10 @@ int main(int argc, char* argv[])
 
         // compute the LUT curves, they are equal for all three colors
         // so only one LUT is computed and stored
-        int N = 1024; // number of points in LUTs            
+        int N = 1024; // number of points in LUTs
         CIccTagCurve* colorTRCTag = new CIccTagCurve(N);
         // apply conversion from RGB to XYZ, stepping the RGB value linearly from 0 to 100%
-        // 1024 steps are computed            
+        // 1024 steps are computed
         for (int i = 0; i < N; ++i)
             (*colorTRCTag)[i] = computeIEC_RGBtoXYZ( (icFloatNumber)i/(N-1));
 
@@ -449,17 +449,17 @@ int main(int argc, char* argv[])
         {
         case icValidateOK:
             break;
-      
+
         case icValidateWarning:
             clog << "Profile validation warning" << endl
                  << validationReport;
             break;
-      
+
         case icValidateNonCompliant:
             clog << "Profile non compliancy" << endl
                  << validationReport;
             break;
-      
+
         case icValidateCriticalError:
         default:
             clog << "Profile Error" << endl
@@ -493,7 +493,7 @@ int main(int argc, char* argv[])
             fprintf(headerfile,"%s\n",the_string);
 
         {
-// spit out the data structure (an array of unsigned char)            
+// spit out the data structure (an array of unsigned char)
             FILE *infile;
 
             int achar, number = 1;
@@ -520,7 +520,7 @@ int main(int argc, char* argv[])
             } while(achar != EOF );
             fprintf(headerfile,"\n};\n\n");
 
-            fclose(infile);      
+            fclose(infile);
         }
         // append the file contents, in human readable form, as comment in the header
         // get the functions from iccDump
@@ -532,7 +532,7 @@ int main(int argc, char* argv[])
         dumpProfile(headerfile, out_file_pathname );
 
         fprintf(headerfile,"\n*****************/\n");
-        //now append the tail      
+        //now append the tail
         idx = 0;
         while((the_string = TheTail[idx++]) != NULL )
             fprintf(headerfile,"%s\n",the_string);

--- a/main/migrationanalysis/src/msokill/StdAfx.cpp
+++ b/main/migrationanalysis/src/msokill/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/migrationanalysis/src/msokill/msokill.cpp
+++ b/main/migrationanalysis/src/msokill/msokill.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -130,12 +130,12 @@ BOOL KillAppFromWindow(
 		printf("App %s: window not found.\n,", appName);
 #endif
 		bRet = FALSE;
-	} else {		
+	} else {
 		DWORD pid;  // Variable to hold the process ID.
 		DWORD dThread;  // Variable to hold (unused) thread ID.
 		dThread = GetWindowThreadProcessId(hWnd, &pid);
 		HANDLE hProcess; // Handle to existing process
-		
+
 		hProcess = OpenProcess(SYNCHRONIZE | PROCESS_ALL_ACCESS, TRUE, pid);
 		if (hProcess == NULL) {
 #ifdef _DEBUG
@@ -145,7 +145,7 @@ BOOL KillAppFromWindow(
 		} else {
 			if (!TerminateProcess(hProcess, 0)) {
 				LPTSTR lpMsgBuf;
-				FormatMessage( 
+				FormatMessage(
 					FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 					NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 					(LPTSTR) &lpMsgBuf, 0, NULL );
@@ -180,19 +180,19 @@ BOOL CloseActiveDialogs() {
 }
 
 /*--------------------------------------------------------------
-  Callback for EnumChildWindows that sends close message to 
+  Callback for EnumChildWindows that sends close message to
   any dialogs that match window class of MSO dialogs
 
   --------------------------------------------------------------*/
-BOOL CALLBACK CloseOfficeDlgProc(HWND hwndChild, LPARAM) 
-{ 
+BOOL CALLBACK CloseOfficeDlgProc(HWND hwndChild, LPARAM)
+{
 	//bosa_sdm_Microsoft Word 9.0
 	//bosa_sdm_XL9
 	//#32770 (Dialog)
 
  	char szBuff[4096];
 	if (GetClassName(hwndChild, szBuff, 4096) == 0) {
-		
+
 	} else {
 		if ((strcmpi(szBuff, pWordDlg2k) == 0) || (strcmpi(szBuff, pWordDlg2k3) == 0)) {
 			gWDDlgCount++;
@@ -210,21 +210,21 @@ BOOL CALLBACK CloseOfficeDlgProc(HWND hwndChild, LPARAM)
 			SendMessage(hwndChild, WM_CLOSE, 0, 0);
 		}
 	}
- 
-    return TRUE; 
-} 
+
+    return TRUE;
+}
 
 
 /*--------------------------------------------------------------
-  Callback for EnumChildWindows that counts numnnber of  
+  Callback for EnumChildWindows that counts numnnber of
   dialogs that match window class of MSO dialogs
 
   --------------------------------------------------------------*/
-BOOL CALLBACK CountOfficeDlgProc(HWND hwndChild, LPARAM) 
+BOOL CALLBACK CountOfficeDlgProc(HWND hwndChild, LPARAM)
 {
  	char szBuff[4096];
 	if (GetClassName(hwndChild, szBuff, 4096) == 0) {
-		
+
 	} else {
 		if ((strcmpi(szBuff, pWordDlg2k) == 0) || (strcmpi(szBuff, pWordDlg2k3) == 0)) {
 			gWDDlgCount++;
@@ -237,12 +237,12 @@ BOOL CALLBACK CountOfficeDlgProc(HWND hwndChild, LPARAM)
 		}
 	}
 
-	return TRUE; 
-} 
+	return TRUE;
+}
 
 /*--------------------------------------------------------------
   Simple usage message...
- 
+
   -------------------------------------------------------------*/
 void printUsage() {
 	printf("Recovery Assistant Utility - try and put MSO apps in a recoverable state\n");

--- a/main/odk/examples/OLE/activex/SOActiveX.cpp
+++ b/main/odk/examples/OLE/activex/SOActiveX.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -33,14 +33,14 @@
 #define BARS_NUMBER  3
 #define BARS_TO_SHOW 2
 
-OLECHAR* pSlotUrl[BARS_NUMBER] = 
+OLECHAR* pSlotUrl[BARS_NUMBER] =
 						{L"slot:5910" // SID_TOGGLEFUNCTIONBAR
 						,L"slot:5920" // SID_TOGGLESTATUSBAR
 						,L"slot:6661" // SID_TOGGLE_MENUBAR
 //						,L"slot:10603" // SID_HYPERLINK_INSERT
 						};
 
-OLECHAR* pSlotName[BARS_NUMBER] = 
+OLECHAR* pSlotName[BARS_NUMBER] =
 						{L"FunctionBarVisible"		// SID_TOGGLEFUNCTIONBAR
 						,L"StatusBarVisible"		// SID_TOGGLESTATUSBAR
 						,L"MenuBarVisible"			// SID_TOGGLE_MENUBAR
@@ -51,10 +51,10 @@ OLECHAR* pSlotName[BARS_NUMBER] =
 
 /////////////////////////////////////////////////////////////////////////////
 
-HRESULT ExecuteFunc( IDispatch* idispUnoObject, 
-					 OLECHAR* sFuncName, 
-					 CComVariant* params, 
-					 unsigned int count, 
+HRESULT ExecuteFunc( IDispatch* idispUnoObject,
+					 OLECHAR* sFuncName,
+					 CComVariant* params,
+					 unsigned int count,
 					 CComVariant* pResult )
 {
 	if( !idispUnoObject )
@@ -68,14 +68,14 @@ HRESULT ExecuteFunc( IDispatch* idispUnoObject,
 
 	// DEBUG
 	EXCEPINFO myInfo;
-	return idispUnoObject->Invoke( id, IID_NULL,LOCALE_USER_DEFAULT, DISPATCH_METHOD, 
+	return idispUnoObject->Invoke( id, IID_NULL,LOCALE_USER_DEFAULT, DISPATCH_METHOD,
                     &dispparams, pResult, &myInfo, 0);
 }
 
-HRESULT GetIDispByFunc( IDispatch* idispUnoObject, 
-					  	OLECHAR* sFuncName, 
-					  	CComVariant* params, 
-					  	unsigned int count, 
+HRESULT GetIDispByFunc( IDispatch* idispUnoObject,
+					  	OLECHAR* sFuncName,
+					  	CComVariant* params,
+					  	unsigned int count,
 					  	CComPtr<IDispatch>& pdispResult )
 {
 	if( !idispUnoObject )
@@ -93,9 +93,9 @@ HRESULT GetIDispByFunc( IDispatch* idispUnoObject,
 	return S_OK;
 }
 
-HRESULT PutPropertiesToIDisp( IDispatch* pdispObject, 
-							  OLECHAR** sMemberNames, 
-							  CComVariant* pVariant, 
+HRESULT PutPropertiesToIDisp( IDispatch* pdispObject,
+							  OLECHAR** sMemberNames,
+							  CComVariant* pVariant,
 							  unsigned int count )
 {
 	for( unsigned int ind = 0; ind < count; ind++ )
@@ -122,18 +122,18 @@ CSOActiveX::CSOActiveX()
 , mOffWin( NULL )
 , mbViewOnly( FALSE )
 {
-	CLSID clsFactory = {0x82154420,0x0FBF,0x11d4,{0x83, 0x13,0x00,0x50,0x04,0x52,0x6A,0xB4}}; 
+	CLSID clsFactory = {0x82154420,0x0FBF,0x11d4,{0x83, 0x13,0x00,0x50,0x04,0x52,0x6A,0xB4}};
 	HRESULT hr = CoCreateInstance( clsFactory, NULL, CLSCTX_ALL, __uuidof(IDispatch), (void**)&mpDispFactory);
 
-    mPWinClass.style			= CS_HREDRAW|CS_VREDRAW; 
-    mPWinClass.lpfnWndProc		= ::DefWindowProc; 
-    mPWinClass.cbClsExtra		= 0; 
-    mPWinClass.cbWndExtra		= 0; 
-    mPWinClass.hInstance		= (HINSTANCE) GetModuleHandle(NULL); //myInstance; 
-    mPWinClass.hIcon			= NULL; 
-    mPWinClass.hCursor			= NULL; 
-    mPWinClass.hbrBackground	= (HBRUSH) COLOR_BACKGROUND; 
-    mPWinClass.lpszMenuName	    = NULL; 
+    mPWinClass.style			= CS_HREDRAW|CS_VREDRAW;
+    mPWinClass.lpfnWndProc		= ::DefWindowProc;
+    mPWinClass.cbClsExtra		= 0;
+    mPWinClass.cbWndExtra		= 0;
+    mPWinClass.hInstance		= (HINSTANCE) GetModuleHandle(NULL); //myInstance;
+    mPWinClass.hIcon			= NULL;
+    mPWinClass.hCursor			= NULL;
+    mPWinClass.hbrBackground	= (HBRUSH) COLOR_BACKGROUND;
+    mPWinClass.lpszMenuName	    = NULL;
     mPWinClass.lpszClassName	= STAROFFICE_WINDOWCLASS;
 
 	RegisterClass(&mPWinClass);
@@ -180,7 +180,7 @@ STDMETHODIMP CSOActiveX::Load ( LPSTREAM pStm )
 
 	// may be later?
 	// for now just ignore
-	
+
     return S_OK;
 }
 
@@ -189,19 +189,19 @@ STDMETHODIMP CSOActiveX::Load( LPPROPERTYBAG pPropBag, LPERRORLOG pErrorLog )
     IPropertyBag2* pPropBag2;
     HRESULT hr = pPropBag->QueryInterface( IID_IPropertyBag2, (void**)&pPropBag2 );
     ATLASSERT( hr >= 0 );
-    
+
     if( !SUCCEEDED( hr ) )
         return hr;
-    
+
     unsigned long aNum;
     hr = pPropBag2->CountProperties( &aNum );
     ATLASSERT( hr >= 0 );
     if( !SUCCEEDED( hr ) )
         return hr;
-        
+
     PROPBAG2* aPropNames = new PROPBAG2[aNum];
     unsigned long aReaded;
-    
+
     hr = pPropBag2->GetPropertyInfo( 0,
                                      aNum,
                                      aPropNames,
@@ -218,7 +218,7 @@ STDMETHODIMP CSOActiveX::Load( LPPROPERTYBAG pPropBag, LPERRORLOG pErrorLog )
 	hr = pPropBag2->Read( aNum,
                           aPropNames,
                           NULL,
-                          aVal, 
+                          aVal,
                           hvs );
     ATLASSERT( hr >= 0 );
     if( !SUCCEEDED( hr ) )
@@ -237,7 +237,7 @@ STDMETHODIMP CSOActiveX::Load( LPPROPERTYBAG pPropBag, LPERRORLOG pErrorLog )
 		{
             mCurFileUrl = wcsdup( aVal[ind].bstrVal );
 		}
-		else if( aVal[ind].vt == VT_BSTR 
+		else if( aVal[ind].vt == VT_BSTR
 				&& !strcmp( OLE2T( aPropNames[ind].pstrName ), "readonly" ) )
 		{
 			if( !strcmp( OLE2T( aVal[ind].bstrVal ), "true" ) )
@@ -258,10 +258,10 @@ STDMETHODIMP CSOActiveX::Load( LPPROPERTYBAG pPropBag, LPERRORLOG pErrorLog )
 
 	if( !mpDispFactory )
 		return hr;
-	
+
 	mbLoad = TRUE;
 
-    Invalidate();  
+    Invalidate();
     UpdateWindow();
 
 	return hr;
@@ -285,10 +285,10 @@ HRESULT CSOActiveX::GetUrlStruct( OLECHAR* sUrl, CComPtr<IDispatch>& pdispUrl )
 	if( !SUCCEEDED( hr ) ) return hr;
 
 	CComPtr<IDispatch> pdispTransformer;
-	hr = GetIDispByFunc( mpDispFactory, 
-						 L"createInstance", 
-						 &CComVariant( L"com.sun.star.util.URLTransformer" ), 
-						 1, 
+	hr = GetIDispByFunc( mpDispFactory,
+						 L"createInstance",
+						 &CComVariant( L"com.sun.star.util.URLTransformer" ),
+						 1,
 						 pdispTransformer );
 	if( !SUCCEEDED( hr ) ) return hr;
 
@@ -318,9 +318,9 @@ HRESULT CSOActiveX::CreateFrameOldWay( HWND hwnd, int width, int height )
 	HRESULT hr = GetUnoStruct( L"com.sun.star.awt.Rectangle", pdispRectangle );
 	if( !SUCCEEDED( hr ) ) return hr;
 
-	OLECHAR* sRectMemberNames[4] = { L"X", 
-								 	 L"Y", 
-								 	 L"Width", 
+	OLECHAR* sRectMemberNames[4] = { L"X",
+								 	 L"Y",
+								 	 L"Width",
 								 	 L"Height" };
 	CComVariant pRectVariant[4];
 	pRectVariant[0] = pRectVariant[1] = pRectVariant[2] = pRectVariant[3] = CComVariant( 0 );
@@ -334,10 +334,10 @@ HRESULT CSOActiveX::CreateFrameOldWay( HWND hwnd, int width, int height )
 	if( !SUCCEEDED( hr ) ) return hr;
 
 	// fill in descriptor with info
-	OLECHAR* sDescriptorMemberNames[6] = { L"Type", 
-								 L"WindowServiceName", 
-								 L"ParentIndex", 
-								 L"Parent", 
+	OLECHAR* sDescriptorMemberNames[6] = { L"Type",
+								 L"WindowServiceName",
+								 L"ParentIndex",
+								 L"Parent",
 								 L"Bounds",
 								 L"WindowAttributes" };
 	CComVariant pDescriptorVar[6];
@@ -391,7 +391,7 @@ HRESULT CSOActiveX::CreateFrameOldWay( HWND hwnd, int width, int height )
 	// initialize window
 	hr = ExecuteFunc( mpDispWin, L"setBackground", &CComVariant( (long)0xFFFFFFFF ), 1, &dummyResult );
 	if( !SUCCEEDED( hr ) ) return hr;
-	
+
 	hr = ExecuteFunc( mpDispWin, L"setVisible", &CComVariant( TRUE ), 1, &dummyResult );
 	if( !SUCCEEDED( hr ) ) return hr;
 
@@ -419,10 +419,10 @@ HRESULT CSOActiveX::CallDispatch1PBool( OLECHAR* sUrl, OLECHAR* sArgName, BOOL s
 	aArgs[2] = CComVariant( pdispURL );
 	aArgs[1] = CComVariant( L"" );
 	aArgs[0] = CComVariant( (int)0 );
-	hr = GetIDispByFunc( mpDispFrame, 
-						 L"queryDispatch", 
-						 aArgs, 
-						 3, 
+	hr = GetIDispByFunc( mpDispFrame,
+						 L"queryDispatch",
+						 aArgs,
+						 3,
 						 pdispXDispatch );
 	if( !SUCCEEDED( hr ) ) return hr;
 
@@ -440,7 +440,7 @@ HRESULT CSOActiveX::CallDispatch1PBool( OLECHAR* sUrl, OLECHAR* sArgName, BOOL s
 	if( !SUCCEEDED( hr ) ) return hr;
 
 	SafeArrayPutElement( pPropVals, &ix, pdispPropVal );
-	
+
 	CComVariant aDispArgs[2];
 	aDispArgs[1] = CComVariant( pdispURL );
 	// aDispArgs[0] = CComVariant( pPropVals ); such constructor is not defined ??!
@@ -486,7 +486,7 @@ HRESULT CSOActiveX::LoadURLToFrame( )
 
 	return S_OK;
 }
-		
+
 HRESULT CSOActiveX::OnDrawAdvanced( ATL_DRAWINFO& di )
 {
     if( m_spInPlaceSite && mCurFileUrl )
@@ -505,7 +505,7 @@ HRESULT CSOActiveX::OnDrawAdvanced( ATL_DRAWINFO& di )
 			}
 
             mParentWin = hwnd;
-            mOffWin = CreateWindow( 
+            mOffWin = CreateWindow(
 								STAROFFICE_WINDOWCLASS,
 								"OfficeContainer",
 								WS_CHILD | WS_CLIPCHILDREN | WS_BORDER,
@@ -524,16 +524,16 @@ HRESULT CSOActiveX::OnDrawAdvanced( ATL_DRAWINFO& di )
         {
             RECT aRect;
             ::GetWindowRect( mOffWin, &aRect );
-            
+
             if( aRect.left !=  di.prcBounds->left || aRect.top != di.prcBounds->top
              || aRect.right != di.prcBounds->right || aRect.bottom != di.prcBounds->bottom )
 			{
 				// on this state the office window should exist already
                 ::SetWindowPos( mOffWin,
                               HWND_TOP,
-							  di.prcBounds->left, 
-							  di.prcBounds->top, 
-							  di.prcBounds->right - di.prcBounds->left, 
+							  di.prcBounds->left,
+							  di.prcBounds->top,
+							  di.prcBounds->right - di.prcBounds->left,
 							  di.prcBounds->bottom - di.prcBounds->top,
                               SWP_NOZORDER );
 
@@ -547,7 +547,7 @@ HRESULT CSOActiveX::OnDrawAdvanced( ATL_DRAWINFO& di )
 				hr = ExecuteFunc( mpDispWin, L"setPosSize", aPosArgs, 5, &dummyResult );
 				if( !SUCCEEDED( hr ) ) return hr;
 			}
-        }                      
+        }
 
 		if( ! mpDispFrame )
 		{
@@ -604,12 +604,12 @@ STDMETHODIMP CSOActiveX::SetClientSite( IOleClientSite* aClientSite )
 	return hr;
 }
 
-STDMETHODIMP CSOActiveX::Invoke(DISPID dispidMember, 
-							    REFIID riid, 
-							    LCID lcid, 
-                                WORD wFlags, 
+STDMETHODIMP CSOActiveX::Invoke(DISPID dispidMember,
+							    REFIID riid,
+							    LCID lcid,
+                                WORD wFlags,
 							    DISPPARAMS* pDispParams,
-                                VARIANT* pvarResult, 
+                                VARIANT* pvarResult,
 							    EXCEPINFO* pExcepInfo,
                                 UINT* puArgErr)
 {
@@ -621,8 +621,8 @@ STDMETHODIMP CSOActiveX::Invoke(DISPID dispidMember,
 
 	if ( dispidMember == DISPID_ONQUIT )
 		Cleanup();
-	
-    IDispatchImpl<ISOActiveX, &IID_ISOActiveX, 
+
+    IDispatchImpl<ISOActiveX, &IID_ISOActiveX,
                   &LIBID_SO_ACTIVEXLib>::Invoke(
              dispidMember, riid, lcid, wFlags, pDispParams,
              pvarResult, pExcepInfo, puArgErr);
@@ -631,4 +631,3 @@ STDMETHODIMP CSOActiveX::Invoke(DISPID dispidMember,
 }
 
 // ---------------------------------------------------------------------------
-

--- a/main/odk/examples/OLE/activex/SOComWindowPeer.cpp
+++ b/main/odk/examples/OLE/activex/SOComWindowPeer.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -32,7 +32,7 @@
 
 STDMETHODIMP SOComWindowPeer::InterfaceSupportsErrorInfo(REFIID riid)
 {
-	static const IID* arr[] = 
+	static const IID* arr[] =
 	{
 		&IID_ISOComWindowPeer,
 	};
@@ -44,4 +44,3 @@ STDMETHODIMP SOComWindowPeer::InterfaceSupportsErrorInfo(REFIID riid)
 	}
 	return S_FALSE;
 }
-

--- a/main/odk/examples/OLE/activex/so_activex.cpp
+++ b/main/odk/examples/OLE/activex/so_activex.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -25,7 +25,7 @@
 
 
 // Note: Proxy/Stub Information
-//      To build a separate proxy/stub DLL, 
+//      To build a separate proxy/stub DLL,
 //      run nmake -f so_activexps.mk in the project directory.
 
 #include "stdafx2.h"
@@ -94,4 +94,3 @@ STDAPI DllUnregisterServer(void)
 
 	return aResult;
 }
-

--- a/main/sal/systools/win32/uwinapi/CheckTokenMembership.cpp
+++ b/main/sal/systools/win32/uwinapi/CheckTokenMembership.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/CommandLineToArgvW.cpp
+++ b/main/sal/systools/win32/uwinapi/CommandLineToArgvW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/CopyFileExA.cpp
+++ b/main/sal/systools/win32/uwinapi/CopyFileExA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/CopyFileExW.cpp
+++ b/main/sal/systools/win32/uwinapi/CopyFileExW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/DeleteVolumeMountPointA.cpp
+++ b/main/sal/systools/win32/uwinapi/DeleteVolumeMountPointA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/DeleteVolumeMountPointW.cpp
+++ b/main/sal/systools/win32/uwinapi/DeleteVolumeMountPointW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/DrawStateW.cpp
+++ b/main/sal/systools/win32/uwinapi/DrawStateW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/EnumProcesses.cpp
+++ b/main/sal/systools/win32/uwinapi/EnumProcesses.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "macros.h"
@@ -55,8 +55,6 @@ IMPLEMENT_THUNK( psapi, WINDOWS, BOOL, WINAPI, EnumProcesses, ( LPDWORD lpProces
 	}
 	else
 		SetLastError( ERROR_INVALID_HANDLE );
-	
+
 	return fSuccess;
 }
-
-

--- a/main/sal/systools/win32/uwinapi/FindFirstVolumeA.cpp
+++ b/main/sal/systools/win32/uwinapi/FindFirstVolumeA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindFirstVolumeMountPointA.cpp
+++ b/main/sal/systools/win32/uwinapi/FindFirstVolumeMountPointA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindFirstVolumeMountPointW.cpp
+++ b/main/sal/systools/win32/uwinapi/FindFirstVolumeMountPointW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindFirstVolumeW.cpp
+++ b/main/sal/systools/win32/uwinapi/FindFirstVolumeW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindNextVolumeA.cpp
+++ b/main/sal/systools/win32/uwinapi/FindNextVolumeA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindNextVolumeMountPointA.cpp
+++ b/main/sal/systools/win32/uwinapi/FindNextVolumeMountPointA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindNextVolumeMountPointW.cpp
+++ b/main/sal/systools/win32/uwinapi/FindNextVolumeMountPointW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindNextVolumeW.cpp
+++ b/main/sal/systools/win32/uwinapi/FindNextVolumeW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindVolumeClose.cpp
+++ b/main/sal/systools/win32/uwinapi/FindVolumeClose.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/FindVolumeMountPointClose.cpp
+++ b/main/sal/systools/win32/uwinapi/FindVolumeMountPointClose.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetDiskFreeSpaceExA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetDiskFreeSpaceExA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -52,4 +52,3 @@ IMPLEMENT_THUNK( kernel32, TRYLOAD, BOOL, WINAPI, GetDiskFreeSpaceExA,(
 
 	return fSuccess;
 }
-

--- a/main/sal/systools/win32/uwinapi/GetDiskFreeSpaceExW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetDiskFreeSpaceExW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,4 +34,3 @@ IMPLEMENT_THUNK( kernel32, WINDOWS, BOOL, WINAPI, GetDiskFreeSpaceExW,(
 
 	return GetDiskFreeSpaceExA( lpRootPathNameA, lpFreeBytesAvailable, lpTotalNumberOfBytes, lpTotalNumberOfFreeBytes );
 }
-

--- a/main/sal/systools/win32/uwinapi/GetLogicalDriveStringsW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetLogicalDriveStringsW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetLongPathName.cpp
+++ b/main/sal/systools/win32/uwinapi/GetLongPathName.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -31,7 +31,7 @@
 		return dwResult;
 	}
 
-	// Assume a not existing buffer means a bufsize of zero 
+	// Assume a not existing buffer means a bufsize of zero
 	if ( !lpLongPath )
 		cchBuffer = 0;
 
@@ -79,7 +79,7 @@
 				int	nParentLen = lpLastSlash - lpShortPath;
 				LPTSTR	lpParentPath = (LPTSTR)_alloca( (nParentLen + 1) * sizeof(TCHAR) );
 
-				CopyMemory( lpParentPath, lpShortPath, nParentLen * sizeof(TCHAR) ); 
+				CopyMemory( lpParentPath, lpShortPath, nParentLen * sizeof(TCHAR) );
 				lpParentPath[nParentLen] = 0;
 
 				dwResult = GetLongPathName( lpParentPath, lpLongPath, cchBuffer );
@@ -106,4 +106,3 @@
 
 	return dwResult;
 }
-

--- a/main/sal/systools/win32/uwinapi/GetLongPathNameA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetLongPathNameA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetLongPathNameW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetLongPathNameW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetModuleFileNameExA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetModuleFileNameExA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "macros.h"
@@ -54,7 +54,7 @@ IMPLEMENT_THUNK( psapi, WINDOWS, DWORD, WINAPI, GetModuleFileNameExA, (HANDLE hP
 			{
 				fFound = (me.hModule == hModule);
 			} while ( !fFound && Module32Next( hSnapshot, &me ) );
-			
+
 			if ( fFound )
 			{
 				dwResult = _tcslen( me.szExePath );
@@ -68,7 +68,6 @@ IMPLEMENT_THUNK( psapi, WINDOWS, DWORD, WINAPI, GetModuleFileNameExA, (HANDLE hP
 
 		CloseHandle( hSnapshot );
 	}
-	
+
 	return dwResult;
 }
-

--- a/main/sal/systools/win32/uwinapi/GetModuleFileNameExW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetModuleFileNameExW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "macros.h"

--- a/main/sal/systools/win32/uwinapi/GetProcessId.cpp
+++ b/main/sal/systools/win32/uwinapi/GetProcessId.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -57,7 +57,7 @@ static FARPROC WINAPI GetRealProcAddress( HMODULE hModule, LPCSTR lpProcName )
 			BFF956C6 58                   pop         eax
 			BFF956C7 9D                   popfd
 			BFF956C8 C3                   ret
-			*/		
+			*/
 		}
 	}
 
@@ -78,7 +78,7 @@ static DWORD WINAPI Obfuscate( DWORD dwPTID )
 
 		if ( lpCode )
 		{
-			/* 
+			/*
 			GetCurrentThreadId:
 			lpCode + 00 BFF84936 A1 DC 9C FC BF       mov         eax,[BFFC9CDC]	; This is the real thread id
 			lpcode + 05 BFF8493B FF 30                push        dword ptr [eax]
@@ -100,7 +100,7 @@ static DWORD WINAPI Obfuscate( DWORD dwPTID )
 			BFF80E6A C2 04 00             ret         4
 			*/
 		}
-		
+
 	}
 
 	return lpfnObfuscate ? lpfnObfuscate( dwPTID ) : 0;
@@ -121,16 +121,16 @@ EXTERN_C DWORD WINAPI GetProcessId_WINDOWS( HANDLE hProcess )
 
 		if ( 0 == ((DWORD)hProcess & 0x03) && dwHandleNumber < pPDB->pHandleTable->cEntries )
 		{
-			if ( 
-				pPDB->pHandleTable->array[dwHandleNumber].pObject && 
-				K32OBJ_PROCESS == pPDB->pHandleTable->array[dwHandleNumber].pObject->Type 
+			if (
+				pPDB->pHandleTable->array[dwHandleNumber].pObject &&
+				K32OBJ_PROCESS == pPDB->pHandleTable->array[dwHandleNumber].pObject->Type
 				)
 			dwProcessId = Obfuscate( (DWORD)pPDB->pHandleTable->array[dwHandleNumber].pObject );
 		}
 
 		SetLastError( ERROR_INVALID_HANDLE );
 	}
-	
+
 	return dwProcessId;
 }
 

--- a/main/sal/systools/win32/uwinapi/GetUserDefaultUILanguage.cpp
+++ b/main/sal/systools/win32/uwinapi/GetUserDefaultUILanguage.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,4 +27,3 @@ IMPLEMENT_THUNK( kernel32, WINDOWS, LANGID, WINAPI, GetUserDefaultUILanguage,())
 {
     return LANGIDFROMLCID(GetUserDefaultLCID());
 }
-

--- a/main/sal/systools/win32/uwinapi/GetUserDomainA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetUserDomainA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,4 +39,3 @@ EXTERN_C void WINAPI ResolveThunk_GetUserDomainA( FARPROC *lppfn, LPCSTR lpLibFi
 }
 
 DEFINE_CUSTOM_THUNK( kernel32, GetUserDomainA, DWORD, WINAPI, GetUserDomainA, ( LPSTR lpBuffer, DWORD nSize ) );
-

--- a/main/sal/systools/win32/uwinapi/GetUserDomainW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetUserDomainW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -40,4 +40,3 @@ EXTERN_C void WINAPI ResolveThunk_GetUserDomainW( FARPROC *lppfn, LPCSTR lpLibFi
 }
 
 DEFINE_CUSTOM_THUNK( kernel32, GetUserDomainW, DWORD, WINAPI, GetUserDomainW, ( LPWSTR lpBuffer, DWORD cchBuffer ) );
-

--- a/main/sal/systools/win32/uwinapi/GetUserDomain_NT.cpp
+++ b/main/sal/systools/win32/uwinapi/GetUserDomain_NT.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetUserDomain_WINDOWS.cpp
+++ b/main/sal/systools/win32/uwinapi/GetUserDomain_WINDOWS.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,10 +27,10 @@
 	DWORD	dwResult = 0;
 
 
-	if ( ERROR_SUCCESS  == RegOpenKeyEx( 
-		HKEY_LOCAL_MACHINE, 
-		TEXT("Network\\Logon"), 
-		0, KEY_READ, &hkeyLogon ) ) 
+	if ( ERROR_SUCCESS  == RegOpenKeyEx(
+		HKEY_LOCAL_MACHINE,
+		TEXT("Network\\Logon"),
+		0, KEY_READ, &hkeyLogon ) )
 	{
 		DWORD	dwLogon = 0;
 		DWORD	dwLogonSize = sizeof(dwLogon);
@@ -41,9 +41,9 @@
 		{
 			HKEY	hkeyNetworkProvider;
 
-			if ( ERROR_SUCCESS  == RegOpenKeyEx( 
-				HKEY_LOCAL_MACHINE, 
-				TEXT("SYSTEM\\CurrentControlSet\\Services\\MSNP32\\NetworkProvider"), 
+			if ( ERROR_SUCCESS  == RegOpenKeyEx(
+				HKEY_LOCAL_MACHINE,
+				TEXT("SYSTEM\\CurrentControlSet\\Services\\MSNP32\\NetworkProvider"),
 				0, KEY_READ, &hkeyNetworkProvider ) )
 			{
 				DWORD	dwBufferSize = nSize;

--- a/main/sal/systools/win32/uwinapi/GetVolumeNameForVolumeMountPointA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetVolumeNameForVolumeMountPointA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetVolumeNameForVolumeMountPointW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetVolumeNameForVolumeMountPointW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetVolumePathNameA.cpp
+++ b/main/sal/systools/win32/uwinapi/GetVolumePathNameA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/GetVolumePathNameW.cpp
+++ b/main/sal/systools/win32/uwinapi/GetVolumePathNameW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/MCIWndCreateW.cpp
+++ b/main/sal/systools/win32/uwinapi/MCIWndCreateW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -24,12 +24,12 @@
 #include "macros.h"
 #include <vfw.h>
 
-IMPLEMENT_THUNK( kernel32, WINDOWS, HWND, VFWAPIV, MCIWndCreateW, 
+IMPLEMENT_THUNK( kernel32, WINDOWS, HWND, VFWAPIV, MCIWndCreateW,
 (
-  HWND hwndParent,      
-  HINSTANCE hInstance,  
-  DWORD dwStyle,        
-  LPCWSTR lpFileW          
+  HWND hwndParent,
+  HINSTANCE hInstance,
+  DWORD dwStyle,
+  LPCWSTR lpFileW
 ))
 {
 	AUTO_WSTR2STR( lpFile );

--- a/main/sal/systools/win32/uwinapi/MoveFileExA.cpp
+++ b/main/sal/systools/win32/uwinapi/MoveFileExA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,7 +39,7 @@ IMPLEMENT_THUNK( kernel32, WINDOWS, BOOL, WINAPI, MoveFileExA, ( LPCSTR lpExisti
 
 		// Path names in WININIT.INI must be in short path name form
 
-		if ( 
+		if (
 			GetShortPathNameA( lpExistingFileNameA, szExistingFileNameA, MAX_PATH ) &&
 			(!lpNewFileNameA || GetShortPathNameA( lpNewFileNameA, szNewFileNameA, MAX_PATH ))
 			)
@@ -90,4 +90,3 @@ IMPLEMENT_THUNK( kernel32, WINDOWS, BOOL, WINAPI, MoveFileExA, ( LPCSTR lpExisti
 
 	return fSuccess;
 }
-

--- a/main/sal/systools/win32/uwinapi/MoveFileExW.cpp
+++ b/main/sal/systools/win32/uwinapi/MoveFileExW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -30,5 +30,3 @@ IMPLEMENT_THUNK( kernel32, WINDOWS, BOOL, WINAPI, MoveFileExW, ( LPCWSTR lpExist
 
 	return MoveFileExA( lpExistingFileNameA, lpNewFileNameA, dwFlags );
 }
-
-

--- a/main/sal/systools/win32/uwinapi/PathAddBackslashW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathAddBackslashW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathAddBackslashW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathAddBackslashW,
 (
     LPWSTR lpPathW
 ))
@@ -34,5 +34,5 @@ IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathAddBackslashW,
     AUTO_WSTR2STR(lpPath);
     PathAddBackslashA(lpPathA);
     STR2WSTR(lpPath, MAX_PATH);
-    return lpPathW + wcslen(lpPathW);    
+    return lpPathW + wcslen(lpPathW);
 }

--- a/main/sal/systools/win32/uwinapi/PathCompactPathExW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathCompactPathExW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/PathFileExistsW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathFileExistsW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,9 +26,9 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathFileExistsW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathFileExistsW,
 (
-    LPCWSTR lpPathW    
+    LPCWSTR lpPathW
 ))
 {
     AUTO_WSTR2STR(lpPath);

--- a/main/sal/systools/win32/uwinapi/PathFindExtensionW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathFindExtensionW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -29,20 +29,20 @@
 #include <tchar.h>
 #include <mbstring.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathFindExtensionW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathFindExtensionW,
 (
     LPCWSTR lpPathW
 ))
 {
-    AUTO_WSTR2STR(lpPath);        
+    AUTO_WSTR2STR(lpPath);
     char* pExt = PathFindExtensionA(lpPathA);
-    
-    if (*pExt)        
-    { 
-        *pExt = '\0';                
+
+    if (*pExt)
+    {
+        *pExt = '\0';
         LPWSTR pOutW = const_cast<LPWSTR>(lpPathW);
-        return (pOutW + _mbslen(reinterpret_cast<unsigned char*>(lpPathA)));      
-    }        
-    else            
-        return const_cast<LPWSTR>(lpPathW) + wcslen(lpPathW);        
+        return (pOutW + _mbslen(reinterpret_cast<unsigned char*>(lpPathA)));
+    }
+    else
+        return const_cast<LPWSTR>(lpPathW) + wcslen(lpPathW);
 }

--- a/main/sal/systools/win32/uwinapi/PathFindFileNameW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathFindFileNameW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,19 +28,19 @@
 
 #include <mbstring.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathFindFileNameW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, LPWSTR, WINAPI, PathFindFileNameW,
 (
     LPCWSTR lpPathW
 ))
 {
-    AUTO_WSTR2STR(lpPath);    
+    AUTO_WSTR2STR(lpPath);
     char* pFname = PathFindFileNameA(lpPathA);
-    
+
     if (pFname > lpPathA)
-    {        
+    {
         *pFname = '\0';
         LPWSTR pOutW = const_cast<LPWSTR>(lpPathW);
-        return (pOutW + _mbslen(reinterpret_cast<unsigned char*>(lpPathA)));      
+        return (pOutW + _mbslen(reinterpret_cast<unsigned char*>(lpPathA)));
     }
     else
         return const_cast<LPWSTR>(lpPathW);

--- a/main/sal/systools/win32/uwinapi/PathIsFileSpecW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathIsFileSpecW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathIsFileSpecW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathIsFileSpecW,
 (
     LPCWSTR lpPathW
 ))

--- a/main/sal/systools/win32/uwinapi/PathIsUNCW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathIsUNCW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathIsUNCW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathIsUNCW,
 (
     LPCWSTR lpPathW
 ))

--- a/main/sal/systools/win32/uwinapi/PathRemoveExtensionW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathRemoveExtensionW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,12 +26,12 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, void, WINAPI, PathRemoveExtensionW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, void, WINAPI, PathRemoveExtensionW,
 (
     LPWSTR lpPathW
 ))
 {
     AUTO_WSTR2STR(lpPath);
     PathRemoveExtensionA(lpPathA);
-    STR2WSTR(lpPath, wcslen(lpPathW) + 1);        
+    STR2WSTR(lpPath, wcslen(lpPathW) + 1);
 }

--- a/main/sal/systools/win32/uwinapi/PathRemoveFileSpecW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathRemoveFileSpecW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,13 +26,13 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathRemoveFileSpecW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathRemoveFileSpecW,
 (
     LPWSTR lpPathW
 ))
 {
     AUTO_WSTR2STR(lpPath);
     BOOL bret = PathRemoveFileSpecA(lpPathA);
-    STR2WSTR(lpPath, wcslen(lpPathW) + 1);        
+    STR2WSTR(lpPath, wcslen(lpPathW) + 1);
     return bret;
 }

--- a/main/sal/systools/win32/uwinapi/PathSetDlgItemPathW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathSetDlgItemPathW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, void, WINAPI, PathSetDlgItemPathW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, void, WINAPI, PathSetDlgItemPathW,
 (
     HWND hDlg,
     int id,
@@ -34,5 +34,5 @@ IMPLEMENT_THUNK( shlwapi, WINDOWS, void, WINAPI, PathSetDlgItemPathW,
 ))
 {
     AUTO_WSTR2STR(lpPath);
-    PathSetDlgItemPathA(hDlg, id, lpPathA);    
+    PathSetDlgItemPathA(hDlg, id, lpPathA);
 }

--- a/main/sal/systools/win32/uwinapi/PathStripToRootW.cpp
+++ b/main/sal/systools/win32/uwinapi/PathStripToRootW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #define _SHLWAPI_
 #include <shlwapi.h>
 
-IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathStripToRootW, 
+IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathStripToRootW,
 (
     LPWSTR lpPathW
 ))
@@ -34,5 +34,5 @@ IMPLEMENT_THUNK( shlwapi, WINDOWS, BOOL, WINAPI, PathStripToRootW,
     AUTO_WSTR2STR(lpPath);
     BOOL bret = PathStripToRootA(lpPathA);
     STR2WSTR(lpPath, wcslen(lpPathW) + 1);
-    return bret;        
+    return bret;
 }

--- a/main/sal/systools/win32/uwinapi/ResolveThunk.cpp
+++ b/main/sal/systools/win32/uwinapi/ResolveThunk.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -56,5 +56,3 @@ EXTERN_C void WINAPI ResolveThunk_ALLWAYS( FARPROC *lppfn, LPCSTR lpLibFileName,
 {
 	*lppfn = lpfnEmulate ? lpfnEmulate : lpfnFailure;
 }
-
-

--- a/main/sal/systools/win32/uwinapi/ResolveUnicows.cpp
+++ b/main/sal/systools/win32/uwinapi/ResolveUnicows.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #ifdef __MINGW32__
@@ -485,7 +485,7 @@ DEFINE_UNICOWS_THUNK( version, DWORD, WINAPI, VerInstallFileW, (DWORD,LPWSTR,LPW
 DEFINE_UNICOWS_THUNK( kernel32, DWORD, WINAPI, VerLanguageNameW, (DWORD,LPWSTR,DWORD) )
 #if ( __W32API_MAJOR_VERSION > 3 ) || ( __W32API_MAJOR_VERSION == 3 && __W32API_MINOR_VERSION > 13 )
 DEFINE_UNICOWS_THUNK( version, BOOL, WINAPI, VerQueryValueW, (const LPVOID,LPCWSTR,LPVOID*,PUINT) )
-#else 
+#else
 DEFINE_UNICOWS_THUNK( version, BOOL, WINAPI, VerQueryValueW, (const LPVOID,LPWSTR,LPVOID*,PUINT) )
 #endif
 DEFINE_UNICOWS_THUNK( user32, SHORT, WINAPI, VkKeyScanExW, (WCHAR,HKL) )

--- a/main/sal/systools/win32/uwinapi/SHCreateItemFromParsingName.cpp
+++ b/main/sal/systools/win32/uwinapi/SHCreateItemFromParsingName.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -45,4 +45,3 @@ extern "C" HRESULT WINAPI SHCreateItemFromParsingName (PCWSTR pszPath, IBindCtx 
 }
 
 HRESULT (WINAPI *pSHCreateItemFromParsingName)(PCWSTR pszPath, IBindCtx *pbc, REFIID riid, void **ppv) = SHCreateItemFromParsingName_Thunk;
-

--- a/main/sal/systools/win32/uwinapi/SHILCreateFromPathW.cpp
+++ b/main/sal/systools/win32/uwinapi/SHILCreateFromPathW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "uwinapi.h"

--- a/main/sal/systools/win32/uwinapi/SetVolumeMountPointA.cpp
+++ b/main/sal/systools/win32/uwinapi/SetVolumeMountPointA.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/SetVolumeMountPointW.cpp
+++ b/main/sal/systools/win32/uwinapi/SetVolumeMountPointW.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sal/systools/win32/uwinapi/toolhelp.cpp
+++ b/main/sal/systools/win32/uwinapi/toolhelp.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "macros.h"

--- a/main/sal/workben/clipboardwben/testcopy/StdAfx.cpp
+++ b/main/sal/workben/clipboardwben/testcopy/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // stdafx.cpp : Quelltextdatei, die nur die Standard-Includes einbindet

--- a/main/sal/workben/clipboardwben/testpaste/StdAfx.cpp
+++ b/main/sal/workben/clipboardwben/testpaste/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // stdafx.cpp : Quelltextdatei, die nur die Standard-Includes einbindet

--- a/main/sal/workben/clipboardwben/testviewer/StdAfx.cpp
+++ b/main/sal/workben/clipboardwben/testviewer/StdAfx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // stdafx.cpp : Quelltextdatei, die nur die Standard-Includes einbindet

--- a/main/vcl/unx/generic/fontmanager/afm_hash.cpp
+++ b/main/vcl/unx/generic/fontmanager/afm_hash.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /* C++ code produced by gperf version 3.0.1 */

--- a/main/winaccessibility/source/UAccCOM/AccAction.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccAction.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /**
@@ -36,7 +36,7 @@ using namespace com::sun::star::uno;
  */
 STDMETHODIMP CAccAction::nActions(/*[out,retval]*/long* nActions)
 {
-    
+
     return CAccActionBase::nActions(nActions);
 }
 
@@ -47,7 +47,7 @@ STDMETHODIMP CAccAction::nActions(/*[out,retval]*/long* nActions)
  */
 STDMETHODIMP CAccAction::doAction(/* [in] */ long actionIndex)
 {
-    
+
     return CAccActionBase::doAction(actionIndex);
 }
 
@@ -59,24 +59,24 @@ STDMETHODIMP CAccAction::doAction(/* [in] */ long actionIndex)
  */
 STDMETHODIMP CAccAction::get_description(long actionIndex,BSTR __RPC_FAR *description)
 {
-    
+
     return CAccActionBase::get_description(actionIndex, description);
 }
 
 STDMETHODIMP CAccAction::get_name( long actionIndex, BSTR __RPC_FAR *name)
 {
-    
+
     return CAccActionBase::get_name(actionIndex, name);
 }
 
 STDMETHODIMP CAccAction::get_localizedName( long actionIndex, BSTR __RPC_FAR *localizedName)
 {
-    
+
     return CAccActionBase::get_localizedName(actionIndex, localizedName);
 }
 
 /**
- * Returns key binding object (if any) associated with specified action 
+ * Returns key binding object (if any) associated with specified action
  * key binding is string.
  * e.g. "alt+d" (like IAccessible::get_accKeyboardShortcut).
  *
@@ -91,7 +91,7 @@ STDMETHODIMP CAccAction::get_keyBinding(
     /* [length_is][length_is][size_is][size_is][out] */ BSTR __RPC_FAR *__RPC_FAR *keyBinding,
     /* [retval][out] */ long __RPC_FAR *nBinding)
 {
-    
+
     return CAccActionBase::get_keyBinding(actionIndex, nMaxBinding,	keyBinding, nBinding);
 }
 
@@ -102,7 +102,7 @@ STDMETHODIMP CAccAction::get_keyBinding(
  */
 STDMETHODIMP CAccAction::put_XInterface(long pXInterface)
 {
-    
+
     return CAccActionBase::put_XInterface(pXInterface);
 }
 /**
@@ -112,7 +112,7 @@ STDMETHODIMP CAccAction::put_XInterface(long pXInterface)
 */
 STDMETHODIMP CAccAction::put_XSubInterface(long pXSubInterface)
 {
-    
+
 
     pRXAct = (XAccessibleAction*)pXSubInterface;
 

--- a/main/winaccessibility/source/UAccCOM/AccActionBase.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccActionBase.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 //////////////////////////////////////////////////////////////////////
@@ -109,7 +109,7 @@ void GetDfActionByUNORole(XAccessibleContext* pRContext, BSTR* pRet)
  */
 STDMETHODIMP CAccActionBase::nActions(/*[out,retval]*/long* nActions)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -134,7 +134,7 @@ STDMETHODIMP CAccActionBase::nActions(/*[out,retval]*/long* nActions)
  */
 STDMETHODIMP CAccActionBase::doAction(/* [in] */ long actionIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -156,7 +156,7 @@ STDMETHODIMP CAccActionBase::doAction(/* [in] */ long actionIndex)
  */
 STDMETHODIMP CAccActionBase::get_description(long actionIndex,BSTR __RPC_FAR *description)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -191,7 +191,7 @@ STDMETHODIMP CAccActionBase::get_localizedName( long, BSTR __RPC_FAR *)
 }
 
 /**
- * Returns key binding object (if any) associated with specified action 
+ * Returns key binding object (if any) associated with specified action
  * key binding is string.
  * e.g. "alt+d" (like IAccessible::get_accKeyboardShortcut).
  *
@@ -206,7 +206,7 @@ STDMETHODIMP CAccActionBase::get_keyBinding(
     /* [length_is][length_is][size_is][size_is][out] */ BSTR __RPC_FAR *__RPC_FAR *keyBinding,
     /* [retval][out] */ long __RPC_FAR *nBinding)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -252,7 +252,7 @@ STDMETHODIMP CAccActionBase::get_keyBinding(
  */
 STDMETHODIMP CAccActionBase::put_XInterface(long pXInterface)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -413,4 +413,3 @@ OLECHAR* CAccActionBase::getOLECHARFromKeyCode(long key)
         return NULL;
     }
 }
-

--- a/main/winaccessibility/source/UAccCOM/AccComponent.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccComponent.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /**
@@ -27,36 +27,36 @@
 #include "AccComponent.h"
 
 /**
- * Returns the location of the upper left corner of the object's bounding 
+ * Returns the location of the upper left corner of the object's bounding
  * box relative to the parent.
- * 
+ *
  * @param    Location    the upper left corner of the object's bounding box.
  */
 STDMETHODIMP CAccComponent::get_locationInParent(long *x, long *y)
 {
-    
+
     return CAccComponentBase::get_locationInParent(x,y);
 }
 
 /**
  * Returns the foreground color of this object.
- * 
+ *
  * @param    Color    the color of foreground.
  */
 STDMETHODIMP CAccComponent::get_foreground(IA2Color * foreground)
 {
-    
+
     return CAccComponentBase::get_foreground(foreground);
 }
 
 /**
  * Returns the background color of this object.
- * 
+ *
  * @param    Color    the color of background.
  */
 STDMETHODIMP CAccComponent::get_background(IA2Color * background)
 {
-    
+
     return CAccComponentBase::get_background(background);
 }
 
@@ -67,6 +67,6 @@ STDMETHODIMP CAccComponent::get_background(IA2Color * background)
  */
 STDMETHODIMP CAccComponent::put_XInterface(long pXInterface)
 {
-    
+
     return CAccComponentBase::put_XInterface(pXInterface);
 }

--- a/main/winaccessibility/source/UAccCOM/AccComponentBase.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccComponentBase.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -40,14 +40,14 @@ CAccComponentBase::~CAccComponentBase()
 
 
 /**
- * Returns the location of the upper left corner of the object's bounding 
+ * Returns the location of the upper left corner of the object's bounding
  * box relative to the parent.
- * 
+ *
  * @param    Location    the upper left corner of the object's bounding box.
  */
 STDMETHODIMP CAccComponentBase::get_locationInParent(long *x, long *y)
 {
-    
+
 	CHECK_ENABLE_INF
 
     try
@@ -70,15 +70,15 @@ STDMETHODIMP CAccComponentBase::get_locationInParent(long *x, long *y)
 }
 
 /**
- * Returns the location of the upper left corner of the object's bounding 
+ * Returns the location of the upper left corner of the object's bounding
  * box in screen.
- * 
- * @param    Location    the upper left corner of the object's bounding 
+ *
+ * @param    Location    the upper left corner of the object's bounding
  *                       box in screen coordinates.
  */
 STDMETHODIMP CAccComponentBase::get_locationOnScreen(long *x, long *y)
 {
-    
+
 	CHECK_ENABLE_INF
 
     try
@@ -103,12 +103,12 @@ STDMETHODIMP CAccComponentBase::get_locationOnScreen(long *x, long *y)
 
 /**
  * Grabs the focus to this object.
- * 
+ *
  * @param    success    the boolean result to be returned.
  */
 STDMETHODIMP CAccComponentBase::grabFocus(boolean * success)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -130,12 +130,12 @@ STDMETHODIMP CAccComponentBase::grabFocus(boolean * success)
 
 /**
  * Returns the foreground color of this object.
- * 
+ *
  * @param    Color    the color of foreground.
  */
 STDMETHODIMP CAccComponentBase::get_foreground(IA2Color * foreground)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -156,12 +156,12 @@ STDMETHODIMP CAccComponentBase::get_foreground(IA2Color * foreground)
 
 /**
  * Returns the background color of this object.
- * 
+ *
  * @param    Color    the color of background.
  */
 STDMETHODIMP CAccComponentBase::get_background(IA2Color * background)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -187,7 +187,7 @@ STDMETHODIMP CAccComponentBase::get_background(IA2Color * background)
  */
 STDMETHODIMP CAccComponentBase::put_XInterface(long pXInterface)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK

--- a/main/winaccessibility/source/UAccCOM/AccEditableText.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccEditableText.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /**
@@ -49,7 +49,7 @@ using namespace std;
  */
 STDMETHODIMP CAccEditableText::copyText(long startOffset, long endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -77,7 +77,7 @@ STDMETHODIMP CAccEditableText::copyText(long startOffset, long endOffset)
  */
 STDMETHODIMP CAccEditableText::deleteText(long startOffset, long endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -102,7 +102,7 @@ STDMETHODIMP CAccEditableText::deleteText(long startOffset, long endOffset)
  */
 STDMETHODIMP CAccEditableText::insertText(long offset, BSTR * text)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -132,7 +132,7 @@ STDMETHODIMP CAccEditableText::insertText(long offset, BSTR * text)
  */
 STDMETHODIMP CAccEditableText::cutText(long startOffset, long endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -156,7 +156,7 @@ STDMETHODIMP CAccEditableText::cutText(long startOffset, long endOffset)
  */
 STDMETHODIMP CAccEditableText::pasteText(long offset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -182,7 +182,7 @@ STDMETHODIMP CAccEditableText::pasteText(long offset)
  */
 STDMETHODIMP CAccEditableText::replaceText(long startOffset, long endOffset, BSTR * text)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -212,7 +212,7 @@ STDMETHODIMP CAccEditableText::replaceText(long startOffset, long endOffset, BST
  */
 STDMETHODIMP CAccEditableText::setAttributes(long startOffset, long endOffset, BSTR * attributes)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -484,7 +484,7 @@ void CAccEditableText::get_AnyFromOLECHAR(const ::rtl::OUString &ouName, const :
  */
 STDMETHODIMP CAccEditableText::put_XInterface(long pXInterface)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 

--- a/main/winaccessibility/source/UAccCOM/AccHyperLink.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccHyperLink.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -37,7 +37,7 @@ using namespace com::sun::star::awt;
  */
 STDMETHODIMP CAccHyperLink::nActions(/*[out,retval]*/long* nActions)
 {
-    
+
     return CAccActionBase::nActions(nActions);
 }
 
@@ -48,7 +48,7 @@ STDMETHODIMP CAccHyperLink::nActions(/*[out,retval]*/long* nActions)
  */
 STDMETHODIMP CAccHyperLink::doAction(/* [in] */ long actionIndex)
 {
-    
+
     return CAccActionBase::doAction(actionIndex);
 }
 
@@ -60,24 +60,24 @@ STDMETHODIMP CAccHyperLink::doAction(/* [in] */ long actionIndex)
  */
 STDMETHODIMP CAccHyperLink::get_description(long actionIndex,BSTR __RPC_FAR *description)
 {
-    
+
     return CAccActionBase::get_description(actionIndex, description);
 }
 
 STDMETHODIMP CAccHyperLink::get_name( long actionIndex, BSTR __RPC_FAR *name)
 {
-    
+
     return CAccActionBase::get_name(actionIndex, name);
 }
 
 STDMETHODIMP CAccHyperLink::get_localizedName( long actionIndex, BSTR __RPC_FAR *localizedName)
 {
-    
+
     return CAccActionBase::get_name(actionIndex, localizedName);
 }
 
 /**
- * Returns key binding object (if any) associated with specified action 
+ * Returns key binding object (if any) associated with specified action
  * key binding is string.
  * e.g. "alt+d" (like IAccessible::get_accKeyboardShortcut).
  *
@@ -92,19 +92,19 @@ STDMETHODIMP CAccHyperLink::get_keyBinding(
     /* [length_is][length_is][size_is][size_is][out] */ BSTR __RPC_FAR *__RPC_FAR *keyBinding,
     /* [retval][out] */ long __RPC_FAR *nBinding)
 {
-    
+
     return CAccActionBase::get_keyBinding(actionIndex, nMaxBinding,	keyBinding, nBinding);
 }
 
 /**
    * get an object
-   * @param 
+   * @param
    * @return Result.
 */
 STDMETHODIMP CAccHyperLink::get_anchor(/* [in] */ long index,
         /* [retval][out] */ VARIANT __RPC_FAR *anchor)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -131,13 +131,13 @@ STDMETHODIMP CAccHyperLink::get_anchor(/* [in] */ long index,
 
 /**
    * get an object
-   * @param 
+   * @param
    * @return Result.
 */
 STDMETHODIMP CAccHyperLink::get_anchorTarget(/* [in] */ long index,
         /* [retval][out] */ VARIANT __RPC_FAR *anchorTarget)
 {
-    
+
 
 	CHECK_ENABLE_INF
     ENTER_PROTECTED_BLOCK
@@ -170,7 +170,7 @@ STDMETHODIMP CAccHyperLink::get_anchorTarget(/* [in] */ long index,
 */
 STDMETHODIMP CAccHyperLink::get_startIndex(/* [retval][out] */ long __RPC_FAR *index)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -194,7 +194,7 @@ STDMETHODIMP CAccHyperLink::get_startIndex(/* [retval][out] */ long __RPC_FAR *i
 */
 STDMETHODIMP CAccHyperLink::get_endIndex(/* [retval][out] */ long __RPC_FAR *index)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -223,7 +223,7 @@ STDMETHODIMP CAccHyperLink::get_endIndex(/* [retval][out] */ long __RPC_FAR *ind
 */
 STDMETHODIMP CAccHyperLink::get_valid(/* [retval][out] */ boolean __RPC_FAR *valid)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -252,7 +252,7 @@ STDMETHODIMP CAccHyperLink::get_valid(/* [retval][out] */ boolean __RPC_FAR *val
 */
 STDMETHODIMP CAccHyperLink::put_XInterface(long pXInterface)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -286,7 +286,7 @@ STDMETHODIMP CAccHyperLink::put_XInterface(long pXInterface)
 */
 STDMETHODIMP CAccHyperLink::put_XSubInterface(long pXSubInterface)
 {
-    
+
 	CHECK_ENABLE_INF
 
     pRXLink = (XAccessibleHyperlink*)pXSubInterface;

--- a/main/winaccessibility/source/UAccCOM/AccHypertext.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccHypertext.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -39,7 +39,7 @@ using namespace com::sun::star::uno;
 */
 STDMETHODIMP CAccHypertext::addSelection(long startOffset, long endOffset)
 {
-    
+
     return CAccTextBase::get_addSelection(startOffset, endOffset);
 }
 
@@ -54,7 +54,7 @@ STDMETHODIMP CAccHypertext::addSelection(long startOffset, long endOffset)
 */
 STDMETHODIMP CAccHypertext::get_attributes(long offset, long * startOffset, long * endOffset, BSTR * textAttributes)
 {
-    
+
     return CAccTextBase::get_attributes(offset, startOffset, endOffset, textAttributes);
 }
 
@@ -65,7 +65,7 @@ STDMETHODIMP CAccHypertext::get_attributes(long offset, long * startOffset, long
 */
 STDMETHODIMP CAccHypertext::get_caretOffset(long * offset)
 {
-    
+
     return CAccTextBase::get_caretOffset(offset);
 }
 
@@ -76,7 +76,7 @@ STDMETHODIMP CAccHypertext::get_caretOffset(long * offset)
 */
 STDMETHODIMP CAccHypertext::get_characterCount(long * nCharacters)
 {
-    
+
     return CAccTextBase::get_characterCount(nCharacters);
 }
 
@@ -91,7 +91,7 @@ STDMETHODIMP CAccHypertext::get_characterCount(long * nCharacters)
 */
 STDMETHODIMP CAccHypertext::get_characterExtents(long offset, IA2CoordinateType coordType, long * x, long * y, long * width, long * height)
 {
-    
+
     return CAccTextBase::get_characterExtents(offset, coordType, x, y, width, height);
 }
 
@@ -102,7 +102,7 @@ STDMETHODIMP CAccHypertext::get_characterExtents(long offset, IA2CoordinateType 
 */
 STDMETHODIMP CAccHypertext::get_nSelections(long * nSelections)
 {
-    
+
     return CAccTextBase::get_nSelections(nSelections);
 }
 
@@ -128,7 +128,7 @@ STDMETHODIMP CAccHypertext::get_offsetAtPoint(long x, long y, IA2CoordinateType 
 */
 STDMETHODIMP CAccHypertext::get_selection(long selection, long * startOffset, long * endOffset)
 {
-    
+
     return CAccTextBase::get_selection(selection, startOffset, endOffset);
 }
 
@@ -141,7 +141,7 @@ STDMETHODIMP CAccHypertext::get_selection(long selection, long * startOffset, lo
 */
 STDMETHODIMP CAccHypertext::get_text(long startOffset, long endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_text(startOffset, endOffset, text);
 }
 
@@ -156,7 +156,7 @@ STDMETHODIMP CAccHypertext::get_text(long startOffset, long endOffset, BSTR * te
 */
 STDMETHODIMP CAccHypertext::get_textBeforeOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textBeforeOffset(offset, boundaryType,
             startOffset, endOffset, text);
 }
@@ -172,7 +172,7 @@ STDMETHODIMP CAccHypertext::get_textBeforeOffset(long offset, IA2TextBoundaryTyp
 */
 STDMETHODIMP CAccHypertext::get_textAfterOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textAfterOffset(offset, boundaryType,
             startOffset, endOffset, text);
 }
@@ -188,7 +188,7 @@ STDMETHODIMP CAccHypertext::get_textAfterOffset(long offset, IA2TextBoundaryType
 */
 STDMETHODIMP CAccHypertext::get_textAtOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textAtOffset(offset, boundaryType,
                                           startOffset, endOffset, text);
 }
@@ -201,7 +201,7 @@ STDMETHODIMP CAccHypertext::get_textAtOffset(long offset, IA2TextBoundaryType bo
 */
 STDMETHODIMP CAccHypertext::removeSelection(long selectionIndex)
 {
-    
+
     return CAccTextBase::removeSelection(selectionIndex);
 }
 
@@ -213,7 +213,7 @@ STDMETHODIMP CAccHypertext::removeSelection(long selectionIndex)
 */
 STDMETHODIMP CAccHypertext::setCaretOffset(long offset)
 {
-    
+
     return CAccTextBase::setCaretOffset(offset);
 }
 
@@ -227,7 +227,7 @@ STDMETHODIMP CAccHypertext::setCaretOffset(long offset)
 */
 STDMETHODIMP CAccHypertext::setSelection(long selectionIndex, long startOffset, long endOffset)
 {
-    
+
     return CAccTextBase::setSelection(selectionIndex, startOffset,
                                       endOffset);
 }
@@ -239,7 +239,7 @@ STDMETHODIMP CAccHypertext::setSelection(long selectionIndex, long startOffset, 
 */
 STDMETHODIMP CAccHypertext::get_nCharacters(long * nCharacters)
 {
-    
+
     return CAccTextBase::get_nCharacters(nCharacters);
 }
 
@@ -261,12 +261,12 @@ STDMETHODIMP CAccHypertext::get_oldText( IA2TextSegment *oldText)
 */
 STDMETHODIMP CAccHypertext::scrollSubstringToPoint(long startIndex, long endIndex,enum IA2CoordinateType coordinateType, long x, long y )
 {
-    
+
     return CAccTextBase::scrollSubstringToPoint(startIndex, endIndex, coordinateType, x, y);
 }
 STDMETHODIMP CAccHypertext::scrollSubstringTo(long startIndex, long endIndex,enum IA2ScrollType scrollType)
 {
-    
+
     return CAccTextBase::scrollSubstringTo(startIndex, endIndex,scrollType);
 }
 
@@ -277,7 +277,7 @@ STDMETHODIMP CAccHypertext::scrollSubstringTo(long startIndex, long endIndex,enu
 */
 STDMETHODIMP CAccHypertext::get_nHyperlinks(long *hyperlinkCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -305,7 +305,7 @@ STDMETHODIMP CAccHypertext::get_nHyperlinks(long *hyperlinkCount)
 */
 STDMETHODIMP CAccHypertext::get_hyperlink(long index,IAccessibleHyperlink **hyperlink)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -358,7 +358,7 @@ STDMETHODIMP CAccHypertext::get_hyperlink(long index,IAccessibleHyperlink **hype
 */
 STDMETHODIMP CAccHypertext::get_hyperlinkIndex(long charIndex, long *hyperlinkIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -385,7 +385,7 @@ STDMETHODIMP CAccHypertext::get_hyperlinkIndex(long charIndex, long *hyperlinkIn
 */
 STDMETHODIMP CAccHypertext::put_XInterface(long pXInterface)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 

--- a/main/winaccessibility/source/UAccCOM/AccImage.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccImage.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -35,7 +35,7 @@ using namespace com::sun::star::uno;
 */
 STDMETHODIMP CAccImage::get_description(BSTR * description)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -77,7 +77,7 @@ STDMETHODIMP CAccImage::get_imageSize(
 */
 STDMETHODIMP CAccImage::put_XInterface(long pXInterface)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 

--- a/main/winaccessibility/source/UAccCOM/AccRelation.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccRelation.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -36,7 +36,7 @@ using namespace com::sun::star::uno;
 */
 STDMETHODIMP CAccRelation::get_relationType(BSTR * relationType)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -56,7 +56,7 @@ STDMETHODIMP CAccRelation::get_relationType(BSTR * relationType)
 // Gets what the type of localized relation is.
 STDMETHODIMP CAccRelation::get_localizedRelationType(BSTR *)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -72,7 +72,7 @@ STDMETHODIMP CAccRelation::get_localizedRelationType(BSTR *)
 */
 STDMETHODIMP CAccRelation::get_nTargets(long * nTargets)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -95,7 +95,7 @@ STDMETHODIMP CAccRelation::get_nTargets(long * nTargets)
 */
 STDMETHODIMP CAccRelation::get_target(long targetIndex, IUnknown * * target)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -133,7 +133,7 @@ STDMETHODIMP CAccRelation::get_target(long targetIndex, IUnknown * * target)
 */
 STDMETHODIMP CAccRelation::get_targets(long, IUnknown * * target, long * nTargets)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -176,7 +176,7 @@ STDMETHODIMP CAccRelation::get_targets(long, IUnknown * * target, long * nTarget
 */
 STDMETHODIMP CAccRelation::put_XSubInterface(long pXSubInterface)
 {
-    
+
     relation = *((AccessibleRelation*)pXSubInterface);
     return S_OK;
 }

--- a/main/winaccessibility/source/UAccCOM/AccTable.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccTable.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /**
@@ -46,7 +46,7 @@ using namespace com::sun::star::uno;
 
 STDMETHODIMP CAccTable::get_accessibleAt(long row, long column, IUnknown * * accessible)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -101,7 +101,7 @@ STDMETHODIMP CAccTable::get_accessibleAt(long row, long column, IUnknown * * acc
   */
 STDMETHODIMP CAccTable::get_caption(IUnknown * *)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -118,7 +118,7 @@ STDMETHODIMP CAccTable::get_caption(IUnknown * *)
   */
 STDMETHODIMP CAccTable::get_columnDescription(long column, BSTR * description)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -152,7 +152,7 @@ STDMETHODIMP CAccTable::get_columnDescription(long column, BSTR * description)
   */
 STDMETHODIMP CAccTable::get_columnExtentAt(long row, long column, long * nColumnsSpanned)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -186,7 +186,7 @@ STDMETHODIMP CAccTable::get_columnExtentAt(long row, long column, long * nColumn
   */
 STDMETHODIMP CAccTable::get_columnHeader(IAccessibleTable __RPC_FAR *__RPC_FAR *accessibleTable, long *startingRowIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -241,7 +241,7 @@ STDMETHODIMP CAccTable::get_columnHeader(IAccessibleTable __RPC_FAR *__RPC_FAR *
   */
 STDMETHODIMP CAccTable::get_nColumns(long * columnCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -267,7 +267,7 @@ STDMETHODIMP CAccTable::get_nColumns(long * columnCount)
   */
 STDMETHODIMP CAccTable::get_nRows(long * rowCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -293,7 +293,7 @@ STDMETHODIMP CAccTable::get_nRows(long * rowCount)
   */
 STDMETHODIMP CAccTable::get_nSelectedColumns(long * columnCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -320,7 +320,7 @@ STDMETHODIMP CAccTable::get_nSelectedColumns(long * columnCount)
   */
 STDMETHODIMP CAccTable::get_nSelectedRows(long * rowCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -348,7 +348,7 @@ STDMETHODIMP CAccTable::get_nSelectedRows(long * rowCount)
   */
 STDMETHODIMP CAccTable::get_rowDescription(long row, BSTR * description)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -383,7 +383,7 @@ STDMETHODIMP CAccTable::get_rowDescription(long row, BSTR * description)
   */
 STDMETHODIMP CAccTable::get_rowExtentAt(long row, long column, long * nRowsSpanned)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -418,7 +418,7 @@ STDMETHODIMP CAccTable::get_rowExtentAt(long row, long column, long * nRowsSpann
   */
 STDMETHODIMP CAccTable::get_rowHeader(IAccessibleTable __RPC_FAR *__RPC_FAR *accessibleTable, long *startingColumnIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -475,7 +475,7 @@ STDMETHODIMP CAccTable::get_rowHeader(IAccessibleTable __RPC_FAR *__RPC_FAR *acc
   */
 STDMETHODIMP CAccTable::get_selectedRows(long, long ** rows, long * nRows)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -515,7 +515,7 @@ STDMETHODIMP CAccTable::get_selectedRows(long, long ** rows, long * nRows)
   */
 STDMETHODIMP CAccTable::get_selectedColumns(long, long ** columns, long * numColumns)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -553,7 +553,7 @@ STDMETHODIMP CAccTable::get_selectedColumns(long, long ** columns, long * numCol
   */
 STDMETHODIMP CAccTable::get_summary(IUnknown * * accessible)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -592,7 +592,7 @@ STDMETHODIMP CAccTable::get_summary(IUnknown * * accessible)
   */
 STDMETHODIMP CAccTable::get_isColumnSelected(long column, unsigned char * isSelected)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -619,7 +619,7 @@ STDMETHODIMP CAccTable::get_isColumnSelected(long column, unsigned char * isSele
   */
 STDMETHODIMP CAccTable::get_isRowSelected(long row, unsigned char * isSelected)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -648,7 +648,7 @@ STDMETHODIMP CAccTable::get_isRowSelected(long row, unsigned char * isSelected)
   */
 STDMETHODIMP CAccTable::get_isSelected(long row, long column, unsigned char * isSelected)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -675,7 +675,7 @@ STDMETHODIMP CAccTable::get_isSelected(long row, long column, unsigned char * is
   */
 STDMETHODIMP CAccTable::selectRow(long row)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -721,7 +721,7 @@ STDMETHODIMP CAccTable::selectRow(long row)
   */
 STDMETHODIMP CAccTable::selectColumn(long column)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -768,7 +768,7 @@ STDMETHODIMP CAccTable::selectColumn(long column)
   */
 STDMETHODIMP CAccTable::unselectRow(long row)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -817,7 +817,7 @@ STDMETHODIMP CAccTable::unselectRow(long row)
   */
 STDMETHODIMP CAccTable::unselectColumn(long column)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -865,7 +865,7 @@ STDMETHODIMP CAccTable::unselectColumn(long column)
  */
 STDMETHODIMP CAccTable::put_XInterface(long pXInterface)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -896,7 +896,7 @@ STDMETHODIMP CAccTable::put_XInterface(long pXInterface)
   */
 STDMETHODIMP CAccTable::get_columnIndex(long childIndex, long * columnIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -921,7 +921,7 @@ STDMETHODIMP CAccTable::get_columnIndex(long childIndex, long * columnIndex)
   */
 STDMETHODIMP CAccTable::get_rowIndex(long childIndex, long * rowIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -946,7 +946,7 @@ STDMETHODIMP CAccTable::get_rowIndex(long childIndex, long * rowIndex)
   */
 STDMETHODIMP CAccTable::get_childIndex(long RowIndex , long columnIndex, long * childIndex )
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -972,7 +972,7 @@ STDMETHODIMP CAccTable::get_rowColumnExtentsAtIndex(long,
         long  *,
         boolean  *)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -984,7 +984,7 @@ STDMETHODIMP CAccTable::get_rowColumnExtentsAtIndex(long,
 
 STDMETHODIMP CAccTable::get_modelChange(IA2TableModelChange  *)
 {
-    
+
     return E_NOTIMPL;
 }
 
@@ -993,7 +993,7 @@ STDMETHODIMP CAccTable::get_modelChange(IA2TableModelChange  *)
 //    Number of children currently selected
 STDMETHODIMP CAccTable::get_nSelectedChildren(long *childCount)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -1025,7 +1025,7 @@ STDMETHODIMP CAccTable::get_nSelectedChildren(long *childCount)
 //    Length of array (not more than maxChildren)
 STDMETHODIMP CAccTable::get_selectedChildren(long, long **children, long *nChildren)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK

--- a/main/winaccessibility/source/UAccCOM/AccText.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccText.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -35,7 +35,7 @@ using namespace com::sun::star::uno;
 */
 STDMETHODIMP CAccText::addSelection(long startOffset, long endOffset)//, unsigned char * success)
 {
-    
+
     return CAccTextBase::get_addSelection(startOffset, endOffset);//, success);
 }
 
@@ -49,7 +49,7 @@ STDMETHODIMP CAccText::addSelection(long startOffset, long endOffset)//, unsigne
 */
 STDMETHODIMP CAccText::get_attributes(long offset, long * startOffset, long * endOffset, BSTR * textAttributes)
 {
-    
+
     return CAccTextBase::get_attributes(offset, startOffset, endOffset, textAttributes);
 }
 
@@ -60,7 +60,7 @@ STDMETHODIMP CAccText::get_attributes(long offset, long * startOffset, long * en
 */
 STDMETHODIMP CAccText::get_caretOffset(long * offset)
 {
-    
+
     return CAccTextBase::get_caretOffset(offset);
 }
 
@@ -71,7 +71,7 @@ STDMETHODIMP CAccText::get_caretOffset(long * offset)
 */
 STDMETHODIMP CAccText::get_characterCount(long * nCharacters)
 {
-    
+
     return CAccTextBase::get_characterCount(nCharacters);
 }
 
@@ -86,7 +86,7 @@ STDMETHODIMP CAccText::get_characterCount(long * nCharacters)
 */
 STDMETHODIMP CAccText::get_characterExtents(long offset, IA2CoordinateType coordType, long * x, long * y, long * width, long * height)
 {
-    
+
     return CAccTextBase::get_characterExtents(offset, coordType, x, y, width, height);
 }
 
@@ -97,7 +97,7 @@ STDMETHODIMP CAccText::get_characterExtents(long offset, IA2CoordinateType coord
 */
 STDMETHODIMP CAccText::get_nSelections(long * nSelections)
 {
-    
+
     return CAccTextBase::get_nSelections(nSelections);
 }
 
@@ -112,7 +112,7 @@ STDMETHODIMP CAccText::get_nSelections(long * nSelections)
 
 STDMETHODIMP CAccText::get_offsetAtPoint(long x, long y, IA2CoordinateType coordType, long * offset)
 {
-    
+
     return CAccTextBase::get_offsetAtPoint(x, y, coordType, offset);
 }
 
@@ -125,7 +125,7 @@ STDMETHODIMP CAccText::get_offsetAtPoint(long x, long y, IA2CoordinateType coord
 */
 STDMETHODIMP CAccText::get_selection(long selection, long * startOffset, long * endOffset)
 {
-    
+
     return CAccTextBase::get_selection(selection, startOffset, endOffset);
 }
 
@@ -138,7 +138,7 @@ STDMETHODIMP CAccText::get_selection(long selection, long * startOffset, long * 
 */
 STDMETHODIMP CAccText::get_text(long startOffset, long endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_text(startOffset, endOffset, text);
 }
 
@@ -153,7 +153,7 @@ STDMETHODIMP CAccText::get_text(long startOffset, long endOffset, BSTR * text)
 */
 STDMETHODIMP CAccText::get_textBeforeOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textBeforeOffset(offset, boundaryType,
             startOffset, endOffset, text);
 }
@@ -169,7 +169,7 @@ STDMETHODIMP CAccText::get_textBeforeOffset(long offset, IA2TextBoundaryType bou
 */
 STDMETHODIMP CAccText::get_textAfterOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textAfterOffset(offset, boundaryType,
             startOffset, endOffset, text);
 }
@@ -185,7 +185,7 @@ STDMETHODIMP CAccText::get_textAfterOffset(long offset, IA2TextBoundaryType boun
 */
 STDMETHODIMP CAccText::get_textAtOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
     return CAccTextBase::get_textAtOffset(offset, boundaryType,
                                           startOffset, endOffset, text);
 }
@@ -198,7 +198,7 @@ STDMETHODIMP CAccText::get_textAtOffset(long offset, IA2TextBoundaryType boundar
 */
 STDMETHODIMP CAccText::removeSelection(long selectionIndex)//, unsigned char * success)
 {
-    
+
     return CAccTextBase::removeSelection(selectionIndex);//, success);
 }
 
@@ -210,7 +210,7 @@ STDMETHODIMP CAccText::removeSelection(long selectionIndex)//, unsigned char * s
 */
 STDMETHODIMP CAccText::setCaretOffset(long offset)
 {
-    
+
     return CAccTextBase::setCaretOffset(offset);
 }
 
@@ -225,7 +225,7 @@ STDMETHODIMP CAccText::setCaretOffset(long offset)
 
 STDMETHODIMP CAccText::setSelection(long selectionIndex, long startOffset, long endOffset)
 {
-    
+
     return CAccTextBase::setSelection(selectionIndex, startOffset,
                                       endOffset);
 }
@@ -237,7 +237,7 @@ STDMETHODIMP CAccText::setSelection(long selectionIndex, long startOffset, long 
 */
 STDMETHODIMP CAccText::get_nCharacters(long * nCharacters)
 {
-    
+
     return CAccTextBase::get_nCharacters(nCharacters);
 }
 
@@ -259,13 +259,13 @@ STDMETHODIMP CAccText::get_oldText( IA2TextSegment *oldText)
 */
 STDMETHODIMP CAccText::scrollSubstringToPoint(long startIndex, long endIndex,enum IA2CoordinateType coordinateType, long x, long y )
 {
-    
+
     return CAccTextBase::scrollSubstringToPoint(startIndex, endIndex, coordinateType, x, y);
 }
 
 STDMETHODIMP CAccText::scrollSubstringTo(long startIndex, long endIndex,enum IA2ScrollType scrollType)
 {
-    
+
     return CAccTextBase::scrollSubstringTo(startIndex, endIndex,scrollType);
 }
 
@@ -276,7 +276,6 @@ STDMETHODIMP CAccText::scrollSubstringTo(long startIndex, long endIndex,enum IA2
 */
 STDMETHODIMP CAccText::put_XInterface(long pXInterface)
 {
-    
+
     return CAccTextBase::put_XInterface(pXInterface);
 }
-

--- a/main/winaccessibility/source/UAccCOM/AccTextBase.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccTextBase.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 //////////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ CAccTextBase::~CAccTextBase()
 */
 STDMETHODIMP CAccTextBase::get_addSelection(long startOffset, long endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -99,7 +99,7 @@ STDMETHODIMP CAccTextBase::get_addSelection(long startOffset, long endOffset)
 */
 STDMETHODIMP CAccTextBase::get_attributes(long offset, long * startOffset, long * endOffset, BSTR * textAttributes)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -115,7 +115,7 @@ STDMETHODIMP CAccTextBase::get_attributes(long offset, long * startOffset, long 
     if( offset < 0 || offset > GetXInterface()->getCharacterCount() )
         return E_FAIL;
 
-	std::wstring strAttrs;  
+	std::wstring strAttrs;
 
     strAttrs += L"Version:1;";
 
@@ -222,7 +222,7 @@ STDMETHODIMP CAccTextBase::get_attributes(long offset, long * startOffset, long 
 */
 STDMETHODIMP CAccTextBase::get_caretOffset(long * offset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -249,7 +249,7 @@ STDMETHODIMP CAccTextBase::get_caretOffset(long * offset)
 */
 STDMETHODIMP CAccTextBase::get_characterCount(long * nCharacters)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -280,7 +280,7 @@ STDMETHODIMP CAccTextBase::get_characterCount(long * nCharacters)
 */
 STDMETHODIMP CAccTextBase::get_characterExtents(long offset, IA2CoordinateType coordType, long * x, long * y, long * width, long * height)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -353,7 +353,7 @@ STDMETHODIMP CAccTextBase::get_characterExtents(long offset, IA2CoordinateType c
 */
 STDMETHODIMP CAccTextBase::get_nSelections(long * nSelections)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -428,7 +428,7 @@ STDMETHODIMP CAccTextBase::get_offsetAtPoint(long x, long y, IA2CoordinateType, 
 
 STDMETHODIMP CAccTextBase::get_selection(long selectionIndex, long * startOffset, long * endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -478,7 +478,7 @@ STDMETHODIMP CAccTextBase::get_selection(long selectionIndex, long * startOffset
 */
 STDMETHODIMP CAccTextBase::get_text(long startOffset, long endOffset, BSTR * text)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -526,7 +526,7 @@ STDMETHODIMP CAccTextBase::get_text(long startOffset, long endOffset, BSTR * tex
 */
 STDMETHODIMP CAccTextBase::get_textBeforeOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -615,7 +615,7 @@ STDMETHODIMP CAccTextBase::get_textBeforeOffset(long offset, IA2TextBoundaryType
 */
 STDMETHODIMP CAccTextBase::get_textAfterOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -702,7 +702,7 @@ STDMETHODIMP CAccTextBase::get_textAfterOffset(long offset, IA2TextBoundaryType 
 */
 STDMETHODIMP CAccTextBase::get_textAtOffset(long offset, IA2TextBoundaryType boundaryType, long * startOffset, long * endOffset, BSTR * text)
 {
-    
+
 
 	CHECK_ENABLE_INF
 
@@ -788,7 +788,7 @@ STDMETHODIMP CAccTextBase::get_textAtOffset(long offset, IA2TextBoundaryType bou
 */
 STDMETHODIMP CAccTextBase::removeSelection(long selectionIndex)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -827,7 +827,7 @@ STDMETHODIMP CAccTextBase::removeSelection(long selectionIndex)
 */
 STDMETHODIMP CAccTextBase::setCaretOffset(long offset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -853,7 +853,7 @@ STDMETHODIMP CAccTextBase::setCaretOffset(long offset)
 */
 STDMETHODIMP CAccTextBase::setSelection(long, long startOffset, long endOffset)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -878,7 +878,7 @@ STDMETHODIMP CAccTextBase::setSelection(long, long startOffset, long endOffset)
 */
 STDMETHODIMP CAccTextBase::get_nCharacters(long * nCharacters)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -918,7 +918,7 @@ STDMETHODIMP CAccTextBase::get_oldText( IA2TextSegment *)
 */
 STDMETHODIMP CAccTextBase::scrollSubstringToPoint(long, long, IA2CoordinateType, long, long )
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -929,7 +929,7 @@ STDMETHODIMP CAccTextBase::scrollSubstringToPoint(long, long, IA2CoordinateType,
 
 STDMETHODIMP CAccTextBase::scrollSubstringTo(long, long, IA2ScrollType)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 
@@ -945,7 +945,7 @@ STDMETHODIMP CAccTextBase::scrollSubstringTo(long, long, IA2ScrollType)
 */
 STDMETHODIMP CAccTextBase::put_XInterface(long pXInterface)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK

--- a/main/winaccessibility/source/UAccCOM/AccValue.cpp
+++ b/main/winaccessibility/source/UAccCOM/AccValue.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -37,7 +37,7 @@ using namespace com::sun::star::uno;
 
 STDMETHODIMP CAccValue::get_currentValue(VARIANT * currentValue)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -65,7 +65,7 @@ STDMETHODIMP CAccValue::get_currentValue(VARIANT * currentValue)
    */
 STDMETHODIMP CAccValue::setCurrentValue(VARIANT value)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -146,7 +146,7 @@ STDMETHODIMP CAccValue::setCurrentValue(VARIANT value)
    */
 STDMETHODIMP CAccValue::get_maximumValue(VARIANT *maximumValue)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -173,7 +173,7 @@ STDMETHODIMP CAccValue::get_maximumValue(VARIANT *maximumValue)
    */
 STDMETHODIMP CAccValue::get_minimumValue(VARIANT *mininumValue)
 {
-    
+
 	CHECK_ENABLE_INF
 
     ENTER_PROTECTED_BLOCK
@@ -200,7 +200,7 @@ STDMETHODIMP CAccValue::get_minimumValue(VARIANT *mininumValue)
    */
 STDMETHODIMP CAccValue::put_XInterface(long pXInterface)
 {
-    
+
 
     ENTER_PROTECTED_BLOCK
 

--- a/main/winaccessibility/source/UAccCOM/CheckEnableAccessible.cpp
+++ b/main/winaccessibility/source/UAccCOM/CheckEnableAccessible.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #define WNT

--- a/main/winaccessibility/source/UAccCOM/EnumVariant.cpp
+++ b/main/winaccessibility/source/UAccCOM/EnumVariant.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"
@@ -33,7 +33,7 @@
 
 /**
    * enumarate method,get next element
-   * @param  cElements The number of elements to be returned. 
+   * @param  cElements The number of elements to be returned.
    * @param  pvar      An array of at least size celt in which the elements are to be returned.
    * @param  pcElementFetched Pointer to the number of elements returned in rgVar, or Null¡£
    * @return Result.
@@ -84,7 +84,7 @@ HRESULT STDMETHODCALLTYPE CEnumVariant::Next(ULONG cElements,VARIANT __RPC_FAR *
 
 /**
    * skip the elements in the given range when enumarate elements
-   * @param  cElements The number of elements to skip. 
+   * @param  cElements The number of elements to skip.
    * @return Result.
    */
 HRESULT STDMETHODCALLTYPE CEnumVariant::Skip(ULONG cElements)
@@ -103,7 +103,7 @@ HRESULT STDMETHODCALLTYPE CEnumVariant::Skip(ULONG cElements)
 
 /**
    * reset the enumaration position to initial value
-   * @param 
+   * @param
    * @return Result.
    */
 HRESULT STDMETHODCALLTYPE CEnumVariant::Reset( void)
@@ -115,7 +115,7 @@ HRESULT STDMETHODCALLTYPE CEnumVariant::Reset( void)
 
 /**
    *create a new IEnumVariant object,
-   *copy current enumaration container and its state to 
+   *copy current enumaration container and its state to
    *the new object
    *AT will use the copy object to get elements
    * @param ppenum On return, pointer to the location of the clone enumerator¡£

--- a/main/winaccessibility/source/UAccCOM/MAccessible.cpp
+++ b/main/winaccessibility/source/UAccCOM/MAccessible.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
-* 
+*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
@@ -7,16 +7,16 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-* 
+*
 *************************************************************/
 
 #include "stdafx.h"
@@ -74,7 +74,7 @@ long IA2_STATES[] =
 };
 /*
 
-<=== map ===>  
+<=== map ===>
 
 */
 short UNO_STATES[] =
@@ -255,7 +255,7 @@ CMAccessible::~CMAccessible()
 }
 
 /**
-* Returns the Parent IAccessible interface pointer to AT. 
+* Returns the Parent IAccessible interface pointer to AT.
 * It should add reference, and the client should release the component.
 * It should return E_FAIL when the parent point is null.
 * @param	ppdispParent [in,out] used to return the parent interface point.
@@ -295,7 +295,7 @@ STDMETHODIMP CMAccessible::get_accParent(IDispatch **ppdispParent)
 }
 
 /**
-* Returns child count of current COM object. 
+* Returns child count of current COM object.
 * @param	pcountChildren [in,out] used to return the children count.
 * @return   S_OK if successful.
 */
@@ -326,7 +326,7 @@ STDMETHODIMP CMAccessible::get_accChildCount(long *pcountChildren)
 }
 
 /**
-* Returns child interface pointer for AT according to input child ID. 
+* Returns child interface pointer for AT according to input child ID.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	ppdispChild, [in,out] use to return the child interface point.
@@ -364,7 +364,7 @@ STDMETHODIMP CMAccessible::get_accChild(VARIANT varChild, IDispatch **ppdispChil
 }
 
 /**
-* Returns the accessible name of the current COM object self or its one child to AT. 
+* Returns the accessible name of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszName, [in,out] use to return the name of the proper object.
@@ -403,7 +403,7 @@ STDMETHODIMP CMAccessible::get_accName(VARIANT varChild, BSTR *pszName)
 }
 
 /**
-* Returns the accessible value of the current COM object self or its one child to AT. 
+* Returns the accessible value of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszValue, [in,out] use to return the value of the proper object.
@@ -448,7 +448,7 @@ STDMETHODIMP CMAccessible::get_accValue(VARIANT varChild, BSTR *pszValue)
 }
 
 /**
-* Returns the accessible description of the current COM object self or its one child to AT. 
+* Returns the accessible description of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszDescription, [in,out] use to return the description of the proper object.
@@ -487,7 +487,7 @@ STDMETHODIMP CMAccessible::get_accDescription(VARIANT varChild, BSTR *pszDescrip
 }
 
 /**
-* Returns the accessible role of the current COM object self or its one child to AT. 
+* Returns the accessible role of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pvarRole, [in,out] use to return the role of the proper object.
@@ -538,7 +538,7 @@ STDMETHODIMP CMAccessible::get_accRole(VARIANT varChild, VARIANT *pvarRole)
 }
 
 /**
-* Returns the accessible state of the current COM object self or its one child to AT. 
+* Returns the accessible state of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pvarState, [in,out] use to return the state of the proper object.
@@ -597,7 +597,7 @@ STDMETHODIMP CMAccessible::get_accState(VARIANT varChild, VARIANT *pvarState)
 }
 
 /**
-* Returns the accessible helpString of the current COM object self or its one child to AT. 
+* Returns the accessible helpString of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszHelp, [in,out] use to return the helpString of the proper object.
@@ -609,7 +609,7 @@ STDMETHODIMP CMAccessible::get_accHelp(VARIANT, BSTR *)
 }
 
 /**
-* Returns the accessible HelpTopic of the current COM object self or its one child to AT. 
+* Returns the accessible HelpTopic of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszHelpFile, [in,out] use to return the HelpTopic of the proper object.
@@ -641,7 +641,7 @@ static void GetMnemonicChar( const ::rtl::OUString& aStr, WCHAR* wStr)
 }
 
 /**
-* Returns the accessible keyboard shortcut of the current COM object self or its one child to AT. 
+* Returns the accessible keyboard shortcut of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pszKeyboardShortcut, [in,out] use to return the kbshortcut of the proper object.
@@ -796,7 +796,7 @@ STDMETHODIMP CMAccessible::get_accKeyboardShortcut(VARIANT varChild, BSTR *pszKe
 }
 
 /**
-* Returns the current focused child to AT. 
+* Returns the current focused child to AT.
 * @param	pvarChild, [in,out] vt member of pvarChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @return   S_OK if successful and E_FAIL if failure.
@@ -833,7 +833,7 @@ STDMETHODIMP CMAccessible::get_accFocus(VARIANT *pvarChild)
 }
 
 /**
-* Returns the selection of the current COM object to AT. 
+* Returns the selection of the current COM object to AT.
 * @param	pvarChildren,[in,out]
 * if selection num is 0,return VT_EMPTY for vt,
 * if selection num is 1,return VT_I4 for vt,and child index for lVal
@@ -880,7 +880,7 @@ STDMETHODIMP CMAccessible::get_accSelection(VARIANT *pvarChildren)
 }
 
 /**
-* Returns the location of the current COM object self or its one child to AT. 
+* Returns the location of the current COM object self or its one child to AT.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	pxLeft, [in,out] use to return the x-coordination of the proper object.
@@ -940,7 +940,7 @@ STDMETHODIMP CMAccessible::accLocation(long *pxLeft, long *pyTop, long *pcxWidth
 }
 
 /**
-* Returns the current focused child to AT. 
+* Returns the current focused child to AT.
 * @param	navDir, the direction flag of the navigation.
 * @param	varStart, the start child id of this navigation action.
 * @param	pvarEndUpAt, [in,out] the end up child of this navigation action.
@@ -1044,7 +1044,7 @@ STDMETHODIMP CMAccessible::accHitTest(long xLeft, long yTop, VARIANT *pvarChild)
 }
 
 /**
-* Get The other Interface from CMAccessible. 
+* Get The other Interface from CMAccessible.
 * @param	guidService, must be IID_IAccessible here.
 * @param	riid, the IID interface .
 * @return   S_OK if successful and S_FALSE if failure.
@@ -1057,7 +1057,7 @@ STDMETHODIMP CMAccessible::QueryService(REFGUID guidService, REFIID riid, void**
 }
 
 /**
-* Set the accessible name of the current COM object self or its one child from UNO. 
+* Set the accessible name of the current COM object self or its one child from UNO.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	szName, the name used to set the name of the proper object.
@@ -1090,7 +1090,7 @@ STDMETHODIMP CMAccessible::put_accName(VARIANT varChild, BSTR szName)
 }
 
 /**
-* Set the accessible value of the current COM object self or its one child from UNO. 
+* Set the accessible value of the current COM object self or its one child from UNO.
 * @param	varChild, vt member of varChild must be VT_I4,and lVal member stores the child ID,
 * the child ID specify child index from 0 to children count, 0 stands for object self.
 * @param	szValue, the value used to set the value of the proper object.
@@ -1123,7 +1123,7 @@ STDMETHODIMP CMAccessible::put_accValue(VARIANT varChild, BSTR szValue)
 }
 
 /**
-* Set the accessible name of the current COM object self from UNO. 
+* Set the accessible name of the current COM object self from UNO.
 * @param	pszName, the name value used to set the name of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1148,7 +1148,7 @@ STDMETHODIMP CMAccessible::Put_XAccName(const OLECHAR __RPC_FAR *pszName)
 }
 
 /**
-* Set the accessible role of the current COM object self from UNO. 
+* Set the accessible role of the current COM object self from UNO.
 * @param	pRole, the role value used to set the role of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1159,7 +1159,7 @@ STDMETHODIMP CMAccessible::Put_XAccRole(unsigned short pRole)
 }
 
 /**
-* Add one state into the current state set for the current COM object from UNO. 
+* Add one state into the current state set for the current COM object from UNO.
 * @param	pXSate, the state used to set the name of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1170,7 +1170,7 @@ STDMETHODIMP CMAccessible::DecreaseState(DWORD pXSate)
 }
 
 /**
-* Delete one state into the current state set for the current COM object from UNO. 
+* Delete one state into the current state set for the current COM object from UNO.
 * @param	pXSate, the state used to set the name of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1181,7 +1181,7 @@ STDMETHODIMP CMAccessible::IncreaseState(DWORD pXSate)
 }
 
 /**
-* Set state into the current state set for the current COM object from UNO. 
+* Set state into the current state set for the current COM object from UNO.
 * @param	pXSate, the state used to set the name of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1194,7 +1194,7 @@ STDMETHODIMP CMAccessible::SetState(DWORD pXSate)
 
 
 /**
-* Set the accessible description of the current COM object self from UNO. 
+* Set the accessible description of the current COM object self from UNO.
 * @param	pszDescription, the name used to set the description of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1220,7 +1220,7 @@ STDMETHODIMP CMAccessible::Put_XAccDescription(const OLECHAR __RPC_FAR *pszDescr
 }
 
 /**
-* Set the accessible value of the current COM object self from UNO. 
+* Set the accessible value of the current COM object self from UNO.
 * @param	pszAccValue, the name used to set the value of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
 */
@@ -1281,8 +1281,8 @@ STDMETHODIMP CMAccessible::Put_XAccFocus(long dChildID)
 		else
 		{
 			m_dFocusChildID = dChildID;
-			//traverse all ancestors to set the focused child ID so that when the get_accFocus is called on 
-			//any of the ancestors, this id can be used to get the IAccessible of focused object. 
+			//traverse all ancestors to set the focused child ID so that when the get_accFocus is called on
+			//any of the ancestors, this id can be used to get the IAccessible of focused object.
 			if(m_pIParent)
 			{
 				m_pIParent->Put_XAccFocus(dChildID);
@@ -1306,7 +1306,7 @@ STDMETHODIMP CMAccessible::Put_XAccLocation(const Location sLocation)
 }
 
 /**
-* Set accessible parent object for the current COM object if 
+* Set accessible parent object for the current COM object if
 * the current object is a child of some COM object
 * @param	pIParent, the parent of the current object.
 * @return   S_OK if successful and E_FAIL if failure.
@@ -1346,7 +1346,7 @@ STDMETHODIMP CMAccessible::Put_XAccAgent(long pAgent)
 
 /**
 * When a UNO control disposing, it disposes its listeners,
-* then notify AccObject in bridge management, then notify 
+* then notify AccObject in bridge management, then notify
 * COM that the XAccessible is invalid,so set pUNOInterface as NULL
 * @param	isDestroy, true is it need to be destroyed.
 * @return   S_OK if successful and E_FAIL if failure.
@@ -1501,7 +1501,7 @@ IMAccessible* CMAccessible::GetNavigateChildForDM(VARIANT varCur, short flags)
 */
 
 /**
-* Return first child for parent container, process differently according 
+* Return first child for parent container, process differently according
 * to whether it is descendant manage
 * @param	varStart, the start child id of this navigation action.
 * @param	pvarEndUpAt, [in,out] the end up child of this navigation action.
@@ -1538,7 +1538,7 @@ HRESULT CMAccessible::GetFirstChild(VARIANT varStart,VARIANT* pvarEndUpAt)
 }
 
 /**
-* Return last child for parent container, process differently according 
+* Return last child for parent container, process differently according
 * to whether it is descendant manage
 * @param	varStart, the start child id of this navigation action.
 * @param	pvarEndUpAt, [in,out] the end up child of this navigation action.
@@ -2146,8 +2146,8 @@ XAccessibleContext* CMAccessible::GetContextByXAcc( XAccessible* pXAcc )
 }
 
 /**
-* Return the member variable m_pXAccessibleSelection, instead of 
-* get XAccessibleSelection according to XAccessibleContext because if so,it will 
+* Return the member variable m_pXAccessibleSelection, instead of
+* get XAccessibleSelection according to XAccessibleContext because if so,it will
 * depend on the UNO implementation code,so when COM is created, put XAccessibleSelection
 * by bridge management system
 * @return   XAccessibleSelection*, the selection of the current object.
@@ -2287,7 +2287,7 @@ STDMETHODIMP CMAccessible::SetXAccessible(long pXAcc)
 
 /**
 * accSelect method has many optional flags, needs to process comprehensively
-* Mozilla and Microsoft do not implement SELFLAG_EXTENDSELECTION flag. 
+* Mozilla and Microsoft do not implement SELFLAG_EXTENDSELECTION flag.
 * The implementation of this flag is a little trouble-shooting,so we also
 * do not implement it now
 * @param	flagsSelect, the selection flag of the select action.
@@ -3272,4 +3272,3 @@ STDMETHODIMP CMAccessible::get_attributes(/*[out]*/ BSTR *pAttr)
 	}
 	LEAVE_PROTECTED_BLOCK
 }
-

--- a/main/winaccessibility/source/UAccCOM/UAccCOM.cpp
+++ b/main/winaccessibility/source/UAccCOM/UAccCOM.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"

--- a/main/winaccessibility/source/UAccCOM/UNOXWrapper.cpp
+++ b/main/winaccessibility/source/UAccCOM/UNOXWrapper.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "stdafx.h"

--- a/main/xmerge/source/activesync/XMergeFactory.cpp
+++ b/main/xmerge/source/activesync/XMergeFactory.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // XMergeFactory.cpp: implementation of the CXMergeFactory class.
@@ -29,14 +29,14 @@
 #include "XMergeFactory.h"
 
 //////////////////////////////////////////////////////////////////////
-// IUnknown implementation 
-//////////////////////////////////////////////////////////////////////																		 
-STDMETHODIMP CXMergeFactory::QueryInterface(REFIID riid, void **ppvObject)  
+// IUnknown implementation
+//////////////////////////////////////////////////////////////////////
+STDMETHODIMP CXMergeFactory::QueryInterface(REFIID riid, void **ppvObject)
 {
 	if(ppvObject == NULL)
 		return E_INVALIDARG;
 
-    if(::IsEqualIID(riid, IID_IUnknown) || ::IsEqualIID(riid, IID_IClassFactory)) 
+    if(::IsEqualIID(riid, IID_IUnknown) || ::IsEqualIID(riid, IID_IClassFactory))
 	{
         *ppvObject = static_cast<IClassFactory*>(this);
 	}
@@ -57,7 +57,7 @@ STDMETHODIMP_(ULONG) CXMergeFactory::AddRef()
 }
 
 
-STDMETHODIMP_(ULONG) CXMergeFactory::Release() 
+STDMETHODIMP_(ULONG) CXMergeFactory::Release()
 {
 	if(::InterlockedDecrement(&m_cRef) == 0)
 	{
@@ -70,20 +70,20 @@ STDMETHODIMP_(ULONG) CXMergeFactory::Release()
 
 
 //////////////////////////////////////////////////////////////////////
-// IUnknown implementation 
-//////////////////////////////////////////////////////////////////////																		 
+// IUnknown implementation
+//////////////////////////////////////////////////////////////////////
 STDMETHODIMP CXMergeFactory::CreateInstance(IUnknown *pUnkOuter, REFIID iid, void **ppvObject)
 {
 	if (ppvObject == NULL)
 		return E_INVALIDARG;
-    
+
 	if (pUnkOuter != NULL)	// cannot aggregate
 	{
 		*ppvObject = NULL;
 		return CLASS_E_NOAGGREGATION;
 	}
 
-	if (iid == IID_ICeFileFilter) 
+	if (iid == IID_ICeFileFilter)
 	{
 		CXMergeFilter *pFilter = new CXMergeFilter();
 		if(pFilter == NULL)
@@ -107,5 +107,3 @@ STDMETHODIMP CXMergeFactory::LockServer(BOOL fLock)
 	_Module.LockServer(fLock);
     return S_OK;
 }
-
-

--- a/main/xmerge/source/activesync/XMergeFilter.cpp
+++ b/main/xmerge/source/activesync/XMergeFilter.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 // XMergeFilter.cpp: implementation of the CXMergeFilter class.
@@ -35,7 +35,7 @@
 #define ERR_BADCLASSPATH 2
 #define ERR_INITJAVA     3
 
-                      
+
 const LPTSTR CXMergeFilter::m_pszPSWExportCLSID		= _T("{BDD611C3-7BAB-460F-8711-5B9AC9EF6020}");
 const LPTSTR CXMergeFilter::m_pszPSWExportExt		= _T("sxw");
 const LPTSTR CXMergeFilter::m_pszPSWExportDesc		= _T("OpenOffice.org XML Writer Document");
@@ -107,7 +107,7 @@ STDMETHODIMP CXMergeFilter::QueryInterface(REFIID riid, void **ppvObject)
 		*ppvObject = NULL;
 		return E_NOINTERFACE;
 	}
-	
+
 	reinterpret_cast<IUnknown *>(*ppvObject)->AddRef();
 	return S_OK;
 }
@@ -140,12 +140,12 @@ STDMETHODIMP CXMergeFilter::FilterOptions(HWND hwndParent)
 	return HRESULT_FROM_WIN32(NOERROR);
 }
 
-STDMETHODIMP CXMergeFilter::FormatMessage(DWORD dwFlags, DWORD dwMessageId, 
-						DWORD dwLanguageId, LPTSTR lpBuffer, DWORD nSize, 
+STDMETHODIMP CXMergeFilter::FormatMessage(DWORD dwFlags, DWORD dwMessageId,
+						DWORD dwLanguageId, LPTSTR lpBuffer, DWORD nSize,
 						va_list *Arguments, DWORD *pcb)
 {
 	TCHAR errMsg[1024];
-	
+
 	HKEY  hKey   = NULL;
 	DWORD dwSize = 1024;
 
@@ -155,12 +155,12 @@ STDMETHODIMP CXMergeFilter::FormatMessage(DWORD dwFlags, DWORD dwMessageId,
 	// Attempt to find the messages in the registry
 	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Sun Microsystems\\StarOffice\\XMergeSync\\Messages\\Error"),
 							0, KEY_READ, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 	{
 		// Try the user's portion of the registry
 		lRet = ::RegOpenKeyEx(HKEY_CURRENT_USER, _T("Software\\Sun Microsystems\\StarOffice\\XMergeSync\\Messages\\Error"),
 							0, KEY_READ, &hKey);
-		if (lRet != ERROR_SUCCESS) 
+		if (lRet != ERROR_SUCCESS)
 		{
 			hKey = NULL;
 		}
@@ -204,24 +204,24 @@ STDMETHODIMP CXMergeFilter::FormatMessage(DWORD dwFlags, DWORD dwMessageId,
 }
 
 
-STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pci, 
-							 CFF_SOURCEFILE *psf, CFF_DESTINATIONFILE *pdf, 
+STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pci,
+							 CFF_SOURCEFILE *psf, CFF_DESTINATIONFILE *pdf,
 							 volatile BOOL *pbCancel, CF_ERROR *perr)
 {
 	std::string appArgs;
-	std::string appName; 
+	std::string appName;
 
 	STARTUPINFO si;
     PROCESS_INFORMATION pi;
 
     ZeroMemory( &si, sizeof(si) );
 	ZeroMemory( &pi, sizeof(pi) );
-    
+
 	si.cb = sizeof(si);
 
 
 	/*
-	 * First step: Locate Java and establish the classpath.  If these can't 
+	 * First step: Locate Java and establish the classpath.  If these can't
 	 *             be done successfully, then avoid all further processing.
 	 */
 
@@ -232,7 +232,7 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 
 		if (m_szJavaBaseDir == NULL)
 		{
-			*perr = ERR_NOJAVA;		
+			*perr = ERR_NOJAVA;
 			return HRESULT_FROM_WIN32(E_FAIL);
 		}
 	}
@@ -241,7 +241,7 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 	if (m_szClasspath == NULL)
 	{
 		m_szClasspath = GetXMergeClassPath();
-		
+
 		if (m_szClasspath == NULL)
 		{
 			*perr = ERR_BADCLASSPATH;
@@ -251,7 +251,7 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 
 
 	/*
-	 * Second step:  Check the files we're going to process.  If we don't have 
+	 * Second step:  Check the files we're going to process.  If we don't have
 	 *				 an XMerge plugin for the file then we can't convert.
 	 */
 	if ((!lstrcmp(psf->szExtension, "sxw")  || !lstrcmp(psf->szExtension, "psw"))
@@ -266,7 +266,7 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 		*perr = ERR_BADCLASSPATH;
 		return HRESULT_FROM_WIN32(E_FAIL);
 	}
-	
+
 
 	/*
 	 * Third step:  Locate the Java executable and build and execute the command
@@ -288,8 +288,8 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 	appName.append("\"");
 
 
-	
-	// Need to build the entire command line for calling out to Java	
+
+	// Need to build the entire command line for calling out to Java
 	appArgs = appName;
         if (*m_szClasspath) {
             appArgs += " -Djava.class.path=";
@@ -334,7 +334,7 @@ STDMETHODIMP CXMergeFilter::NextConvertFile(int nConversion, CFF_CONVERTINFO *pc
 				  CREATE_NO_WINDOW,	// No console
 				  NULL,				// No special environment
 				  NULL,				// Current Working Directory is okay
-				  &si,			
+				  &si,
 				  &pi))
 	{
 		*perr = ERR_INITJAVA;
@@ -360,7 +360,7 @@ TCHAR* CXMergeFilter::GetJavaBaseDir()
 
 	HKEY hKey = NULL;
 	HKEY hDataKey = NULL;
-	
+
 	TCHAR szClassName[_MAX_PATH] = "\0";
 	TCHAR szKeyName[_MAX_PATH]   = "\0";
     TCHAR szCurrentJava[_MAX_PATH] = "\0";
@@ -382,7 +382,7 @@ TCHAR* CXMergeFilter::GetJavaBaseDir()
 
     /* use current version */
     lRet = ::RegQueryValueEx(hKey, _T("CurrentVersion"), 0, NULL, (LPBYTE)szCurrentJava, &dwSize);
-    
+
     /*
 	for (DWORD i = 0; lRet != ERROR_NO_MORE_ITEMS; i++)
 	{
@@ -393,8 +393,8 @@ TCHAR* CXMergeFilter::GetJavaBaseDir()
 	}
     // Found a Java 1.4 installation.  Can now read its home directory.
     */
-	
-    
+
+
 	lRet = ::RegOpenKeyEx(hKey, _T(szCurrentJava), 0, KEY_READ, &hDataKey);
 	if (lRet != ERROR_SUCCESS)
 	{
@@ -418,7 +418,7 @@ TCHAR* CXMergeFilter::GetJavaBaseDir()
 	RegCloseKey(hDataKey);
 	RegCloseKey(hKey);
 
-	
+
 	// Check that the directory exists before returning it
 	DWORD dwAttrs = GetFileAttributes(szJavaHome);
 
@@ -437,7 +437,7 @@ TCHAR* CXMergeFilter::GetXMergeClassPath()
 {
 	/*
 	 * The DLL will be installed by setup in the program directory of
-	 * the installation.  The XMerge Jar files, if present, will be 
+	 * the installation.  The XMerge Jar files, if present, will be
 	 * located in the classes directory below program.
 	 */
 
@@ -472,7 +472,7 @@ TCHAR* CXMergeFilter::GetXMergeClassPath()
 	{
 		return NULL;
 	}
-	else 
+	else
 	{
 		clsPath += szTmpPath;
 		clsPath += ";";

--- a/main/xmerge/source/activesync/XMergeSync.cpp
+++ b/main/xmerge/source/activesync/XMergeSync.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -59,7 +59,7 @@ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
 {
 	// Create the factory object
 	CXMergeFactory *pFactory = new CXMergeFactory();
-	if (pFactory == NULL) 
+	if (pFactory == NULL)
 	{
 		*ppv = NULL;
 		return E_OUTOFMEMORY;
@@ -72,7 +72,7 @@ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
 }
 
 
-STDAPI DllCanUnloadNow() 
+STDAPI DllCanUnloadNow()
 {
 	if (_Module.GetLockCount() == 0)
 		return S_OK;
@@ -87,10 +87,10 @@ static _signalRegError(long lRet, HKEY hKey, HKEY hDataKey)
 	if (hKey)
 		::RegCloseKey(hKey);
 
-	
+
 	if (hDataKey)
 		::RegCloseKey(hDataKey);
-	
+
 	return HRESULT_FROM_WIN32(lRet);
 }
 
@@ -99,7 +99,7 @@ STDAPI DllRegisterServer()
 {
 	HKEY hKey = NULL;
 	HKEY hDataKey = NULL;
-	
+
 	long lRet = 0;
 	TCHAR sTemp[_MAX_PATH + 1] = "\0";
 
@@ -107,23 +107,23 @@ STDAPI DllRegisterServer()
 	/*
 	 * Following calls create the HKEY_CLASSES_ROOT\CLSID entry for the Writer export filter.
 	 *
-	 * Note that import are export are relative to the WinCE device, so files are 
+	 * Note that import are export are relative to the WinCE device, so files are
 	 * exported to the desktop format.
 	 */
 
 	// Get a handle to the CLSID key
 	lRet = ::RegOpenKeyEx(HKEY_CLASSES_ROOT, _T("CLSID"), 0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Create the CLSID key for the XMergeFilter
 	lRet = ::RegCreateKeyEx(hKey, CXMergeFilter::m_pszPSWExportCLSID, 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hKey, _T(""), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWExportShortDesc,
 				(::_tcslen(CXMergeFilter::m_pszPSWExportShortDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -133,7 +133,7 @@ STDAPI DllRegisterServer()
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"),
-							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0")) 
+							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"))
 							   * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
@@ -141,48 +141,48 @@ STDAPI DllRegisterServer()
 
 	// Create the InprocServer32 key
 	lRet = ::RegCreateKeyEx(hKey, _T("InProcServer32"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, _T("ThreadingModel"), 0, REG_SZ, (LPBYTE)_T("Apartment"), 10);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
-	
+
 	// Create the key for the DLL file.  First find the filename of the dll
 	if (!::GetModuleFileName((HMODULE)_Module.m_hInst, sTemp, (_MAX_PATH + 1)))
 	{
 		lRet = ::GetLastError();
-		if (lRet != ERROR_SUCCESS) 
-			return _signalRegError(lRet, hKey, hDataKey);	
+		if (lRet != ERROR_SUCCESS)
+			return _signalRegError(lRet, hKey, hDataKey);
 	}
-	
-	
-	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp, 
+
+
+	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp,
 				(::_tcslen(sTemp) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
 
 	// Setup the PegasusFilter key values
 	lRet = ::RegCreateKeyEx(hKey, _T("PegasusFilter"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, _T("Description"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWExportDesc,
 				(::_tcslen(CXMergeFilter::m_pszPSWExportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("Export"), 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("NewExtension"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWExportExt,
 				(::_tcslen(CXMergeFilter::m_pszPSWExportExt) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -193,23 +193,23 @@ STDAPI DllRegisterServer()
 
 
 	/*
-	 * Following calls create the entries for the filter in 
+	 * Following calls create the entries for the filter in
 	 * HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows CE Services\Filters
 	 */
 
-	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"), 
+	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"),
 				0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	_snprintf(sTemp, _MAX_PATH + 1, "%c%s\\InstalledFilters\0", '.', CXMergeFilter::m_pszPSWImportExt);
-	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 
+	lRet = ::RegCreateKeyEx(hKey, _T(sTemp),
 				0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, CXMergeFilter::m_pszPSWExportCLSID, 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hKey);		hKey = NULL;
@@ -220,22 +220,22 @@ STDAPI DllRegisterServer()
 	/*
 	 * Following calls create the HKEY_CLASSES_ROOT\CLSID entry for the Writer import filter.
 	 *
-	 * Note that import are export are relative to the WinCE device, so files are 
+	 * Note that import are export are relative to the WinCE device, so files are
 	 * exported to the desktop format.
 	 */
 	// Get a handle to the CLSID key
 	lRet = ::RegOpenKeyEx(HKEY_CLASSES_ROOT, _T("CLSID"), 0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Create the CLSID key for the XMergeFilter
 	lRet = ::RegCreateKeyEx(hKey, CXMergeFilter::m_pszPSWImportCLSID, 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hKey, _T(""), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWImportShortDesc,
 				(::_tcslen(CXMergeFilter::m_pszPSWImportShortDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -245,20 +245,20 @@ STDAPI DllRegisterServer()
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"),
-							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0")) 
+							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"))
 							   * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);  hDataKey = NULL;
 
-	
+
 	// Create the InprocServer32 key
 	lRet = ::RegCreateKeyEx(hKey, _T("InProcServer32"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, _T("ThreadingModel"), 0, REG_SZ, (LPBYTE)_T("Apartment"), 10);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -266,37 +266,37 @@ STDAPI DllRegisterServer()
 	if (!::GetModuleFileName((HMODULE)_Module.m_hInst, sTemp, (_MAX_PATH + 1)))
 	{
 		lRet = ::GetLastError();
-		if (lRet != ERROR_SUCCESS) 
-			return _signalRegError(lRet, hKey, hDataKey);	
+		if (lRet != ERROR_SUCCESS)
+			return _signalRegError(lRet, hKey, hDataKey);
 	}
-	
-	
-	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp, 
+
+
+	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp,
 				(::_tcslen(sTemp) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
 
 	// Setup the PegasusFilter key values
 	lRet = ::RegCreateKeyEx(hKey, _T("PegasusFilter"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 		lRet = ::RegSetValueEx(hDataKey, _T("Description"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWImportDesc,
 				(::_tcslen(CXMergeFilter::m_pszPSWImportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("Import"), 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("NewExtension"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPSWImportExt,
 				(::_tcslen(CXMergeFilter::m_pszPSWImportExt) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -305,44 +305,44 @@ STDAPI DllRegisterServer()
 
 
 	/*
-	 * Following calls create the entries for the filter in 
+	 * Following calls create the entries for the filter in
 	 * HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows CE Services\Filters
 	 */
-	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"), 
+	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"),
 				0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Add in defaults for import and export
 	_snprintf(sTemp, _MAX_PATH +1, "%c%s\0", '.', CXMergeFilter::m_pszPSWExportExt);
 	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
-	lRet = ::RegSetValueEx(hDataKey, _T("DefaultImport"), 0, REG_SZ, 
-							(LPBYTE)CXMergeFilter::m_pszPSWImportCLSID, 
+	lRet = ::RegSetValueEx(hDataKey, _T("DefaultImport"), 0, REG_SZ,
+							(LPBYTE)CXMergeFilter::m_pszPSWImportCLSID,
 							(::_tcslen(CXMergeFilter::m_pszPSWImportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("DefaultExport"), 0, REG_SZ, (LPBYTE)_T("Binary Copy"),
 							(::_tcslen(_T("Binary Copy")) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hDataKey);
-							
+
 	// Update registered filters
 	_snprintf(sTemp, _MAX_PATH + 1, "%c%s\\InstalledFilters\0", '.', CXMergeFilter::m_pszPSWExportExt);
-	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 
+	lRet = ::RegCreateKeyEx(hKey, _T(sTemp),
 				0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
-	
+
 	lRet = ::RegSetValueEx(hDataKey, CXMergeFilter::m_pszPSWImportCLSID, 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hKey);		hKey = NULL;
@@ -353,24 +353,24 @@ STDAPI DllRegisterServer()
 	/*
 	 * Following calls create the HKEY_CLASSES_ROOT\CLSID entry for the Calc export filter.
 	 *
-	 * Note that import are export are relative to the WinCE device, so files are 
+	 * Note that import are export are relative to the WinCE device, so files are
 	 * exported to the desktop format.
 	 */
 
 	// Get a handle to the CLSID key
 	lRet = ::RegOpenKeyEx(HKEY_CLASSES_ROOT, _T("CLSID"), 0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Create the CLSID key for the XMerge Filter
-	lRet = ::RegCreateKeyEx(hKey, CXMergeFilter::m_pszPXLExportCLSID, 0, _T(""), 
+	lRet = ::RegCreateKeyEx(hKey, CXMergeFilter::m_pszPXLExportCLSID, 0, _T(""),
 								0, KEY_ALL_ACCESS, NULL, &hKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hKey, _T(""), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLExportShortDesc,
 				(::_tcslen(CXMergeFilter::m_pszPXLExportShortDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -380,7 +380,7 @@ STDAPI DllRegisterServer()
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"),
-							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0")) 
+							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"))
 							   * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
@@ -389,49 +389,49 @@ STDAPI DllRegisterServer()
 
 	// Create the InprocServer32 key
 	lRet = ::RegCreateKeyEx(hKey, _T("InProcServer32"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, _T("ThreadingModel"), 0, REG_SZ, (LPBYTE)_T("Apartment"), 10);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
-	
+
 	// Create the key for the DLL file.  First find the filename of the dll
 	if (!::GetModuleFileName((HMODULE)_Module.m_hInst, sTemp, (_MAX_PATH + 1)))
 	{
 		lRet = ::GetLastError();
-		if (lRet != ERROR_SUCCESS) 
-			return _signalRegError(lRet, hKey, hDataKey);	
+		if (lRet != ERROR_SUCCESS)
+			return _signalRegError(lRet, hKey, hDataKey);
 	}
-	
-	
-	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp, 
+
+
+	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp,
 				(::_tcslen(sTemp) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
 
 	// Setup the PegasusFilter key values
 	lRet = ::RegCreateKeyEx(hKey, _T("PegasusFilter"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 		lRet = ::RegSetValueEx(hDataKey, _T("Description"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLExportDesc,
 				(::_tcslen(CXMergeFilter::m_pszPXLExportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("Export"), 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("NewExtension"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLExportExt,
 				(::_tcslen(CXMergeFilter::m_pszPXLExportExt) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -442,23 +442,23 @@ STDAPI DllRegisterServer()
 
 
 	/*
-	 * Following calls create the entries for the filter in 
+	 * Following calls create the entries for the filter in
 	 * HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows CE Services\Filters
 	 */
 
-	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"), 
+	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"),
 				0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	_snprintf(sTemp, _MAX_PATH + 1, "%c%s\\InstalledFilters\0", '.', CXMergeFilter::m_pszPXLImportExt);
-	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 
+	lRet = ::RegCreateKeyEx(hKey, _T(sTemp),
 				0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, CXMergeFilter::m_pszPXLExportCLSID, 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hKey);		hKey = NULL;
@@ -469,23 +469,23 @@ STDAPI DllRegisterServer()
 	/*
 	 * Following calls create the HKEY_CLASSES_ROOT\CLSID entry for the Calc import filter.
 	 *
-	 * Note that import are export are relative to the WinCE device, so files are 
+	 * Note that import are export are relative to the WinCE device, so files are
 	 * exported to the desktop format.
 	 */
 	// Get a handle to the CLSID key
 	lRet = ::RegOpenKeyEx(HKEY_CLASSES_ROOT, _T("CLSID"), 0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	// Create the CLSID key for the XMergeFilter
 	lRet = ::RegCreateKeyEx(hKey, CXMergeFilter::m_pszPXLImportCLSID, 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hKey, _T(""), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLImportShortDesc,
 				(::_tcslen(CXMergeFilter::m_pszPXLImportShortDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Create the DefaultIcon key.  For the moment, use one of the Async supplied ones
@@ -494,20 +494,20 @@ STDAPI DllRegisterServer()
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"),
-							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0")) 
+							(::_tcslen(_T("C:\\Program Files\\Microsoft ActiveSync\\pwdcnv.dll,0"))
 							   * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);  hDataKey = NULL;
 
-	
+
 	// Create the InprocServer32 key
 	lRet = ::RegCreateKeyEx(hKey, _T("InProcServer32"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, _T("ThreadingModel"), 0, REG_SZ, (LPBYTE)_T("Apartment"), 10);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -515,37 +515,37 @@ STDAPI DllRegisterServer()
 	if (!::GetModuleFileName((HMODULE)_Module.m_hInst, sTemp, (_MAX_PATH + 1)))
 	{
 		lRet = ::GetLastError();
-		if (lRet != ERROR_SUCCESS) 
-			return _signalRegError(lRet, hKey, hDataKey);	
+		if (lRet != ERROR_SUCCESS)
+			return _signalRegError(lRet, hKey, hDataKey);
 	}
-	
-	
-	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp, 
+
+
+	lRet = ::RegSetValueEx(hDataKey, NULL, 0, REG_SZ, (LPBYTE)sTemp,
 				(::_tcslen(sTemp) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
 
 	// Setup the PegasusFilter key values
 	lRet = ::RegCreateKeyEx(hKey, _T("PegasusFilter"), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 		lRet = ::RegSetValueEx(hDataKey, _T("Description"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLImportDesc,
 				(::_tcslen(CXMergeFilter::m_pszPXLImportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("Import"), 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("NewExtension"), 0, REG_SZ, (LPBYTE)CXMergeFilter::m_pszPXLImportExt,
 				(::_tcslen(CXMergeFilter::m_pszPXLImportExt) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
@@ -555,45 +555,45 @@ STDAPI DllRegisterServer()
 
 
 	/*
-	 * Following calls create the entries for the filter in 
+	 * Following calls create the entries for the filter in
 	 * HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows CE Services\Filters
 	 */
-	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"), 
+	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"),
 				0, KEY_ALL_ACCESS, &hKey);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	// Add in defaults for import and export
 	_snprintf(sTemp, _MAX_PATH +1, "%c%s\0", '.', CXMergeFilter::m_pszPXLExportExt);
 	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
-	lRet = ::RegSetValueEx(hDataKey, _T("DefaultImport"), 0, REG_SZ, 
-							(LPBYTE)CXMergeFilter::m_pszPXLImportCLSID, 
+	lRet = ::RegSetValueEx(hDataKey, _T("DefaultImport"), 0, REG_SZ,
+							(LPBYTE)CXMergeFilter::m_pszPXLImportCLSID,
 							(::_tcslen(CXMergeFilter::m_pszPSWImportDesc) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 
 	lRet = ::RegSetValueEx(hDataKey, _T("DefaultExport"), 0, REG_SZ, (LPBYTE)_T("Binary Copy"),
 							(::_tcslen(_T("Binary Copy")) * sizeof(TCHAR) + (1 * sizeof(TCHAR))));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hDataKey);
-							
+
 	// Update registered filters
 
 
 	_snprintf(sTemp, _MAX_PATH + 1, "%c%s\\InstalledFilters\0", '.', CXMergeFilter::m_pszPXLExportExt);
-	lRet = ::RegCreateKeyEx(hKey, _T(sTemp), 
+	lRet = ::RegCreateKeyEx(hKey, _T(sTemp),
 				0, _T(""), 0, KEY_ALL_ACCESS, NULL, &hDataKey, NULL);
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	lRet = ::RegSetValueEx(hDataKey, CXMergeFilter::m_pszPXLImportCLSID, 0, REG_SZ, (LPBYTE)_T(""), (1 * sizeof(TCHAR)));
-	if (lRet != ERROR_SUCCESS) 
+	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hKey);		hKey = NULL;
@@ -610,7 +610,7 @@ STDAPI DllUnregisterServer()
 	long lRet = 0;
 	HKEY hKey = NULL;
 	HKEY hDataKey = NULL;
-	
+
 	TCHAR szClassName[_MAX_PATH] = "\0";
 	TCHAR szKeyName[_MAX_PATH]   = "\0";
 	DWORD dwClassName            = _MAX_PATH;
@@ -728,13 +728,13 @@ STDAPI DllUnregisterServer()
 		return _signalRegError(lRet, hKey, hDataKey);
 
 	::RegCloseKey(hKey);  hKey = NULL;
-		
+
 
 
 	/*
 	 * Remove the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows CE Services\Filters
 	 */
-	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"), 
+	lRet = ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows CE Services\\Filters"),
 							0, KEY_ALL_ACCESS, &hKey);
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
@@ -749,7 +749,7 @@ STDAPI DllUnregisterServer()
 	lRet = ::RegDeleteValue(hDataKey, CXMergeFilter::m_pszPSWExportCLSID);
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
-	
+
 	::lstrcpyn(szKeyName, "\0", _MAX_PATH);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
@@ -792,7 +792,7 @@ STDAPI DllUnregisterServer()
 	lRet = ::RegDeleteValue(hDataKey, CXMergeFilter::m_pszPXLExportCLSID);
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
-	
+
 	::lstrcpyn(szKeyName, "\0", _MAX_PATH);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
@@ -805,7 +805,7 @@ STDAPI DllUnregisterServer()
 	lRet = ::RegDeleteValue(hDataKey, CXMergeFilter::m_pszPXLImportCLSID);
 	if (lRet != ERROR_SUCCESS)
 		return _signalRegError(lRet, hKey, hDataKey);
-	
+
 	::lstrcpyn(szKeyName, "\0", _MAX_PATH);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
@@ -824,22 +824,22 @@ STDAPI DllUnregisterServer()
 	::lstrcpyn(szKeyName, "\0", _MAX_PATH);
 	::RegCloseKey(hDataKey);	hDataKey = NULL;
 
-	
+
 
 	::RegCloseKey(hKey);		hKey	 = NULL;
-	
+
 	return HRESULT_FROM_WIN32(lRet);
-} 
+}
 
 
 //////////////////////////////////////////////////////////////////////
 // CXMergeSyncModule methods
 //////////////////////////////////////////////////////////////////////
-CXMergeSyncModule::CXMergeSyncModule () 
+CXMergeSyncModule::CXMergeSyncModule ()
 {
 }
 
-CXMergeSyncModule::~CXMergeSyncModule () 
+CXMergeSyncModule::~CXMergeSyncModule ()
 {
 }
 
@@ -855,4 +855,3 @@ long CXMergeSyncModule::GetLockCount()
 {
 	return m_lLocks + m_lObjs;
 }
-

--- a/main/xmerge/source/activesync/stdafx.cpp
+++ b/main/xmerge/source/activesync/stdafx.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 //
@@ -25,4 +25,3 @@
 //	stdafx.obj will contain the pre-compiled type information
 //
 #include "stdafx.h"
-

--- a/main/xmerge/source/regutil/regutil.cpp
+++ b/main/xmerge/source/regutil/regutil.cpp
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 /*
@@ -44,12 +44,12 @@ int main(int argc, char* argv[])
 		return -1;
 	}
 
-	
+
 	if (argc == 3)
 	{
 		if (strcmp("/u", argv[1]))
 		{
-			printf("\nUnrecognised option: %s\n", argv[1]); 
+			printf("\nUnrecognised option: %s\n", argv[1]);
 			return -1;
 		}
 
@@ -57,34 +57,34 @@ int main(int argc, char* argv[])
 		nPathIndex = 2;
 	}
 
-	
+
 	// Dynamically load the library
 	HMODULE hmXMDll = LoadLibrary(argv[nPathIndex]);
 
-	if (hmXMDll == NULL) 
+	if (hmXMDll == NULL)
 	{
 		printf("\nUnable to load the library %s\n", argv[nPathIndex]);
 		return -1;
 	}
 
-	
+
 	// Get an offset to the either the DllRegisterServer or DllUnregisterServer functions
-	if (!bUninstall) 
+	if (!bUninstall)
 	{
 		printf("\nRegistering %s ... ", argv[nPathIndex]);
 
 		DLLREGISTERSERVER DllRegisterServer = (DLLREGISTERSERVER)GetProcAddress(hmXMDll, "DllRegisterServer");
-		
+
 		if (DllRegisterServer == NULL)
 		{
 			printf("failed.\n\nDllRegisterServer is not present in library.\n");
 			return -1;
-		}	
+		}
 
 		// Now call the procedure ...
 		HRESULT regResult = DllRegisterServer() ;
 
-		if (regResult != S_OK) 
+		if (regResult != S_OK)
 		{
 			printf("failed.\n");
 			return -1;
@@ -100,12 +100,12 @@ int main(int argc, char* argv[])
 		{
 			printf("failed.\n\nDllUnregisterServer is not present in library.\n");
 			return -1;
-		}	
+		}
 
 		// Now call the procedure ...
 		HRESULT regResult = DllUnregisterServer() ;
 
-		if (regResult != S_OK) 
+		if (regResult != S_OK)
 		{
 			printf("failed.\n");
 			return -1;
@@ -118,6 +118,6 @@ int main(int argc, char* argv[])
 
 	// Clean up
 	FreeLibrary(hmXMDll);
-	
+
 	return 0;
 }


### PR DESCRIPTION
For `cpp` files enforced three hooks

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace