### PR TITLE
Add manual hook `chmod` to set file permissions for `md` files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,3 +45,5 @@ jobs:
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: pre-commit run --all-files
+      - name: Run pre-commit manual stages
+        run: pre-commit run --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
+      - id: chmod
+        name: set file permissions
+        args: ['644']
+        files: \.md$
+        stages: [manual]
       - id: insert-license
         name: add license for all Markdown files
         files: \.md$


### PR DESCRIPTION
chmod is not available on standard Windows so set this hook to manual.

Linux and macOS users can run this hook locally for a full repository clean up.

Also added the manual stage hook to GitHub Actions so we don't lose coverage

Example usage:

https://github.com/Lucas-C/pre-commit-hooks?tab=readme-ov-file#usage

https://github.com/apache/sedona/blob/3a1e9b7515b4dea994969f7f3c9ff43cf700e177/.pre-commit-config.yaml#L81

Finally renamed the workflow `linter.yml` to `pre-commit.yml`