### PR TITLE
linter.yml: bump `actions/cache` and `actions/checkout`

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check Out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
       - name: Set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
Both actions moved up one version

https://github.com/actions/checkout

https://github.com/actions/cache