### PR TITLE
Fix update-related issues due to GUI functions in secondary threads

### DIFF
--- a/main/extensions/prj/build.lst
+++ b/main/extensions/prj/build.lst
@@ -1,4 +1,4 @@
-ex  extensions :  officecfg  L10N:l10n rdbmaker svx SANE:sane TWAIN:twain offapi stoc ZLIB:zlib CURL:curl LIBXSLT:libxslt NULL
+ex  extensions :  officecfg  L10N:l10n rdbmaker svx SANE:sane TWAIN:twain offapi stoc vcl ZLIB:zlib CURL:curl LIBXSLT:libxslt NULL
 
 ex  extensions                                  usr1    -   all ex_mkout NULL
 ex  extensions\inc                              nmake   -   all ex_inc NULL

--- a/main/extensions/source/update/check/Jobs.xcu
+++ b/main/extensions/source/update/check/Jobs.xcu
@@ -57,10 +57,5 @@
 		</node>
 	</node>
 	<node oor:name="Events">
-		<node oor:name="onFirstVisibleTask" oor:op="fuse">
-			<node oor:name="JobList">
-				<node oor:name="UpdateCheck" oor:op="replace"/>
-			</node>
-		</node>
 	</node>
 </oor:component-data>

--- a/main/extensions/source/update/check/makefile.mk
+++ b/main/extensions/source/update/check/makefile.mk
@@ -86,7 +86,8 @@ SHL1STDLIBS=    \
         $(CURLLIB) \
         $(SALLIB) \
         $(SHELL32LIB) \
-        $(OLE32LIB)
+        $(OLE32LIB) \
+        $(VCLLIB)
 
 SHL1VERSIONMAP=$(SOLARENV)/src/component.map
 SHL1DEF=$(MISC)$/$(SHL1TARGET).def

--- a/main/extensions/source/update/check/updatecheckjob.cxx
+++ b/main/extensions/source/update/check/updatecheckjob.cxx
@@ -49,25 +49,6 @@ namespace uno = com::sun::star::uno ;
 namespace
 {
 
-class InitUpdateCheckJobThread : public osl::Thread
-{
-public:
-    InitUpdateCheckJobThread( const uno::Reference< uno::XComponentContext > &xContext,
-                              const uno::Sequence< beans::NamedValue > &xParameters,
-                              bool bShowDialog );
-
-    virtual void SAL_CALL run();
-
-    void    setTerminating();
-
-private:
-    osl::Condition m_aCondition;
-    uno::Reference<uno::XComponentContext> m_xContext;
-    uno::Sequence<beans::NamedValue> m_xParameters;
-    bool m_bShowDialog;
-    bool m_bTerminating;
-};
-
 class UpdateCheckJob :
     public ::cppu::WeakImplHelper3< task::XJob, lang::XServiceInfo, frame::XTerminateListener >
 {
@@ -109,50 +90,10 @@ public:
 private:
     uno::Reference<uno::XComponentContext>  m_xContext;
     uno::Reference< frame::XDesktop >       m_xDesktop;
-    std::auto_ptr< InitUpdateCheckJobThread > m_pInitThread;
 
     void handleExtensionUpdates( const uno::Sequence< beans::NamedValue > &rListProp );
 };
 
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-InitUpdateCheckJobThread::InitUpdateCheckJobThread(
-            const uno::Reference< uno::XComponentContext > &xContext,
-            const uno::Sequence< beans::NamedValue > &xParameters,
-            bool bShowDialog ) :
-    m_xContext( xContext ),
-    m_xParameters( xParameters ),
-    m_bShowDialog( bShowDialog ),
-    m_bTerminating( false )
-{
-    create();
-}
-
-//------------------------------------------------------------------------------
-void SAL_CALL InitUpdateCheckJobThread::run()
-{
-    if (!m_bShowDialog) {
-        TimeValue tv = { 25, 0 };
-        m_aCondition.wait( &tv );
-        if ( m_bTerminating )
-            return;
-    }
-
-    rtl::Reference< UpdateCheck > aController( UpdateCheck::get() );
-    aController->initialize( m_xParameters, m_xContext );
-
-    if ( m_bShowDialog )
-        aController->showDialog( true );
-}
-
-void InitUpdateCheckJobThread::setTerminating() {
-    m_bTerminating = true;
-    m_aCondition.set();
-}
-
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 
 UpdateCheckJob::UpdateCheckJob( const uno::Reference<uno::XComponentContext>& xContext ) :
@@ -216,19 +157,9 @@ UpdateCheckJob::execute(const uno::Sequence<beans::NamedValue>& namedValues)
     uno::Sequence<beans::NamedValue> aConfig =
         getValue< uno::Sequence<beans::NamedValue> > (namedValues, "JobConfig");
 
-    /* Determine the way we got invoked here -
-     * see Developers Guide Chapter "4.7.2 Jobs" to understand the magic
-     */
-
-    uno::Sequence<beans::NamedValue> aEnvironment =
-        getValue< uno::Sequence<beans::NamedValue> > (namedValues, "Environment");
-
-    rtl::OUString aEventName = getValue< rtl::OUString > (aEnvironment, "EventName");
-
-    m_pInitThread.reset(
-        new InitUpdateCheckJobThread(
-            m_xContext, aConfig,
-            !aEventName.equalsAscii("onFirstVisibleTask")));
+    rtl::Reference< UpdateCheck > aController( UpdateCheck::get() );
+    aController->initialize( aConfig, m_xContext );
+    aController->showDialog( true );
 
     return uno::Any();
 }
@@ -326,11 +257,6 @@ void SAL_CALL UpdateCheckJob::queryTermination( lang::EventObject const & )
 void SAL_CALL UpdateCheckJob::notifyTermination( lang::EventObject const & )
     throw ( uno::RuntimeException )
 {
-    if ( m_pInitThread.get() != 0 )
-    {
-        m_pInitThread->setTerminating();
-        m_pInitThread->join();
-    }
 }
 
 } // anonymous namespace

--- a/main/extensions/source/update/check/updatehdl.cxx
+++ b/main/extensions/source/update/check/updatehdl.cxx
@@ -65,6 +65,9 @@
 #include "updatehdl.hrc"
 #include <tools/urlobj.hxx>
 
+#include <vcl/svapp.hxx>
+#include <vos/mutex.hxx>
+
 #define UNISTRING(s) rtl::OUString(RTL_CONSTASCII_USTRINGPARAM(s))
 
 #define COMMAND_CLOSE       UNISTRING("close")
@@ -175,6 +178,7 @@ bool UpdateHandler::isVisible() const
 {
     if ( !mxUpdDlg.is() ) return false;
 
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XWindow2 > xWindow( mxUpdDlg, uno::UNO_QUERY );
 
     if ( xWindow.is() )
@@ -201,6 +205,7 @@ void UpdateHandler::setVisible( bool bVisible )
 
         updateState( meCurState );
 
+        ::vos::OGuard aGuard( Application::GetSolarMutex() );
         uno::Reference< awt::XWindow > xWindow( mxUpdDlg, uno::UNO_QUERY );
 
         if ( xWindow.is() )
@@ -219,6 +224,7 @@ void UpdateHandler::setVisible( bool bVisible )
     }
     else if ( mxUpdDlg.is() )
     {
+        ::vos::OGuard aGuard( Application::GetSolarMutex() );
         uno::Reference< awt::XWindow > xWindow( mxUpdDlg, uno::UNO_QUERY );
 
         if ( xWindow.is() )
@@ -388,6 +394,7 @@ void SAL_CALL UpdateHandler::windowOpened( const lang::EventObject& )
 void SAL_CALL UpdateHandler::windowClosing( const lang::EventObject& e )
     throw( uno::RuntimeException )
 {
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     awt::ActionEvent aActionEvt;
     aActionEvt.ActionCommand = COMMAND_CLOSE;
     aActionEvt.Source = e.Source;
@@ -482,6 +489,7 @@ void SAL_CALL UpdateHandler::queryTermination( const lang::EventObject& )
 {
     if ( mbShowsMessageBox )
     {
+        ::vos::OGuard aGuard( Application::GetSolarMutex() );
         uno::Reference< awt::XTopWindow > xTopWindow( mxUpdDlg, uno::UNO_QUERY );
         if ( xTopWindow.is() )
             xTopWindow->toFront();
@@ -502,6 +510,7 @@ void SAL_CALL UpdateHandler::notifyTermination( const lang::EventObject& )
 
     if ( mxUpdDlg.is() )
     {
+        ::vos::OGuard aGuard( Application::GetSolarMutex() );
         uno::Reference< awt::XTopWindow > xTopWindow( mxUpdDlg, uno::UNO_QUERY );
         if ( xTopWindow.is() )
             xTopWindow->removeTopWindowListener( this );
@@ -752,6 +761,7 @@ void UpdateHandler::loadStrings()
 //--------------------------------------------------------------------
 void UpdateHandler::startThrobber( bool bStart )
 {
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XControlContainer > xContainer( mxUpdDlg, uno::UNO_QUERY );
     uno::Reference< awt::XAnimation > xThrobber( xContainer->getControl( CTRL_THROBBER ), uno::UNO_QUERY );
 
@@ -775,6 +785,7 @@ void UpdateHandler::setControlProperty( const rtl::OUString &rCtrlName,
 {
     if ( !mxUpdDlg.is() ) return;
 
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XControlContainer > xContainer( mxUpdDlg, uno::UNO_QUERY );
     uno::Reference< awt::XControl > xControl( xContainer->getControl( rCtrlName ), uno::UNO_QUERY_THROW );
     uno::Reference< awt::XControlModel > xControlModel( xControl->getModel(), uno::UNO_QUERY_THROW );
@@ -792,6 +803,7 @@ void UpdateHandler::setControlProperty( const rtl::OUString &rCtrlName,
 //--------------------------------------------------------------------
 void UpdateHandler::showControl( const rtl::OUString &rCtrlName, bool bShow )
 {
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XControlContainer > xContainer( mxUpdDlg, uno::UNO_QUERY );
 
     if ( !xContainer.is() )
@@ -808,6 +820,7 @@ void UpdateHandler::showControl( const rtl::OUString &rCtrlName, bool bShow )
 //--------------------------------------------------------------------
 void UpdateHandler::focusControl( DialogControls eID )
 {
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XControlContainer > xContainer( mxUpdDlg, uno::UNO_QUERY );
 
     if ( !xContainer.is() )
@@ -824,6 +837,7 @@ void UpdateHandler::focusControl( DialogControls eID )
 }
 
 //--------------------------------------------------------------------
+// Requires the Solar Mutex to be locked
 void UpdateHandler::insertControlModel( uno::Reference< awt::XControlModel > & rxDialogModel,
                                         rtl::OUString const & rServiceName,
                                         rtl::OUString const & rControlName,
@@ -934,6 +948,7 @@ bool UpdateHandler::showWarning( const rtl::OUString &rWarningText ) const
 {
     bool bRet = false;
 
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< awt::XControl > xControl( mxUpdDlg, uno::UNO_QUERY );
     if ( !xControl.is() ) return bRet;
 
@@ -983,6 +998,7 @@ bool UpdateHandler::showWarning( const rtl::OUString &rWarningText,
 {
 	bool bRet = false;
 
+	::vos::OGuard aGuard( Application::GetSolarMutex() );
 	uno::Reference< awt::XControl > xControl( mxUpdDlg, uno::UNO_QUERY );
 	if ( !xControl.is() ) return bRet;
 
@@ -1151,6 +1167,7 @@ void UpdateHandler::createDialog()
 
     loadStrings();
 
+    ::vos::OGuard aGuard( Application::GetSolarMutex() );
     uno::Reference< lang::XMultiComponentFactory > xFactory( mxContext->getServiceManager(), uno::UNO_QUERY_THROW );
     uno::Reference< awt::XControlModel > xControlModel( xFactory->createInstanceWithContext(
                                                          UNISTRING("com.sun.star.awt.UnoControlDialogModel"),


### PR DESCRIPTION
The following bugs:
- [127154](https://bz.apache.org/ooo/show_bug.cgi?id=127154)
- [128617](https://bz.apache.org/ooo/show_bug.cgi?id=128617)

and possibly others are caused by GUI calls in secondary threads.

The purpose of this pull request is to fix the above and similar bugs.