### PR TITLE
Update servicemanager.cxx: Fix `unique` word

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -2951,7 +2951,6 @@ ue
 ues
 uesd
 uhandled
-uique
 uknown
 ultimatly
 ummark

--- a/main/stoc/source/servicemanager/servicemanager.cxx
+++ b/main/stoc/source/servicemanager/servicemanager.cxx
@@ -569,7 +569,7 @@ public:
     virtual Reference<XInterface > SAL_CALL createInstance(const OUString &) throw(::com::sun::star::uno::Exception, ::com::sun::star::uno::RuntimeException);
     virtual Reference<XInterface > SAL_CALL createInstanceWithArguments(const OUString &, const Sequence<Any >& Arguments) throw(::com::sun::star::uno::Exception, ::com::sun::star::uno::RuntimeException);
 
-	// The same as the getAvailableServiceNames, but only uique names
+	// The same as the getAvailableServiceNames, but only unique names
 	Sequence< OUString > getUniqueAvailableServiceNames(
         HashSet_OWString & aNameSet );
 


### PR DESCRIPTION
This pull request updates `servicemanager.cxx` to fix the usage of a unique word, ensuring consistency and correctness in the codebase.

## Changes

Modified: main/stoc/source/servicemanager/servicemanager.cxx

---

Addressed wording issue for improved clarity and accuracy.

## Additional Notes

This change is minor but helps maintain consistency across the project.