### PR TITLE
chore: whitespace clean up for `.src` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: \.(asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/accessibility/source/helper/accessiblestrings.src
+++ b/main/accessibility/source/helper/accessiblestrings.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/avmedia/util/hidother.src
+++ b/main/avmedia/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,23 +7,23 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
 
 #include "../inc/helpids.hrc"
 
-hidspecial HID_AVMEDIA_TOOLBOXITEM_PLAY    { HelpId = HID_AVMEDIA_TOOLBOXITEM_PLAY; };   
+hidspecial HID_AVMEDIA_TOOLBOXITEM_PLAY    { HelpId = HID_AVMEDIA_TOOLBOXITEM_PLAY; };
 hidspecial HID_AVMEDIA_TOOLBOXITEM_PAUSE   { HelpId = HID_AVMEDIA_TOOLBOXITEM_PAUSE; };
 hidspecial HID_AVMEDIA_TOOLBOXITEM_STOP    { HelpId = HID_AVMEDIA_TOOLBOXITEM_STOP; };
 hidspecial HID_AVMEDIA_TOOLBOXITEM_MUTE    { HelpId = HID_AVMEDIA_TOOLBOXITEM_MUTE; };

--- a/main/basctl/source/basicide/moptions.src
+++ b/main/basctl/source/basicide/moptions.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -115,32 +115,3 @@ ModalDialog RID_MACROOPTIONS
 		TabStop = TRUE ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/basctl/source/basicide/objdlg.src
+++ b/main/basctl/source/basicide/objdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -92,5 +92,4 @@ FloatingWindow RID_BASICIDE_OBJCAT
 String RID_STR_TLB_MACROS
 {
 	Text [ en-US ] = "Objects Tree";
-}; 
-
+};

--- a/main/basctl/source/dlged/dlgresid.src
+++ b/main/basctl/source/dlged/dlgresid.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -131,41 +131,3 @@ String RID_STR_BRWTITLE_MULTISELECT
 };
 
 // -----------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/basctl/source/dlged/managelang.src
+++ b/main/basctl/source/dlged/managelang.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -193,41 +193,3 @@ ModalDialog RID_DLG_SETDEF_LANGUAGE
 };
 
 // -----------------------------------------------------------------------
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/basctl/util/hidother.src
+++ b/main/basctl/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -37,4 +37,3 @@ hidspecial HID_BASICIDE_TABBAR				{ HelpID = HID_BASICIDE_TABBAR; };
 hidspecial HID_BASICIDE_WATCHWINDOW_LIST	{ HelpID = HID_BASICIDE_WATCHWINDOW_LIST; };
 hidspecial HID_BASICIDE_STACKWINDOW_LIST	{ HelpID = HID_BASICIDE_STACKWINDOW_LIST; };
 hidspecial HID_BASICIDE_ADDNEW_LANGUAGE		{ HelpID = HID_BASICIDE_ADDNEW_LANGUAGE; };
-

--- a/main/basic/source/sbx/format.src
+++ b/main/basic/source/sbx/format.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -51,31 +51,3 @@ String STR_BASICKEY_FORMAT_CURRENCY
 {
 	Text [ en-US ] = "@0.00 $;@(0.00 $)" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/basic/workben/basmgr.src
+++ b/main/basic/workben/basmgr.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/Strings_AdditionalControls.src
+++ b/main/chart2/source/controller/dialogs/Strings_AdditionalControls.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/Strings_ChartTypes.src
+++ b/main/chart2/source/controller/dialogs/Strings_ChartTypes.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/Strings_Scale.src
+++ b/main/chart2/source/controller/dialogs/Strings_Scale.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_ChartType.src
+++ b/main/chart2/source/controller/dialogs/dlg_ChartType.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -35,19 +35,19 @@
 ModalDialog DLG_DIAGRAM_TYPE
 {
     HelpID = HID_DIAGRAM_TYPE ;
-    
+
     Size = MAP_APPFONT ( CHART_TYPE_DLG_WIDTH , CHART_TYPE_DLG_HEIGHT ) ;
 
 	OutputSize = TRUE ;
 	SVLook = TRUE ;
 	Moveable = TRUE ;
     Closeable = TRUE ;
-    
+
     FixedLine FL_BUTTONS
 	{
 		Pos = MAP_APPFONT ( 0 , CHART_TYPE_DLG_HEIGHT-24  ) ;
 		Size = MAP_APPFONT ( CHART_TYPE_DLG_WIDTH , 8 ) ;
 	};
-	
+
 	BUTTONS_OK_CANCEL_HELP( CHART_TYPE_DLG_WIDTH-161 ,CHART_TYPE_DLG_HEIGHT-17 , 53, 0 )
 };

--- a/main/chart2/source/controller/dialogs/dlg_CreationWizard.src
+++ b/main/chart2/source/controller/dialogs/dlg_CreationWizard.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_DataEditor.src
+++ b/main/chart2/source/controller/dialogs/dlg_DataEditor.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_DataSource.src
+++ b/main/chart2/source/controller/dialogs/dlg_DataSource.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_InsertAxis_Grid.src
+++ b/main/chart2/source/controller/dialogs/dlg_InsertAxis_Grid.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -52,7 +52,7 @@ ModalDialog DLG_AXIS_OR_GRID
 	CheckBox CB_X_PRIMARY
 	{
 	    HelpID = HID_SCH_CB_XAXIS;
-	
+
 		Pos = MAP_APPFONT ( 12 , 14  );
 		Size = MAP_APPFONT ( 80 , 10 );
 		TabStop = TRUE;
@@ -61,7 +61,7 @@ ModalDialog DLG_AXIS_OR_GRID
 	CheckBox CB_Y_PRIMARY
 	{
 	    HelpID = HID_SCH_CB_YAXIS;
-	
+
 		Pos = MAP_APPFONT ( 12 , 28  );
 		Size = MAP_APPFONT ( 80 , 10 );
 		TabStop = TRUE;
@@ -70,7 +70,7 @@ ModalDialog DLG_AXIS_OR_GRID
 	CheckBox CB_Z_PRIMARY
 	{
 	    HelpID = HID_SCH_CB_ZAXIS;
-	
+
 		Pos = MAP_APPFONT ( 12 , 42  );
 		Size = MAP_APPFONT ( 80 , 10 );
 		TabStop = TRUE;

--- a/main/chart2/source/controller/dialogs/dlg_InsertLegend.src
+++ b/main/chart2/source/controller/dialogs/dlg_InsertLegend.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_InsertTitle.src
+++ b/main/chart2/source/controller/dialogs/dlg_InsertTitle.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_InsertTrendline.src
+++ b/main/chart2/source/controller/dialogs/dlg_InsertTrendline.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -41,4 +41,3 @@ ModalDialog DLG_DATA_TRENDLINE
     BUTTONS_OK_CANCEL_HELP_STACKED( DLG_DATA_TRENDLINE_RES_WIDTH + DLG_DATA_TRENDLINE_ADD_TO_RES )
     RESOURCE_TRENDLINE( DLG_DATA_TRENDLINE_RES_WIDTH, 22 )
 };
-

--- a/main/chart2/source/controller/dialogs/dlg_ShapeFont.src
+++ b/main/chart2/source/controller/dialogs/dlg_ShapeFont.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_ShapeParagraph.src
+++ b/main/chart2/source/controller/dialogs/dlg_ShapeParagraph.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/dlg_View3D.src
+++ b/main/chart2/source/controller/dialogs/dlg_View3D.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,7 +39,6 @@ TabDialog DLG_3D_VIEW
 		OutputSize = TRUE ;
 		Pos = MAP_APPFONT ( 3 , 3 ) ;
 		Size = MAP_APPFONT ( VIEW3D_PAGE_WIDTH , VIEW3D_PAGE_HEIGHT ) ;
-	};	
+	};
 	BUTTONS_OK_CANCEL_HELP_STACKED(VIEW3D_PAGE_HEIGHT+3)
 };
-

--- a/main/chart2/source/controller/dialogs/hidother.src
+++ b/main/chart2/source/controller/dialogs/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/res_BarGeometry.src
+++ b/main/chart2/source/controller/dialogs/res_BarGeometry.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/res_TextSeparator.src
+++ b/main/chart2/source/controller/dialogs/res_TextSeparator.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,7 +34,7 @@ ListBox LB_TEXT_SEPARATOR
     Group = TRUE ;
     DropDown=TRUE;
     DDExtraWidth = TRUE ;
-    
+
     StringList [ en-US ] =
     {
         "Space" ;

--- a/main/chart2/source/controller/dialogs/tp_3D_SceneAppearance.src
+++ b/main/chart2/source/controller/dialogs/tp_3D_SceneAppearance.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,7 +34,7 @@
 #define HEIGHT_FT 10
 
 #define POS_X_0 6
-#define POS_X_1 6 
+#define POS_X_1 6
 #define POS_X_2 POS_X_1+WIDTH_FT+4
 
 #define POS_Y_SCHEME 8
@@ -72,8 +72,8 @@ TabPage TP_3D_SCENEAPPEARANCE
 	{
 		Pos = MAP_APPFONT ( POS_X_0 , POS_Y_SEPERATOR  ) ;
 		Size = MAP_APPFONT ( WIDTH_FL , HEIGHT_FL ) ;
-    };    
-	
+    };
+
     CheckBox CB_SHADING
     {
         HelpID = "chart2:CheckBox:TP_3D_SCENEAPPEARANCE:CB_SHADING";
@@ -95,4 +95,3 @@ TabPage TP_3D_SCENEAPPEARANCE
 		Text [ en-US ] = "~Rounded edges" ;
 	};
 };
-

--- a/main/chart2/source/controller/dialogs/tp_3D_SceneGeometry.src
+++ b/main/chart2/source/controller/dialogs/tp_3D_SceneGeometry.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,7 +39,7 @@
 #define HEIGHT_FT 10
 
 #define POS_X_0 6
-#define POS_X_1 6 
+#define POS_X_1 6
 #define POS_X_2 POS_X_1+WIDTH_FT+4
 
 #define POS_Y_0 (8)
@@ -70,7 +70,7 @@ TabPage TP_3D_SCENEGEOMETRY
 	SVLook = TRUE ;
 	Hide = TRUE ;
 	Size = MAP_APPFONT ( VIEW3D_PAGE_WIDTH , VIEW3D_PAGE_HEIGHT ) ;
-    
+
     CheckBox CBX_RIGHT_ANGLED_AXES
     {
         HelpID = "chart2:CheckBox:TP_3D_SCENEGEOMETRY:CBX_RIGHT_ANGLED_AXES";
@@ -118,7 +118,7 @@ TabPage TP_3D_SCENEGEOMETRY
 		Size = MAP_APPFONT ( WIDTH_MF , HEIGHT_MF ) ;
         CUSTOMUNITTEXT_DEGREE
 	};
-	
+
 	CheckBox CBX_PERSPECTIVE
 	{
 	    HelpID = "chart2:CheckBox:TP_3D_SCENEGEOMETRY:CBX_PERSPECTIVE";
@@ -146,4 +146,3 @@ TabPage TP_3D_SCENEGEOMETRY
         Unit = FUNIT_PERCENT ;
 	};
 };
-

--- a/main/chart2/source/controller/dialogs/tp_3D_SceneIllumination.src
+++ b/main/chart2/source/controller/dialogs/tp_3D_SceneIllumination.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -60,7 +60,7 @@ TabPage TP_3D_SCENEILLUMINATION
 	SVLook = TRUE ;
 	Hide = TRUE ;
 	Size = MAP_APPFONT ( VIEW3D_PAGE_WIDTH , VIEW3D_PAGE_HEIGHT ) ;
-	
+
     FixedText FT_LIGHTSOURCE
 	{
 	    Pos = MAP_APPFONT ( POS_X_0 , POS_Y_LIGHTSOURCE_HEAD ) ;
@@ -120,7 +120,7 @@ TabPage TP_3D_SCENEILLUMINATION
 	    HelpID = "chart2:ListBox:TP_3D_SCENEILLUMINATION:LB_LIGHTSOURCE";
 		Border = TRUE ;
         Pos = MAP_APPFONT ( POS_X_0 , POS_Y_LIGHTSOURCE ) ;
-		Size = MAP_APPFONT ( WIDTH_LB , HEIGHT_LB ) ;    
+		Size = MAP_APPFONT ( WIDTH_LB , HEIGHT_LB ) ;
 		TabStop = TRUE ;
 		DropDown = TRUE ;
 	};
@@ -157,9 +157,9 @@ TabPage TP_3D_SCENEILLUMINATION
 		Size = MAP_APPFONT ( WIDTH_IB , HEIGHT_IB ) ;
 		TabStop = TRUE ;
 	};
-	
 
-	
+
+
 	Control CTL_LIGHT_PREVIEW
 	{
         Border = TRUE ;
@@ -173,4 +173,3 @@ String STR_LIGHT_PREVIEW
 {
 	Text [ en-US ] = "Light Preview" ;
 };
-

--- a/main/chart2/source/controller/dialogs/tp_AxisLabel.src
+++ b/main/chart2/source/controller/dialogs/tp_AxisLabel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -187,4 +187,3 @@ TabPage TP_AXIS_LABEL
         DropDown = TRUE;
     };
 };
-

--- a/main/chart2/source/controller/dialogs/tp_ChartType.src
+++ b/main/chart2/source/controller/dialogs/tp_ChartType.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -169,7 +169,7 @@ TabPage TP_CHARTTYPE
         Size = MAP_APPFONT ( 12 , 14 ) ;
         Text [ en-US ] = "Properties..." ;
     };
-    
+
     CheckBox CB_XVALUE_SORTING
     {
         HelpID = "chart2:CheckBox:TP_CHARTTYPE:CB_XVALUE_SORTING";
@@ -178,7 +178,7 @@ TabPage TP_CHARTTYPE
         Size = MAP_APPFONT ( WIDTH_XVALUE_SORTING , 10 ) ;
 		Text [ en-US ] = "~Sort by X values" ;
     };
-    
+
 };
 
 ModalDialog DLG_SPLINE_PROPERTIES

--- a/main/chart2/source/controller/dialogs/tp_DataLabel.src
+++ b/main/chart2/source/controller/dialogs/tp_DataLabel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_DataSource.src
+++ b/main/chart2/source/controller/dialogs/tp_DataSource.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_ErrorBars.src
+++ b/main/chart2/source/controller/dialogs/tp_ErrorBars.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_LegendPosition.src
+++ b/main/chart2/source/controller/dialogs/tp_LegendPosition.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_Location.src
+++ b/main/chart2/source/controller/dialogs/tp_Location.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_PointGeometry.src
+++ b/main/chart2/source/controller/dialogs/tp_PointGeometry.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_PolarOptions.src
+++ b/main/chart2/source/controller/dialogs/tp_PolarOptions.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_RangeChooser.src
+++ b/main/chart2/source/controller/dialogs/tp_RangeChooser.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_Scale.src
+++ b/main/chart2/source/controller/dialogs/tp_Scale.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -49,7 +49,7 @@
         "Months" ; \
         "Years" ; \
     };
-    
+
 TabPage TP_SCALE
 {
     HelpID = "chart2:TabPage:TP_SCALE";
@@ -99,7 +99,7 @@ TabPage TP_SCALE
         Group = TRUE ;
         DropDown=TRUE;
         DDExtraWidth = TRUE ;
-        
+
         StringList [ en-US ] =
         {
             "Automatic" ;
@@ -173,7 +173,7 @@ TabPage TP_SCALE
         Group = TRUE ;
         DropDown=TRUE;
         DDExtraWidth = TRUE ;
-        
+
         STR_LIST_TIME_UNIT
     };
     CheckBox CBX_AUTO_TIME_RESOLUTION
@@ -216,7 +216,7 @@ TabPage TP_SCALE
         Last = 100000 ;
         SpinSize = 1 ;
     };
-        
+
     ListBox LB_MAIN_TIME_UNIT
     {
         HelpID = "chart2:ListBox:TP_SCALE:LB_MAIN_TIME_UNIT";
@@ -228,10 +228,10 @@ TabPage TP_SCALE
         Group = TRUE ;
         DropDown=TRUE;
         DDExtraWidth = TRUE ;
-        
+
         STR_LIST_TIME_UNIT
     };
-    
+
     CheckBox CBX_AUTO_STEP_MAIN
     {
         HelpID = "chart2:CheckBox:TP_SCALE:CBX_AUTO_STEP_MAIN";
@@ -281,7 +281,7 @@ TabPage TP_SCALE
         Group = TRUE ;
         DropDown=TRUE;
         DDExtraWidth = TRUE ;
-        
+
         STR_LIST_TIME_UNIT
     };
     CheckBox CBX_AUTO_STEP_HELP
@@ -316,5 +316,5 @@ TabPage TP_SCALE
         TabStop = TRUE ;
         Text [ en-US ] = "Automat~ic" ;
     };
-    //---------------------------    
+    //---------------------------
 };

--- a/main/chart2/source/controller/dialogs/tp_SeriesToAxis.src
+++ b/main/chart2/source/controller/dialogs/tp_SeriesToAxis.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -127,7 +127,7 @@ TabPage TP_OPTIONS
         TabStop = TRUE ;
         Text [ en-US ] = "Show ~bars side by side";
     };
-    
+
     FixedLine FL_PLOT_OPTIONS
     {
         Pos = MAP_APPFONT ( 6 , 113  ) ;
@@ -141,34 +141,34 @@ TabPage TP_OPTIONS
         Size = MAP_APPFONT ( 80 , 8 ) ;
         Text [ en-US ] = "Plot missing values";
     };
-    
+
     RadioButton RB_DONT_PAINT
     {
         HelpID = "chart2:RadioButton:TP_OPTIONS:RB_DONT_PAINT";
         Pos = MAP_APPFONT ( 82 , 127  ) ;
         Size = MAP_APPFONT ( 80 , 10 ) ;
         TabStop = TRUE ;
-        Text [ en-US ] = "~Leave gap";  
+        Text [ en-US ] = "~Leave gap";
     };
-    
+
     RadioButton RB_ASSUME_ZERO
     {
         HelpID = "chart2:RadioButton:TP_OPTIONS:RB_ASSUME_ZERO";
         Pos = MAP_APPFONT ( 82 , 141  ) ;
         Size = MAP_APPFONT ( 80 , 10 ) ;
         TabStop = TRUE ;
-        Text [ en-US ] = "~Assume zero";  
+        Text [ en-US ] = "~Assume zero";
     };
-    
+
     RadioButton RB_CONTINUE_LINE
     {
         HelpID = "chart2:RadioButton:TP_OPTIONS:RB_CONTINUE_LINE";
         Pos = MAP_APPFONT ( 82 , 155  ) ;
         Size = MAP_APPFONT ( 80 , 10 ) ;
         TabStop = TRUE ;
-        Text [ en-US ] = "~Continue line";  
+        Text [ en-US ] = "~Continue line";
     };
-      
+
     CheckBox CB_INCLUDE_HIDDEN_CELLS
     {
         HelpID = "chart2:CheckBox:TP_OPTIONS:CB_INCLUDE_HIDDEN_CELLS";

--- a/main/chart2/source/controller/dialogs/tp_TitleRotation.src
+++ b/main/chart2/source/controller/dialogs/tp_TitleRotation.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -86,4 +86,3 @@ TabPage TP_ALIGNMENT
         DropDown = TRUE;
     };
 };
-

--- a/main/chart2/source/controller/dialogs/tp_Trendline.src
+++ b/main/chart2/source/controller/dialogs/tp_Trendline.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/dialogs/tp_Wizard_TitlesAndObjects.src
+++ b/main/chart2/source/controller/dialogs/tp_Wizard_TitlesAndObjects.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/chart2/source/controller/menus/ShapeContextMenu.src
+++ b/main/chart2/source/controller/menus/ShapeContextMenu.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -72,7 +72,7 @@ Menu RID_CONTEXTMENU_SHAPE
             Command = ".uno:ArrangeRow";
             SubMenu = Menu
             {
-                ItemList = 
+                ItemList =
                 {
                     MenuItem
                     {
@@ -94,7 +94,7 @@ Menu RID_CONTEXTMENU_SHAPE
                         Identifier = COMMAND_ID_SEND_TO_BACK;
                         Command = ".uno:SendToBack";
                     };
-                };            
+                };
             };
         };
         MenuItem

--- a/main/chart2/source/controller/menus/ShapeEditContextMenu.src
+++ b/main/chart2/source/controller/menus/ShapeEditContextMenu.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/connectivity/source/drivers/hsqldb/hsqlui.src
+++ b/main/connectivity/source/drivers/hsqldb/hsqlui.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -35,7 +35,7 @@
 
     If there were another possibility to ensure that the images are
     put into the repository, instead of creating a resource file for them,
-    then we would use this other way ...    
+    then we would use this other way ...
 */
 
 Image 1000

--- a/main/connectivity/source/resource/conn_error_message.src
+++ b/main/connectivity/source/resource/conn_error_message.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -92,4 +92,3 @@ String 256 + 2*550 + 1
 {
     Text = "IM001";
 };
-

--- a/main/connectivity/source/resource/conn_log_res.src
+++ b/main/connectivity/source/resource/conn_log_res.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/cui/source/customize/acccfg.src
+++ b/main/cui/source/customize/acccfg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/cui/source/customize/eventdlg.src
+++ b/main/cui/source/customize/eventdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/cui/source/options/optasian.src
+++ b/main/cui/source/options/optasian.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/cui/source/options/optgenrl.src
+++ b/main/cui/source/options/optgenrl.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -290,39 +290,3 @@ QueryBox RID_SVXQB_CHANGEDATA
 };
 
  // ********************************************************************** EOF
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/cui/source/options/optimprove.src
+++ b/main/cui/source/options/optimprove.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -117,4 +117,3 @@ TabPage RID_SVXPAGE_IMPROVEMENT
         Text [ en-US ] = "More Information" ;
     };
 };
-

--- a/main/cui/util/hidother.src
+++ b/main/cui/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -197,4 +197,3 @@ hidspecial UID_OFA_CONNPOOL_DRIVERLIST_BACK         { HelpId = UID_OFA_CONNPOOL_
 hidspecial UID_SEARCH_RECORDSTATUS          { HelpID = UID_SEARCH_RECORDSTATUS ;};
 hidspecial HID_MACRO_HEADERTABLISTBOX       { HelpID = HID_MACRO_HEADERTABLISTBOX ;};
 hidspecial HID_DLG_PASSWORD_TO_OPEN_MODIFY  { HelpID = HID_DLG_PASSWORD_TO_OPEN_MODIFY ;};
-

--- a/main/dbaccess/source/sdbtools/resource/sdbt_strings.src
+++ b/main/dbaccess/source/sdbtools/resource/sdbt_strings.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/dbaccess/source/ui/browser/bcommon.src
+++ b/main/dbaccess/source/ui/browser/bcommon.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,4 +28,3 @@ String RID_STR_TBL_TITLE
 {
 	Text [ en-US ] = "Table #" ;
 };
-

--- a/main/dbaccess/source/ui/browser/sbagrid.src
+++ b/main/dbaccess/source/ui/browser/sbagrid.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -132,4 +132,3 @@ String STR_DATASOURCE_GRIDCONTROL_DESC
 {
 	Text [ en-US ] = "Shows the selected table or query.";
 };
-

--- a/main/dbaccess/source/ui/control/TableGrantCtrl.src
+++ b/main/dbaccess/source/ui/control/TableGrantCtrl.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -63,30 +63,3 @@ String STR_TABLE_PRIV_DROP
 {
 	Text [ en-US ] = "Drop structure";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/dbaccess/source/ui/control/tabletree.src
+++ b/main/dbaccess/source/ui/control/tabletree.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -81,4 +81,3 @@ String STR_ALL_TABLES_AND_VIEWS
 {
 	Text [ en-US ] = "All tables and views";
 };
-

--- a/main/dbaccess/source/ui/control/undosqledit.src
+++ b/main/dbaccess/source/ui/control/undosqledit.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -29,34 +29,3 @@ String STR_QUERY_UNDO_MODIFYSQLEDIT
 {
 	Text [ en-US ] = "Modify SQL statement(s)" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/dbaccess/source/ui/dlg/AdabasStat.src
+++ b/main/dbaccess/source/ui/dlg/AdabasStat.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -202,33 +202,3 @@ String STR_ADABAS_ERROR_SYSTEMTABLES
 {
 	Text [ en-US ] = "No information could be displayed because no access rights exist for the required system tables.";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/dbaccess/source/ui/dlg/RelationDlg.src
+++ b/main/dbaccess/source/ui/dlg/RelationDlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -83,8 +83,8 @@ ModalDialog DLG_REL_PROPERTIES
 		};
 	};
 
-	
-	
+
+
 
     FixedLine FL_CASC_UPD
 	{
@@ -179,4 +179,3 @@ ModalDialog DLG_REL_PROPERTIES
 	};
 
 };
-

--- a/main/dbaccess/source/ui/dlg/adtabdlg.src
+++ b/main/dbaccess/source/ui/dlg/adtabdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/dbaccess/source/ui/dlg/advancedsettings.src
+++ b/main/dbaccess/source/ui/dlg/advancedsettings.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -233,7 +233,7 @@
 			< "SQL" ; Default ; > ;                                                 \
 			< "Mixed" ; Default ; > ;                                               \
 			< "MS Access" ; Default ; > ;                                           \
-		};                                                                          
+		};
 
 
 #define AUTO_BOOLEANCOMPARISON(AUTO_Y)                                              \
@@ -365,29 +365,29 @@ TabPage PAGE_ADVANCED_SETTINGS_SPECIAL
 //-------------------------------------------------------------------------
 
 TabDialog DLG_DATABASE_ADVANCED
-{                                                                           
+{
     OutputSize = TRUE ;
     SVLook = TRUE ;
     Moveable = TRUE ;
     Closeable = TRUE ;
     Hide = TRUE;
     HelpId = HID_DSADMIN_ADVANCED;
-    
+
     TabControl 1
     {
         OutputSize = TRUE ;
         HelpId = HID_DSADMIN_TABCONTROL;
     };
-    
+
     String STR_GENERATED_VALUE
     {
         Text [ en-US ] = "Generated Values";
     };
-    
+
     String STR_DS_BEHAVIOUR
     {
         Text [ en-US ] = "Special Settings";
     };
-    
+
     Text [ en-US ] = "Advanced Settings" ;
 };

--- a/main/dbaccess/source/ui/dlg/dlgsave.src
+++ b/main/dbaccess/source/ui/dlg/dlgsave.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -137,4 +137,3 @@ ModalDialog DLG_SAVE_AS
 		Text [ en-US ] = "Insert as";
 	};
 };
-

--- a/main/dbaccess/source/ui/dlg/paramdialog.src
+++ b/main/dbaccess/source/ui/dlg/paramdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -97,4 +97,3 @@ ModalDialog DLG_PARAMETERS
 		Text [ en-US ] = "The entry could not be converted to a valid value for the \"$name$\"column";
 	};
 };
-

--- a/main/dbaccess/source/ui/dlg/textconnectionsettings.src
+++ b/main/dbaccess/source/ui/dlg/textconnectionsettings.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/dbaccess/source/ui/querydesign/query.src
+++ b/main/dbaccess/source/ui/querydesign/query.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/dbaccess/source/ui/querydesign/querydlg.src
+++ b/main/dbaccess/source/ui/querydesign/querydlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -187,5 +187,3 @@ String STR_QUERY_NATURAL_JOIN
 {
 	Text [ en-US ] = "Contains only one column for each pair of equally-named columns from '%1' and from '%2'.";
 };
-
-

--- a/main/dbaccess/source/ui/uno/copytablewizard.src
+++ b/main/dbaccess/source/ui/uno/copytablewizard.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/dbaccess/source/ui/uno/dbinteraction.src
+++ b/main/dbaccess/source/ui/uno/dbinteraction.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,4 +34,3 @@ String STR_REMEMBERPASSWORD_PERSISTENT
 {
 	Text [ en-US ] = "~Remember password";
 };
-

--- a/main/dbaccess/util/hidother.src
+++ b/main/dbaccess/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/desktop/source/deployment/gui/dp_gui_versionboxes.src
+++ b/main/desktop/source/deployment/gui/dp_gui_versionboxes.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -36,7 +36,7 @@ String RID_STR_WARNINGBOX_VERSION_LESS_DIFFERENT_NAMES {
     Text [en-US] = "You are about to install version $NEW of the extension \'$NAME\'.\n"
     "The newer version $DEPLOYED, named \'$OLDNAME\', is already installed.\n"
     "Click \'OK\' to replace the installed extension.\n"
-    "Click \'Cancel\' to stop the installation.";  
+    "Click \'Cancel\' to stop the installation.";
 };
 
 WarningBox RID_WARNINGBOX_VERSION_EQUAL {
@@ -58,7 +58,7 @@ String RID_STR_WARNINGBOX_VERSION_EQUAL_DIFFERENT_NAMES {
 WarningBox RID_WARNINGBOX_VERSION_GREATER {
     Buttons = WB_OK_CANCEL;
     DefButton = WB_DEF_OK;
-    Message[en-US] = "You are about to install version $NEW of the extension \'$NAME\'.\n" 
+    Message[en-US] = "You are about to install version $NEW of the extension \'$NAME\'.\n"
     "The older version $DEPLOYED is already installed.\n"
     "Click \'OK\' to replace the installed extension.\n"
     "Click \'Cancel\' to stop the installation.";

--- a/main/desktop/source/deployment/manager/dp_manager.src
+++ b/main/desktop/source/deployment/manager/dp_manager.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/desktop/source/deployment/registry/component/dp_component.src
+++ b/main/desktop/source/deployment/registry/component/dp_component.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -52,4 +52,3 @@ String RID_STR_JAVA_TYPELIB
 {
     Text [ en-US ] = "UNO Java Type Library";
 };
-

--- a/main/desktop/source/deployment/registry/configuration/dp_configuration.src
+++ b/main/desktop/source/deployment/registry/configuration/dp_configuration.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -32,4 +32,3 @@ String RID_STR_CONF_DATA
 {
     Text [ en-US ] = "Configuration Data";
 };
-

--- a/main/desktop/source/deployment/registry/dp_registry.src
+++ b/main/desktop/source/deployment/registry/dp_registry.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,7 +34,7 @@ String RID_STR_REVOKING_PACKAGE
 };
 
 String RID_STR_CANNOT_DETECT_MEDIA_TYPE
-{	
+{
     Text [ en-US ] = "Cannot detect media-type: ";
 };
 
@@ -52,4 +52,3 @@ String RID_STR_ERROR_WHILE_REVOKING
 {
     Text [ en-US ] = "An error occurred while disabling: ";
 };
-

--- a/main/desktop/source/deployment/registry/help/dp_help.src
+++ b/main/desktop/source/deployment/registry/help/dp_help.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -37,4 +37,3 @@ String RID_STR_HELPPROCESSING_XMLPARSING_ERROR
 {
     Text [ en-US ] = "The extension will not be installed because an error occurred in the Help files:\n";
 };
-

--- a/main/desktop/source/deployment/registry/package/dp_package.src
+++ b/main/desktop/source/deployment/registry/package/dp_package.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,4 +27,3 @@ String RID_STR_PACKAGE_BUNDLE
 {
     Text [ en-US ] = "Extension";
 };
-

--- a/main/desktop/source/deployment/registry/script/dp_script.src
+++ b/main/desktop/source/deployment/registry/script/dp_script.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -42,4 +42,3 @@ String RID_STR_LIBNAME_ALREADY_EXISTS
 {
     Text [ en-US ] = "This library name already exists. Please choose a different name.";
 };
-

--- a/main/desktop/source/deployment/registry/sfwk/dp_sfwk.src
+++ b/main/desktop/source/deployment/registry/sfwk/dp_sfwk.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,5 +27,3 @@ String RID_STR_SFWK_LIB
 {
     Text [ en-US ] = "%MACROLANG Library";
 };
-
-

--- a/main/desktop/source/deployment/unopkg/unopkg.src
+++ b/main/desktop/source/deployment/unopkg/unopkg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -77,4 +77,3 @@ String RID_STR_UNOPKG_ERROR
 {
     Text [ en-US ] = "ERROR: ";
 };
-

--- a/main/desktop/util/hidother.src
+++ b/main/desktop/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -35,7 +35,7 @@ hidspecial HID_FIRSTSTART_PREV { HelpId = HID_FIRSTSTART_PREV;};
 hidspecial HID_FIRSTSTART_NEXT { HelpId = HID_FIRSTSTART_NEXT;};
 hidspecial HID_FIRSTSTART_CANCEL { HelpId = HID_FIRSTSTART_CANCEL;};
 hidspecial HID_FIRSTSTART_FINISH { HelpId = HID_FIRSTSTART_FINISH;};
-hidspecial UID_FIRSTSTART_HELP { HelpId = UID_FIRSTSTART_HELP;}; 
+hidspecial UID_FIRSTSTART_HELP { HelpId = UID_FIRSTSTART_HELP;};
 
 hidspecial UID_BTN_LICENSE_ACCEPT { HelpId = UID_BTN_LICENSE_ACCEPT;};
 
@@ -47,4 +47,3 @@ hidspecial HID_EXTENSION_MANAGER_LISTBOX_OPTIONS { HelpId = HID_EXTENSION_MANAGE
 hidspecial HID_EXTENSION_MANAGER_LISTBOX_ENABLE  { HelpId = HID_EXTENSION_MANAGER_LISTBOX_ENABLE; };
 hidspecial HID_EXTENSION_MANAGER_LISTBOX_DISABLE { HelpId = HID_EXTENSION_MANAGER_LISTBOX_DISABLE; };
 hidspecial HID_EXTENSION_MANAGER_LISTBOX_REMOVE  { HelpId = HID_EXTENSION_MANAGER_LISTBOX_REMOVE; };
-

--- a/main/editeng/source/accessibility/accessibility.src
+++ b/main/editeng/source/accessibility/accessibility.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -42,5 +42,3 @@ String RID_SVXSTR_A11Y_PARAGRAPH_NAME
 {
 	Text [ en-US ] = "Paragraph $(ARG)" ;
 };
-
-

--- a/main/editeng/util/hidother.src
+++ b/main/editeng/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "../inc/helpid.hrc"
@@ -39,5 +39,3 @@ hidspecial HID_AUTOCORR_HELP_SENTWORDENEMDASH       { HelpID =  HID_AUTOCORR_HEL
 hidspecial HID_AUTOCORR_HELP_SETINETATTR        { HelpID =  HID_AUTOCORR_HELP_SETINETATTR;};
 hidspecial HID_AUTOCORR_HELP_WORD           { HelpID =  HID_AUTOCORR_HELP_WORD;};
 hidspecial HID_AUTOCORR_HELP_WORDENEMDASH           { HelpID =  HID_AUTOCORR_HELP_WORDENEMDASH;};
-
-

--- a/main/extensions/qa/complex/extensions/orl_de.src
+++ b/main/extensions/qa/complex/extensions/orl_de.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/extensions/qa/complex/extensions/orl_en-US.src
+++ b/main/extensions/qa/complex/extensions/orl_en-US.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/extensions/source/bibliography/hidother.src
+++ b/main/extensions/source/bibliography/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/extensions/source/bibliography/menu.src
+++ b/main/extensions/source/bibliography/menu.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -29,7 +29,7 @@
 
 /*
 
-The menu bar resource has become obsolete. You find the menu bar definition 
+The menu bar resource has become obsolete. You find the menu bar definition
 now at: <project>/uiconfig/sbibliography/menubar/menubar.xml
 
 */

--- a/main/extensions/util/hidother.src
+++ b/main/extensions/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/extensions/workben/testresource.src
+++ b/main/extensions/workben/testresource.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,20 +7,20 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
 String 1000
 {
 	Text = "Hello";
-};	
+};

--- a/main/filter/source/flash/impswfdialog.src
+++ b/main/filter/source/flash/impswfdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -167,21 +167,3 @@ ModalDialog DLG_OPTIONS
 	};
 
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/filter/source/graphicfilter/eps/epsstr.src
+++ b/main/filter/source/graphicfilter/eps/epsstr.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,39 +28,3 @@ String KEY_VERSION_CHECK
 {
 	Text [ en-US ] = "Warning: Not all of the imported EPS graphics could be saved at level1\nas some are at a higher level!";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/filter/source/t602/t602filter.src
+++ b/main/filter/source/t602/t602filter.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
 #include "t602filter.hrc"
 

--- a/main/filter/source/xsltdialog/hidother.src
+++ b/main/filter/source/xsltdialog/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/filter/source/xsltdialog/xmlfiltertabdialog.src
+++ b/main/filter/source/xsltdialog/xmlfiltertabdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -51,11 +51,3 @@ TabDialog DLG_XML_FILTER_TABDIALOG
 		};
 	};
 };
-
-
-
-
-
-
-
-

--- a/main/filter/source/xsltdialog/xmlfiltertabpagebasic.src
+++ b/main/filter/source/xsltdialog/xmlfiltertabpagebasic.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -138,11 +138,3 @@ TabPage RID_XML_FILTER_TABPAGE_BASIC
 		IgnoreTab = TRUE ;
 	};
 };
-
-
-
-
-
-
-
-

--- a/main/filter/source/xsltdialog/xmlfiltertabpagexslt.src
+++ b/main/filter/source/xsltdialog/xmlfiltertabpagexslt.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -169,4 +169,3 @@ TabPage RID_XML_FILTER_TABPAGE_XSLT
 		Text [ en-US ]	= "Browse...";
 	};
 };
-

--- a/main/filter/source/xsltdialog/xmlfiltertestdialog.src
+++ b/main/filter/source/xsltdialog/xmlfiltertestdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -85,7 +85,7 @@ ModalDialog DLG_XML_FILTER_TEST_DIALOG
 		HelpId				= HID_XML_FILTER_TEST_EXPORT_BROWSE;
 		Text [ en-US ]	= "~Browse...";
 	};
-	
+
 	PushButton PB_CURRENT_DOCUMENT
 	{
 		Pos					= MAP_APPFONT ( SECOND_ROW_X , FIRST_ROW_Y + 3 * ROW_HEIGHT + 3 * SPACING ) ;
@@ -163,7 +163,7 @@ ModalDialog DLG_XML_FILTER_TEST_DIALOG
 		TabStop				= TRUE ;
 		Text [ en-US ]	= "B~rowse...";
 	};
-	
+
 	PushButton PB_RECENT_DOCUMENT
 	{
 		Pos					= MAP_APPFONT ( SECOND_ROW_X , FIRST_ROW_Y + 10 * ROW_HEIGHT + 10 * SPACING ) ;
@@ -180,7 +180,7 @@ ModalDialog DLG_XML_FILTER_TEST_DIALOG
 		HelpId				= HID_XML_FILTER_TEST_IMPORT_RECENT_FILE;
 		Right				= TRUE;
 	};
-		
+
 	PushButton PB_CLOSE
 	{
 		Pos					= MAP_APPFONT ( DIALOG_WIDTH - 2*50 - 2*6 , DIALOG_HEIGHT - 6 - 14 ) ;
@@ -196,11 +196,3 @@ ModalDialog DLG_XML_FILTER_TEST_DIALOG
 		Size				= MAP_APPFONT ( 50, 14 );
 	};
 };
-
-
-
-
-
-
-
-

--- a/main/forms/source/resource/strings.src
+++ b/main/forms/source/resource/strings.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/forms/source/resource/xforms.src
+++ b/main/forms/source/resource/xforms.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/formula/source/core/resource/core_resource.src
+++ b/main/formula/source/core/resource/core_resource.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -88,7 +88,7 @@ Resource RID_STRLIST_FUNCTION_NAMES_ENGLISH_ODFF
     String SC_OPCODE_COSECANT { Text = "CSC" ; };
     String SC_OPCODE_SECANT { Text = "SEC" ; };
     String SC_OPCODE_COSECANT_HYP { Text = "CSCH" ; };
-    String SC_OPCODE_SECANT_HYP { Text = "SECH" ; }; 
+    String SC_OPCODE_SECANT_HYP { Text = "SECH" ; };
 	String SC_OPCODE_EXP { Text = "EXP" ; };
 	String SC_OPCODE_LN { Text = "LN" ; };
 	String SC_OPCODE_SQRT { Text = "SQRT" ; };
@@ -1978,5 +1978,3 @@ Resource RID_STRLIST_FUNCTION_NAMES
     };
     /* END defined ERROR.TYPE() values. */
 };
-
-

--- a/main/formula/util/hidother.src
+++ b/main/formula/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/framework/util/hidother.src
+++ b/main/framework/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/reportdesign/source/ui/dlg/GroupsSorting.src
+++ b/main/reportdesign/source/ui/dlg/GroupsSorting.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -41,14 +41,14 @@ FloatingWindow RID_GROUPS_SORTING
 	Moveable = TRUE ;
 	Closeable = TRUE ;
 	Sizeable = TRUE;
-	
+
 	FixedLine FL_SEPARATOR2
 	{
 		Pos = MAP_APPFONT ( RELATED_CONTROLS , RELATED_CONTROLS ) ;
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "Groups";
 	};
-	
+
 	Control WND_CONTROL
 	{
 		Pos = MAP_APPFONT( UNRELATED_CONTROLS, 2*UNRELATED_CONTROLS );
@@ -57,7 +57,7 @@ FloatingWindow RID_GROUPS_SORTING
 		Border = TRUE;
 		TabStop = TRUE;
 	};
-	
+
 	FixedText FT_MOVELABEL
 	{
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS , 3*UNRELATED_CONTROLS + BROWSER_HEIGHT ) ;
@@ -65,15 +65,15 @@ FloatingWindow RID_GROUPS_SORTING
 //		Text [ en-US ] = "Move group" ;
 		Text [ en-US ] = "Group actions" ;
 	};
-	
+
 //     /*
 //       |                                  PAGE_WIDTH                                            |
 //       |                         /-----\            {-------\            /---------\            |
 //       | unreleated FT_MOVELABEL |PB_UP| unreleated |PB_DOWN| unreleated |PD_DELETE| unreleated |
-//       |                         \_____/            \_______/            \_________/            | 
-// 
+//       |                         \_____/            \_______/            \_________/            |
+//
 //       Don't set any position here, it will be done in OGroupsSortingDialog::Resize()
-// 
+//
 //       Find possible IMAGEBUTTON_* in rscicpx.cxx
 //       Symbol is vclrsc.hxx
 //      */
@@ -86,7 +86,7 @@ FloatingWindow RID_GROUPS_SORTING
 //         Symbol = IMAGEBUTTON_SPIN_UP ; // triangle up
 // //        Symbol = IMAGEBUTTON_FLOAT;
 // 	};
-// 	
+//
 // 	ImageButton PB_DOWN
 // 	{
 // 		Pos = MAP_APPFONT ( PAGE_WIDTH - 2*UNRELATED_CONTROLS - 2*14 - 2*RELATED_CONTROLS, 3*UNRELATED_CONTROLS + BROWSER_HEIGHT - 1 ) ;
@@ -95,9 +95,9 @@ FloatingWindow RID_GROUPS_SORTING
 // //        Symbol = IMAGEBUTTON_ARROW_DOWN ; // arrow down
 // //        Symbol = IMAGEBUTTON_FIRST ;
 //         Symbol = IMAGEBUTTON_SPIN_DOWN;
-// 
+//
 // 	};
-// 	
+//
 // 	ImageButton PB_DELETE
 // 	{
 // 		Pos = MAP_APPFONT ( PAGE_WIDTH - UNRELATED_CONTROLS - 14, 3*UNRELATED_CONTROLS + BROWSER_HEIGHT - 1 ) ;
@@ -120,7 +120,7 @@ FloatingWindow RID_GROUPS_SORTING
 			{
 				Identifier = SID_RPT_GROUPSORT_MOVE_UP ;
 				// Command = ".uno:ReportGroupMoveUp" ; // default_images/res/commandimages/sc_reportgroupmoveup.png
-				HelpID = HID_RPT_GROUPSORT_MOVE_UP ; 
+				HelpID = HID_RPT_GROUPSORT_MOVE_UP ;
 				Text [ en-US ] = "Move up" ;
 				Checkable = TRUE;
 //                Disable              = TRUE;
@@ -128,7 +128,7 @@ FloatingWindow RID_GROUPS_SORTING
 			ToolBoxItem
 			{
 				Identifier = SID_RPT_GROUPSORT_MOVE_DOWN ;
-				// Command = ".uno:ReportGroupMoveDown" ; 
+				// Command = ".uno:ReportGroupMoveDown" ;
 				HelpID = HID_RPT_GROUPSORT_MOVE_DOWN ;
 				Text [ en-US ] = "Move down" ;
 				Checkable = TRUE;
@@ -152,7 +152,7 @@ FloatingWindow RID_GROUPS_SORTING
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "Properties";
 	};
-	
+
 	FixedText FT_ORDER
 	{
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS , 4*UNRELATED_CONTROLS + BROWSER_HEIGHT + BUTTON_HEIGHT + FIXEDTEXT_HEIGHT ) ;
@@ -175,7 +175,7 @@ FloatingWindow RID_GROUPS_SORTING
 			< "Ascending" ; 0 ; > ;
 			< "Descending" ; 1 ; > ;
 		};
-		
+
 	};
 	FixedText FT_HEADER
 	{
@@ -183,7 +183,7 @@ FloatingWindow RID_GROUPS_SORTING
         Size = MAP_APPFONT ( FIXEDTEXT_WIDTH , FIXEDTEXT_HEIGHT ) ;
         Hide = TRUE;
 		Text [ en-US ] = "Group Header" ;
-		
+
 	};
 	ListBox LST_HEADERLST
 	{
@@ -207,7 +207,7 @@ FloatingWindow RID_GROUPS_SORTING
         Size = MAP_APPFONT ( FIXEDTEXT_WIDTH , FIXEDTEXT_HEIGHT ) ;
         Hide = TRUE;
         Text [ en-US ] = "Group Footer" ;
-		
+
 	};
 	ListBox LST_FOOTERLST
 	{
@@ -231,7 +231,7 @@ FloatingWindow RID_GROUPS_SORTING
         Size = MAP_APPFONT ( FIXEDTEXT_WIDTH , FIXEDTEXT_HEIGHT ) ;
         Hide = TRUE;
 		Text [ en-US ] = "Group On" ;
-		
+
 	};
 	ListBox LST_GROUPONLST
 	{
@@ -264,7 +264,7 @@ FloatingWindow RID_GROUPS_SORTING
 		Size = MAP_APPFONT( LISTBOX_WIDTH, EDIT_HEIGHT );
 		TabStop = TRUE;
 	};
-	
+
 	FixedText FT_KEEPTOGETHER
 	{
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS , 9*UNRELATED_CONTROLS + BROWSER_HEIGHT + BUTTON_HEIGHT + 6*FIXEDTEXT_HEIGHT) ;
@@ -289,21 +289,21 @@ FloatingWindow RID_GROUPS_SORTING
 			< "With First Detail" ; 2 ; > ;
 		};
 	};
-	
+
 	FixedLine FL_SEPARATOR1
 	{
 		Pos = MAP_APPFONT ( RELATED_CONTROLS , 10*UNRELATED_CONTROLS + BROWSER_HEIGHT + BUTTON_HEIGHT + 7*FIXEDTEXT_HEIGHT) ;
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "Help";
 	};
-	
+
 	FixedText HELP_FIELD
 	{
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS , 12*UNRELATED_CONTROLS + BROWSER_HEIGHT + BUTTON_HEIGHT + 7*FIXEDTEXT_HEIGHT) ;
 		Size = MAP_APPFONT( PAGE_WIDTH - 2*UNRELATED_CONTROLS, 4*FIXEDTEXT_HEIGHT);
 		WordBreak = TRUE;
 	};
-	
+
 //BTN 	Image IMG_UP_H
 //BTN 	{
 //BTN 		ImageBitmap = Bitmap { File = "arrow_move_up_hc" ; };
@@ -397,7 +397,7 @@ Menu RID_GROUPSROWPOPUPMENU
 {
 	ItemList =
 	{
-/*	
+/*
 		MenuItem
 		{
 			ITEM_EDIT_CUT
@@ -471,7 +471,7 @@ ImageList IMGLST_GROUPSORT_DLG_SCH
 //     };
 //     DEF_MASKCOLOR;
 // };
-// 
+//
 // Image IMG_GROUPSORT_MOVEUP_H
 // {
 //     ImageBitmap = Bitmap

--- a/main/reportdesign/source/ui/dlg/PageNumber.src
+++ b/main/reportdesign/source/ui/dlg/PageNumber.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -40,14 +40,14 @@ ModalDialog RID_PAGENUMBERS
 	HelpId = HID_RPT_PAGENUMBERS_DLG;
 	Moveable = TRUE ;
 	Closeable = TRUE ;
-	
+
 	FixedLine FL_FORMAT
 	{
 		Pos = MAP_APPFONT ( RELATED_CONTROLS , RELATED_CONTROLS ) ;
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS, FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "Format";
 	};
-	
+
 	RadioButton RB_PAGE_N
 	{
 	    HelpID = "reportdesign:RadioButton:RID_PAGENUMBERS:RB_PAGE_N";
@@ -64,14 +64,14 @@ ModalDialog RID_PAGENUMBERS
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
         Text [ en-US ]  = "Page N of M";
 	};
-	
+
 	FixedLine FL_POSITION
 	{
 		Pos = MAP_APPFONT ( RELATED_CONTROLS , 3*RELATED_CONTROLS + UNRELATED_CONTROLS + 3*FIXEDTEXT_HEIGHT) ;
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "Position";
 	};
-	
+
 	RadioButton RB_PAGE_TOPPAGE
 	{
 	    HelpID = "reportdesign:RadioButton:RID_PAGENUMBERS:RB_PAGE_TOPPAGE";
@@ -85,17 +85,17 @@ ModalDialog RID_PAGENUMBERS
 	{
 	    HelpID = "reportdesign:RadioButton:RID_PAGENUMBERS:RB_PAGE_BOTTOMPAGE";
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS + RELATED_CONTROLS, 5*RELATED_CONTROLS + UNRELATED_CONTROLS + 5*FIXEDTEXT_HEIGHT) ;
-		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;		
+		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
         Text [ en-US ]  = "Bottom of Page (Footer)";
 	};
-	
+
 	FixedLine FL_MISC
 	{
 		Pos = MAP_APPFONT ( RELATED_CONTROLS , 5*RELATED_CONTROLS + 2*UNRELATED_CONTROLS + 6*FIXEDTEXT_HEIGHT) ;
 		Size = MAP_APPFONT ( PAGE_WIDTH - 2*RELATED_CONTROLS , FIXEDTEXT_HEIGHT ) ;
 		Text [ en-US ] = "General";
 	};
-	
+
 	FixedText FL_ALIGNMENT
 	{
 		Pos = MAP_APPFONT ( UNRELATED_CONTROLS , 6*RELATED_CONTROLS + 2*UNRELATED_CONTROLS + 7*FIXEDTEXT_HEIGHT) ;

--- a/main/reportdesign/source/ui/inspection/inspection.src
+++ b/main/reportdesign/source/ui/inspection/inspection.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -260,37 +260,37 @@ String RID_STR_ILLEGAL_POSITION
 	Text [ en-US ] = "This position can not be set. It is invalid.";
 };
 String RID_STR_SCOPE_GROUP
-{	
+{
     Text [ en-US ] = "Group: %1";
 };
 String RID_STR_FORMULALIST
-{	
+{
     Text [ en-US ] = "Function";
 };
 String RID_STR_SCOPE
-{	
+{
     Text [ en-US ] = "Scope";
 };
 String RID_STR_TYPE
-{	
+{
     Text [ en-US ] = "Data Field Type";
 };
 Resource RID_STR_TYPE_CONST
 {
     String 1
-    {	
+    {
         Text [ en-US ] = "Field or Formula";
     };
     String 2
-    {	
+    {
         Text [ en-US ] = "Function";
     };
     String 3
-    {	
+    {
         Text [ en-US ] = "Counter";
     };
     String 4
-    {	
+    {
         Text [ en-US ] = "User defined Function";
     };
 };
@@ -385,4 +385,3 @@ String RID_STR_F_MAXIMUM
 {
 	Text [ en-US ] = "Maximum" ;
 };
-

--- a/main/reportdesign/util/hidother.src
+++ b/main/reportdesign/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -120,14 +120,14 @@ hidspecial HID_RPT_PROP_CONTROLBACKGROUNDTRANSPARENT    { HelpId = HID_RPT_PROP_
 /*
 hidspecial SID_ARRANGEMENU    { HelpId = SID_ARRANGEMENU; };
 hidspecial SID_SELECTALL_IN_SECTION    { HelpId = SID_SELECTALL_IN_SECTION; };
-hidspecial SID_SECTION_ALIGN { HelpId = SID_SECTION_ALIGN; };         
-hidspecial SID_SECTION_ALIGN_LEFT { HelpId = SID_SECTION_ALIGN_LEFT; };    
-hidspecial SID_SECTION_ALIGN_CENTER { HelpId = SID_SECTION_ALIGN_CENTER; };  
-hidspecial SID_SECTION_ALIGN_RIGHT { HelpId = SID_SECTION_ALIGN_RIGHT; };   
-hidspecial SID_SECTION_ALIGN_UP { HelpId = SID_SECTION_ALIGN_UP; };      
-hidspecial SID_SECTION_ALIGN_MIDDLE { HelpId = SID_SECTION_ALIGN_MIDDLE; };  
-hidspecial SID_SECTION_ALIGN_DOWN { HelpId = SID_SECTION_ALIGN_DOWN; };    
-hidspecial SID_NEXT_MARK { HelpId = SID_NEXT_MARK; };    
+hidspecial SID_SECTION_ALIGN { HelpId = SID_SECTION_ALIGN; };
+hidspecial SID_SECTION_ALIGN_LEFT { HelpId = SID_SECTION_ALIGN_LEFT; };
+hidspecial SID_SECTION_ALIGN_CENTER { HelpId = SID_SECTION_ALIGN_CENTER; };
+hidspecial SID_SECTION_ALIGN_RIGHT { HelpId = SID_SECTION_ALIGN_RIGHT; };
+hidspecial SID_SECTION_ALIGN_UP { HelpId = SID_SECTION_ALIGN_UP; };
+hidspecial SID_SECTION_ALIGN_MIDDLE { HelpId = SID_SECTION_ALIGN_MIDDLE; };
+hidspecial SID_SECTION_ALIGN_DOWN { HelpId = SID_SECTION_ALIGN_DOWN; };
+hidspecial SID_NEXT_MARK { HelpId = SID_NEXT_MARK; };
 hidspecial SID_PREV_MARK { HelpId = SID_PREV_MARK; };
 hidspecial SID_SECTION_SHRINK { HelpId = SID_SECTION_SHRINK; };
 hidspecial SID_SECTION_SHRINK_TOP { HelpId = SID_SECTION_SHRINK_TOP; };
@@ -168,4 +168,3 @@ hidspecial HID_RPT_GROUPSORT_DELETE	    { HelpId = HID_RPT_GROUPSORT_DELETE; };
 hidspecial HID_RPT_PROP_MIMETYPE        { HelpId = HID_RPT_PROP_MIMETYPE; };
 hidspecial HID_RPT_PROP_VERTICALALIGN   { HelpId = HID_RPT_PROP_VERTICALALIGN; };
 hidspecial HID_RPT_PROP_PARAADJUST      { HelpId = HID_RPT_PROP_PARAADJUST; };
-

--- a/main/sc/addin/datefunc/dfa.src
+++ b/main/sc/addin/datefunc/dfa.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/formdlg/formdlgs.src
+++ b/main/sc/source/ui/formdlg/formdlgs.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/miscdlgs/sharedocdlg.src
+++ b/main/sc/source/ui/miscdlgs/sharedocdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -62,7 +62,7 @@ ModalDialog RID_SCDLG_SHAREDOCUMENT
         Pos = MAP_APPFONT ( 6 , 82 ) ;
         Size = MAP_APPFONT ( 192 , 72 ) ;
         Border = TRUE ;
-    };    
+    };
     FixedLine FL_END
     {
         Pos = MAP_APPFONT ( 1 , 156 ) ;

--- a/main/sc/source/ui/navipi/navipi.src
+++ b/main/sc/source/ui/navipi/navipi.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -366,45 +366,3 @@ Menu RID_POPUP_NAVIPI_SCENARIO
 		};
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sc/source/ui/pagedlg/hfedtdlg.src
+++ b/main/sc/source/ui/pagedlg/hfedtdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/pagedlg/pagedlg.src
+++ b/main/sc/source/ui/pagedlg/pagedlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/sidebar/AlignmentPropertyPanel.src
+++ b/main/sc/source/ui/sidebar/AlignmentPropertyPanel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "AlignmentPropertyPanel.hrc"
@@ -30,10 +30,10 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 	DialogControl = TRUE;
 	Border = FALSE;
 
-	Size = MAP_APPFONT( PROPERTYPAGE_WIDTH, PANEL_HEIGHT );	
+	Size = MAP_APPFONT( PROPERTYPAGE_WIDTH, PANEL_HEIGHT );
 	HelpID = HID_PROPERTYPANEL_SC_ALIGN_SECTION;
 	Text [ en-US ] = "Alignment";
-		
+
 	//------------ Alignment -------------
 	ToolBox TBX_HORIZONTAL_ALIGNMENT
 	{
@@ -42,32 +42,32 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 		SVLook = TRUE ;
 		Border = FALSE ;
 		HelpID = HID_PROPERTY_PANEL_ALIGN_TBX_HOR;
-		Text [ en-US ] = "Horizontal Alignment" ;	
+		Text [ en-US ] = "Horizontal Alignment" ;
 		ItemList =
 		{
 			ToolBoxItem
 			{
 				Identifier = ID_SUBSTLEFT ;
-				Text [ en-US ] = "Align Left" ;	
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_L;		
+				Text [ en-US ] = "Align Left" ;
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_L;
 			};
 			ToolBoxItem
 			{
 				Identifier = ID_SUBSTCENTER ;
-				Text [ en-US ] = "Align Center" ;	
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_C;			
+				Text [ en-US ] = "Align Center" ;
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_C;
 			};
 			ToolBoxItem
 			{
 				Identifier = ID_SUBSTRIGHT ;
 				Text [ en-US ] = "Align Right" ;
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_R;		
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_R;
 			};
 			ToolBoxItem
 			{
 				Identifier = ID_SUBSTJUSTIFY ;
 				Text [ en-US ] = "Align Justified" ;
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_J;			
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_HOR_J;
 			};
 		};
 	};
@@ -79,28 +79,28 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 		Size = MAP_APPFONT ( TOOLBOX_ITEM_WIDTH * 3 ,  TOOLBOX_ITEM_HEIGHT) ;
 		TabStop = TRUE ;
 		HelpID = HID_PROPERTY_PANEL_ALIGN_TBX_VER;
-		Text [ en-US ] = "Vertical Alignment" ;	
+		Text [ en-US ] = "Vertical Alignment" ;
 		ItemList =
 		{
 			ToolBoxItem
 			{
 				Identifier = IID_VERT_TOP ;
-				Text [ en-US ] = "Align Top" ;	
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_T;		
+				Text [ en-US ] = "Align Top" ;
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_T;
 			};
-			
+
 			ToolBoxItem
 			{
 				Identifier = IID_VERT_CENTER ;
-				Text [ en-US ] = "Align Center Vertically" ;	
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_C;			
+				Text [ en-US ] = "Align Center Vertically" ;
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_C;
 			};
-			
+
 			ToolBoxItem
 			{
 				Identifier = IID_VERT_BOTTOM ;
 				Text [ en-US ] = "Align Bottom" ;
-				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_B;				
+				HelpID = HID_PROPERTY_PANEL_ALIGN_TBI_VER_B;
 			};
 		};
 	};
@@ -108,7 +108,7 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 	FixedText FT_LEFT_INDENT
 	{
 		Pos = MAP_APPFONT ( FT_LEFTINDENT_X, FT_LEFTINDENT_Y );
-		Size = MAP_APPFONT (CBX_WRAP_X - FT_LEFTINDENT_X - 1 , TEXT_HEIGHT) ; //MBOX_WIDTH 
+		Size = MAP_APPFONT (CBX_WRAP_X - FT_LEFTINDENT_X - 1 , TEXT_HEIGHT) ; //MBOX_WIDTH
 		Text [ en-US ] = "Left ~indent:";
 	};
 	MetricField MF_LEFT_INDENT
@@ -134,7 +134,7 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 		Text [ en-US ] = "~Wrap text" ;
 		QuickHelpText [ en-US ] = "Wrap texts automatically.";
 		HelpID = HID_PROPERTY_PANEL_ALIGN_CBX_WRAP;
-	};	
+	};
 	CheckBox CBX_MERGE
 	{
 		Pos = MAP_APPFONT ( CBX_MERGE_X , CBX_MERGE_Y ) ;
@@ -143,7 +143,7 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 		Text [ en-US ] = "~Merge cells" ;
 		QuickHelpText [ en-US ] = "Joins the selected cells into one.";
 		HelpID = HID_PROPERTY_PANEL_ALIGN_CBX_MERGE;
-	};	
+	};
 	//------------ Text orientation ------------
 	FixedText FT_ORIENT
 	{
@@ -183,7 +183,7 @@ Control RID_PROPERTYPANEL_SC_ALIGNMENT
 		QuickHelpText [ en-US ] = "Aligns text vertically.";
 		HelpID = HID_PROPERTY_PANEL_ALIGN_CBX_VERT;
 	};
-	
+
 	Image IMG_ALIGN_LEFT
 	{
 		ImageBitmap = Bitmap{File = "sidebar/sc_alignleft.png";};

--- a/main/sc/source/ui/src/attrdlg.src
+++ b/main/sc/source/ui/src/attrdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -162,42 +162,3 @@ TabPage RID_SCPAGE_PROTECTION
 		Text [ en-US ] = "Print" ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sc/source/ui/src/dbnamdlg.src
+++ b/main/sc/source/ui/src/dbnamdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -181,24 +181,3 @@ ModelessDialog RID_SCDLG_DBNAMES
 		Text [ en-US ] = "Invalid range" ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sc/source/ui/src/miscdlgs.src
+++ b/main/sc/source/ui/src/miscdlgs.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -1433,6 +1433,3 @@ ModalDialog RID_SCDLG_CHARTCOLROW
 	};
 	Text [ en-US ] = "Change Source Data Range" ;
 };
-
-
-

--- a/main/sc/source/ui/src/sc.src
+++ b/main/sc/source/ui/src/sc.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/src/simpref.src
+++ b/main/sc/source/ui/src/simpref.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/src/tabopdlg.src
+++ b/main/sc/source/ui/src/tabopdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/source/ui/styleui/scstyles.src
+++ b/main/sc/source/ui/styleui/scstyles.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/util/hidother.src
+++ b/main/sc/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,20 +7,20 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
-#include "../inc/helpids.h"		
+#include "../inc/helpids.h"
 
 //	Help-IDs fuer Dokument-Fenster
 

--- a/main/scaddins/source/analysis/analysis.src
+++ b/main/scaddins/source/analysis/analysis.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -3706,39 +3706,3 @@ Resource RID_ANALYSIS_FUNCTION_DESCRIPTIONS
 		};
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/scaddins/source/analysis/analysis_deffuncnames.src
+++ b/main/scaddins/source/analysis/analysis_deffuncnames.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -938,5 +938,3 @@ Resource RID_ANALYSIS_DEFFUNCTION_NAMES
 	};
 
 };
-
-

--- a/main/scaddins/source/analysis/analysis_funcnames.src
+++ b/main/scaddins/source/analysis/analysis_funcnames.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -534,51 +534,3 @@ Resource RID_ANALYSIS_FUNCTION_NAMES
 	};
 
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/scaddins/source/datefunc/datefunc.src
+++ b/main/scaddins/source/datefunc/datefunc.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -310,35 +310,3 @@ Resource RID_DATE_DEFFUNCTION_NAMES
         };
     };
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sccomp/source/solver/solver.src
+++ b/main/sccomp/source/solver/solver.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -72,4 +72,3 @@ String RID_ERROR_TIMEOUT
 {
     Text [ en-US ] = "The time limit was reached.";
 };
-

--- a/main/scripting/source/runtimemgr/ScriptExecDialog.src
+++ b/main/scripting/source/runtimemgr/ScriptExecDialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sd/source/ui/table/TableDesignPane.src
+++ b/main/sd/source/ui/table/TableDesignPane.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -32,37 +32,37 @@ Control DLG_TABLEDESIGNPANE
 
 	Size = MAP_APPFONT( 264, 134 );
 	Text [ en-US ] = "Table Design";
-	
+
 	FixedLine FL_STYLE_OPTIONS+1
 	{
         Pos = MAP_APPFONT ( 143, 3 ) ;
         Size = MAP_APPFONT ( 120, 10 ) ;
-		OutputSize = TRUE;	
+		OutputSize = TRUE;
 		Text [ en-US ] = "Show";
 	};
-	
+
 	CheckBox CB_HEADER_ROW+1
 	{
         Pos = MAP_APPFONT ( 146, 3 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "Header Row" ;	
+		Text [ en-US ] = "Header Row" ;
 	};
-	
+
 	CheckBox CB_TOTAL_ROW+1
 	{
         Pos = MAP_APPFONT ( 146, 16 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "Total Row" ;	
+		Text [ en-US ] = "Total Row" ;
 	};
-	
+
 	CheckBox CB_BANDED_ROWS+1
 	{
         Pos = MAP_APPFONT ( 146, 29 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "Banded Rows" ;	
+		Text [ en-US ] = "Banded Rows" ;
 	};
 
 	CheckBox CB_FIRST_COLUMN+1
@@ -70,7 +70,7 @@ Control DLG_TABLEDESIGNPANE
         Pos = MAP_APPFONT ( 146, 42 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "First Column" ;	
+		Text [ en-US ] = "First Column" ;
 	};
 
 	CheckBox CB_LAST_COLUMN+1
@@ -78,7 +78,7 @@ Control DLG_TABLEDESIGNPANE
         Pos = MAP_APPFONT ( 146, 55 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "Last Column" ;	
+		Text [ en-US ] = "Last Column" ;
 	};
 
 	CheckBox CB_BANDED_COLUMNS+1
@@ -86,7 +86,7 @@ Control DLG_TABLEDESIGNPANE
         Pos = MAP_APPFONT ( 146, 68 ) ;
         Size = MAP_APPFONT ( 120 , 10 ) ;
 		TabStop = TRUE ;
-		Text [ en-US ] = "Banded Columns" ;	
+		Text [ en-US ] = "Banded Columns" ;
 	};
 
 	FixedLine FL_TABLE_STYLES+1
@@ -96,13 +96,13 @@ Control DLG_TABLEDESIGNPANE
 		OutputSize = TRUE;
 		Text [ en-US ] = "Styles";
 	};
-	
+
 	Control CT_TABLE_STYLES+1
 	{
         Pos = MAP_APPFONT ( 4, 3 ) ;
 		Size = MAP_APPFONT( 120, 143 );
 		Border = TRUE ;
-		TabStop = TRUE ;	
+		TabStop = TRUE ;
 	};
 };
 
@@ -134,7 +134,7 @@ ModalDialog DLG_TABLEDESIGNPANE
 		Pos = MAP_APPFONT ( 6 , 176 ) ;
 		Size = MAP_APPFONT ( 50 , 14 ) ;
 		TabStop = TRUE ;
-	};	
+	};
 	OKButton BTN_OK
 	{
 		Pos = MAP_APPFONT ( 158 , 176 ) ;

--- a/main/sdext/source/presenter/PresenterScreen.src
+++ b/main/sdext/source/presenter/PresenterScreen.src
@@ -110,4 +110,3 @@ Bitmap SCROLLBARTHUMBMIDDLENORMAL{ File = "presenter/ScrollbarThumbMiddleNormal.
 Bitmap SCROLLBARTHUMBTOPMOUSEOVER{ File = "presenter/ScrollbarThumbTopMouseOver.png"; };
 Bitmap SCROLLBARTHUMBTOPNORMAL{ File = "presenter/ScrollbarThumbTopNormal.png"; };
 Bitmap VIEWBACKGROUND{ File = "presenter/ViewBackground.png"; };
-

--- a/main/sfx2/source/bastyp/fltfnc.src
+++ b/main/sfx2/source/bastyp/fltfnc.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,38 +34,3 @@ String STR_FILTER_CONSULT_SERVICE
 {
 	Text [ en-US ] = "The selected filter $(FILTER) is not included in your edition.\nYou can find information about orders on our homepage.";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sfx2/source/doc/graphhelp.src
+++ b/main/sfx2/source/doc/graphhelp.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -52,4 +52,3 @@ Bitmap BMP_128X128_WRITER_DOC
 {
 	File = "128x128_writer_doc-p.png";
 };
-

--- a/main/sfx2/util/hidother.src
+++ b/main/sfx2/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -101,4 +101,3 @@ hidspecial HID_HELP_TEXT_SELECTION_MODE         { HelpID = HID_HELP_TEXT_SELECTI
 hidspecial HID_DLG_CHECKFORONLINEUPDATE         { HelpID = HID_DLG_CHECKFORONLINEUPDATE; };
 hidspecial HID_DOCINFOSECURITY                  { HelpID = HID_DOCINFOSECURITY; };
 hidspecial HID_TASKPANE_VIEW_MENU               { HelpID = HID_TASKPANE_VIEW_MENU; };
-

--- a/main/svl/source/items/cstitem.src
+++ b/main/svl/source/items/cstitem.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,40 +26,3 @@ String STR_COLUM_DT_AUTO
 {
 	Text [ en-US ] = "automatic" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svl/source/misc/mediatyp.src
+++ b/main/svl/source/misc/mediatyp.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -576,28 +576,3 @@ String STR_SVT_MIMETYPE_APP_SXIPACKED
 {
 	Text [ en-US ] = "%PRODUCTXMLFILEFORMATNAME %PRODUCTXMLFILEFORMATVERSION Presentation (packed)" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svtools/source/brwbox/editbrowsebox.src
+++ b/main/svtools/source/brwbox/editbrowsebox.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svtools/source/control/calendar.src
+++ b/main/svtools/source/control/calendar.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -38,33 +38,3 @@ String STR_SVT_CALENDAR_NONE
 {
 	Text [ en-US ] = "None" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svtools/source/control/filectrl.src
+++ b/main/svtools/source/control/filectrl.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -43,4 +43,3 @@ String STR_TABBAR_PUSHBUTTON_MOVETOEND
 {
 	Text [ en-US ] = "Move To End" ;
 };
-

--- a/main/svtools/source/dialogs/prnsetup.src
+++ b/main/svtools/source/dialogs/prnsetup.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -241,38 +241,3 @@ ModalDialog DLG_SVT_PRNDLG_PRNSETUPDLG
 		Size = MAP_APPFONT ( 50 , 14 ) ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svtools/source/plugapp/testtool.src
+++ b/main/svtools/source/plugapp/testtool.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -194,4 +194,3 @@ String TT_ALTERNATE_CAPTION
 {
 	Text[ en-US ] = "HelpID does not match UniqueID: ";
 };
-

--- a/main/svtools/source/toolpanel/toolpanel.src
+++ b/main/svtools/source/toolpanel/toolpanel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svtools/util/hidother.src
+++ b/main/svtools/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svx/source/accessibility/accessibility.src
+++ b/main/svx/source/accessibility/accessibility.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -204,55 +204,3 @@ String RID_SVXSTR_CHARACTER_CODE
 	// The space behind is a must.
 	Text [ en-US ] = "Character code ";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svx/source/dialog/hyprlink.src
+++ b/main/svx/source/dialog/hyprlink.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -153,11 +153,3 @@ QueryBox RID_SVXQB_DONTEXIST
 	DEFBUTTON = WB_DEF_YES ;
 	Message [ en-US ] = "This URL does not exist.\nInsert anyway?" ;
 };
-
-
-
-
-
-
-
-

--- a/main/svx/source/dialog/prtqry.src
+++ b/main/svx/source/dialog/prtqry.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -40,31 +40,3 @@ String RID_SVXSTR_QRY_PRINT_SELECTION
 {
 	Text [ en-US ] = "~Selection";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/svx/source/dialog/txenctab.src
+++ b/main/svx/source/dialog/txenctab.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -115,4 +115,3 @@ StringArray RID_SVXSTR_TEXTENCODING_TABLE
 	};
 };
  // ********************************************************************** EOF
-

--- a/main/svx/source/dialog/ucsubset.src
+++ b/main/svx/source/dialog/ucsubset.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svx/source/items/svxitems.src
+++ b/main/svx/source/items/svxitems.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -91,8 +91,8 @@ StringArray RID_ATTR_NAMES
 		< "Vertical text alignment"	;   SID_PARA_VERTALIGN ; > ;
 	};
 };
- 
- 
+
+
 String RID_SVXITEMS_EXTRAS_CHARCOLOR
 {
 	Text [ en-US ] = "Font color" ;
@@ -386,4 +386,3 @@ String RID_SVXITEMS_BRUSH_CHAR
 	Text [ en-US ] = "Character background";
 };
  // ********************************************************************** EOF
-

--- a/main/svx/source/mnuctrls/mnuctrls.src
+++ b/main/svx/source/mnuctrls/mnuctrls.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -71,7 +71,3 @@ Menu RID_MN_FONTSIZE {
 		};
 	};
 };
-
-
-
-

--- a/main/svx/source/sidebar/insert/InsertPropertyPanel.src
+++ b/main/svx/source/sidebar/insert/InsertPropertyPanel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,21 +7,21 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "InsertPropertyPanel.hrc"
 #include <sfx2/sidebar/ResourceDefinitions.hrc>
-#include "helpid.hrc"                       
+#include "helpid.hrc"
 
 #define FIRST_LINE_Y    SECTIONPAGE_MARGIN_VERTICAL_TOP
 #define SECOND_LINE_Y   FIRST_LINE_Y + TOOLBOX_ITEM_HEIGHT + CONTROL_SPACING_VERTICAL  + 1
@@ -34,13 +34,13 @@ Control RID_SIDEBAR_INSERT_PANEL
 
 	Size = MAP_APPFONT(
           PROPERTYPAGE_WIDTH,
-          SECTIONPAGE_MARGIN_VERTICAL_TOP 
-          + TOOLBOX_ITEM_HEIGHT * 2 
+          SECTIONPAGE_MARGIN_VERTICAL_TOP
+          + TOOLBOX_ITEM_HEIGHT * 2
           + CONTROL_SPACING_VERTICAL
           + SECTIONPAGE_MARGIN_VERTICAL_BOT);
 	HelpID = HID_SIDEBAR_INSERT_PANEL;
 	Text = "Insert";
-	
+
 	ToolBox TB_INSERT_STANDARD
 	{
 		SVLook = TRUE ;

--- a/main/svx/source/sidebar/possize/PosSizePropertyPanel.src
+++ b/main/svx/source/sidebar/possize/PosSizePropertyPanel.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "PosSizePropertyPanel.hrc"
@@ -37,7 +37,7 @@ Control RID_SIDEBAR_POSSIZE_PANEL
          BTN_FLIP_HORI_Y + TOOLBOX_HEIGHT + SECTIONPAGE_MARGIN_VERTICAL_BOT);
 	HelpID = HID_PROPERTYPANEL_POSIZE_SECTION ;
 	Text  = "Position and Size";
-	
+
 	FixedText FT_WIDTH
 	{
 	    Pos = MAP_APPFONT ( FT_WIDTH_X, FT_WIDTH_Y );
@@ -118,7 +118,7 @@ Control RID_SIDEBAR_POSSIZE_PANEL
 		Pos = MAP_APPFONT ( FT_POSITION_Y_X , FT_POSITION_Y_Y );
 		Size = MAP_APPFONT ( MBOX_WIDTH , TEXT_HEIGHT) ;
 		Text [ en-US ] = "~Vertical:";
-	};	
+	};
 	MetricField MF_SBSHAPE_VERTICAL
 	{
 		Border = TRUE;
@@ -141,8 +141,8 @@ Control RID_SIDEBAR_POSSIZE_PANEL
 		Pos = MAP_APPFONT ( FT_ROTATION_X , FT_ROTATION_Y );
 		Size = MAP_APPFONT ( TEXT_WIDTH + 50, TEXT_HEIGHT) ;
 		Text [ en-US ] = "~Rotation:";
-	};	
-	
+	};
+
 	MetricBox MTR_FLD_ANGLE
 	{
 		Border = TRUE ;
@@ -157,14 +157,14 @@ Control RID_SIDEBAR_POSSIZE_PANEL
 		DropDown = TRUE ;
 		HelpID = HID_PROPERTY_PANEL_POSIZE_MTR_FLD_ANGLE;
 	};
-	
+
 	FixedText FT_FLIP
 	{
 		Pos = MAP_APPFONT ( FT_FLIP_X , FT_FLIP_Y );
 		Size = MAP_APPFONT ( PROPERTYPAGE_WIDTH - SECTIONPAGE_MARGIN_HORIZONTAL*2  - 40 - CONTROL_SPACING_HORIZONTAL - TOOLBOX_ITEM_WIDTH * 2 , TEXT_HEIGHT) ;//20     wj
 		Text [ en-US ] = "~Flip:";
 	};
-	
+
 	ToolBox TBX_FLIP
 	{
         Pos = MAP_APPFONT ( BTN_FLIP_HORI_X , BTN_FLIP_HORI_Y );
@@ -189,7 +189,7 @@ Control RID_SIDEBAR_POSSIZE_PANEL
 			};
 		};
 	};
-	
+
 	String STR_QH_HORI_FLIP
 	{
 		Text [ en-US ] = "Flip the selected object horizontally.";
@@ -198,7 +198,7 @@ Control RID_SIDEBAR_POSSIZE_PANEL
 	{
 		Text [ en-US ] = "Flip the selected object vertically.";
 	};
-	
+
 	Control	DIAL_CONTROL
 	{
 		Pos = MAP_APPFONT ( ROTATE_CONTROL_X , ROTATE_CONTROL_Y );

--- a/main/svx/source/src/app.src
+++ b/main/svx/source/src/app.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -83,4 +83,3 @@ String RID_DESKTOP
 {
 	Text = "%PRODUCTNAME" ;
 };
-

--- a/main/svx/source/table/table.src
+++ b/main/svx/source/table/table.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,4 +27,3 @@ String RID_SVXSTR_STYLEFAMILY_TABLEDESIGN
 {
     Text [ en-US ] = "Table Design Styles";
 };
-

--- a/main/svx/source/unodialogs/textconversiondlgs/chinese_dialogs.src
+++ b/main/svx/source/unodialogs/textconversiondlgs/chinese_dialogs.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -91,10 +91,10 @@ ModalDialog DLG_CHINESEDICTIONARY
         HelpID = "svx:CheckBox:DLG_CHINESEDICTIONARY:CB_REVERSE";
 		Pos = MAP_APPFONT ( COL_1, ROW_3 ) ;
 		Size = MAP_APPFONT ( FULL_WIDTH - COL_1 - RSC_SP_DLG_INNERBORDER_RIGHT , RSC_CD_CHECKBOX_HEIGHT ) ;
-		
+
 		Text [ en-US ] = "Reverse mapping";
 	};
-	
+
 	FixedText FT_TERM
 	{
         Pos = MAP_APPFONT ( COL_1 , ROW_4 ) ;
@@ -108,8 +108,8 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_1 , ROW_5 ) ;
 		Size = MAP_APPFONT ( COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 	};
-	
-	
+
+
 	FixedText FT_MAPPING
 	{
         Pos = MAP_APPFONT ( COL_2 , ROW_4 ) ;
@@ -123,7 +123,7 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_2 , ROW_5 ) ;
 		Size = MAP_APPFONT ( COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 	};
-	
+
 	FixedText FT_PROPERTY
 	{
         Pos = MAP_APPFONT ( COL_3 , ROW_4 ) ;
@@ -137,7 +137,7 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_3 , ROW_5 ) ;
 		Size = MAP_APPFONT ( REST_COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 		DropDown = TRUE ;
-		
+
         stringlist [ en-US ] =
 		{
 		    < "Other" ; Default ; > ;
@@ -157,14 +157,14 @@ ModalDialog DLG_CHINESEDICTIONARY
 			< "Brand name" ; > ;
 		};
 	};
-	
+
 	Control CT_MAPPINGLIST
 	{
 	    Pos = MAP_APPFONT ( COL_1, ROW_6 ) ;
         Size = MAP_APPFONT ( COL_4 - COL_1 - RSC_SP_CTRL_GROUP_X, LIST_HEIGHT ) ;
         TabStop = TRUE ;
 	};
-	
+
 	PushButton PB_ADD
 	{
 	    HelpID = "svx:PushButton:DLG_CHINESEDICTIONARY:PB_ADD";
@@ -189,13 +189,13 @@ ModalDialog DLG_CHINESEDICTIONARY
 
 		Text [ en-US ] = "~Delete";
 	};
-		
+
     FixedLine FL_BOTTOMLINE
 	{
         Pos = MAP_APPFONT ( 0 , ROW_7 ) ;
         Size = MAP_APPFONT ( FULL_WIDTH, RSC_CD_FIXEDLINE_HEIGHT ) ;
 	};
-	
+
 	BUTTONS_OK_CANCEL_HELP_ABREAST( FULL_WIDTH - RSC_SP_DLG_INNERBORDER_RIGHT, ROW_8 )
 };
 
@@ -286,4 +286,3 @@ ModalDialog DLG_CHINESETRANSLATION
 
 	BUTTONS_OK_CANCEL_HELP_ABREAST( T_FULL_WIDTH - RSC_SP_DLG_INNERBORDER_RIGHT, T_ROW_8 )
 };
-

--- a/main/svx/source/unodialogs/textconversiondlgs/chinese_dictionarydialog.src
+++ b/main/svx/source/unodialogs/textconversiondlgs/chinese_dictionarydialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -79,10 +79,10 @@ ModalDialog DLG_CHINESEDICTIONARY
         HelpID = "svx:CheckBox:DLG_CHINESEDICTIONARY:CB_REVERSE";
 		Pos = MAP_APPFONT ( COL_1, ROW_3 ) ;
 		Size = MAP_APPFONT ( FULL_WIDTH - COL_1 - RSC_SP_DLG_INNERBORDER_RIGHT , RSC_CD_CHECKBOX_HEIGHT ) ;
-		
+
 		Text [ en-US ] = "Reverse mapping";
 	};
-	
+
 	FixedText FT_TERM
 	{
         Pos = MAP_APPFONT ( COL_1 , ROW_4 ) ;
@@ -96,8 +96,8 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_1 , ROW_5 ) ;
 		Size = MAP_APPFONT ( COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 	};
-	
-	
+
+
 	FixedText FT_MAPPING
 	{
         Pos = MAP_APPFONT ( COL_2 , ROW_4 ) ;
@@ -111,7 +111,7 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_2 , ROW_5 ) ;
 		Size = MAP_APPFONT ( COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 	};
-	
+
 	FixedText FT_PROPERTY
 	{
         Pos = MAP_APPFONT ( COL_3 , ROW_4 ) ;
@@ -125,7 +125,7 @@ ModalDialog DLG_CHINESEDICTIONARY
 		Pos = MAP_APPFONT ( COL_3 , ROW_5 ) ;
 		Size = MAP_APPFONT ( REST_COL_WIDTH , RSC_CD_TEXTBOX_HEIGHT ) ;
 		DropDown = TRUE ;
-		
+
         stringlist [ en-US ] =
 		{
 		    < "Other" ; Default ; > ;
@@ -145,14 +145,14 @@ ModalDialog DLG_CHINESEDICTIONARY
 			< "Brand name" ; > ;
 		};
 	};
-	
+
 	Control CT_MAPPINGLIST
 	{
 	    Pos = MAP_APPFONT ( COL_1, ROW_6 ) ;
         Size = MAP_APPFONT ( COL_4 - COL_1 - RSC_SP_CTRL_GROUP_X, LIST_HEIGHT ) ;
         TabStop = TRUE ;
 	};
-	
+
 	PushButton PB_ADD
 	{
 	    HelpID = "svx:PushButton:DLG_CHINESEDICTIONARY:PB_ADD";
@@ -177,12 +177,12 @@ ModalDialog DLG_CHINESEDICTIONARY
 
 		Text [ en-US ] = "~Delete";
 	};
-		
+
     FixedLine FL_BOTTOMLINE
 	{
         Pos = MAP_APPFONT ( 0 , ROW_7 ) ;
         Size = MAP_APPFONT ( FULL_WIDTH, RSC_CD_FIXEDLINE_HEIGHT ) ;
 	};
-	
+
 	BUTTONS_OK_CANCEL_HELP_ABREAST( FULL_WIDTH - RSC_SP_DLG_INNERBORDER_RIGHT, ROW_8 )
 };

--- a/main/svx/source/unodialogs/textconversiondlgs/chinese_translationdialog.src
+++ b/main/svx/source/unodialogs/textconversiondlgs/chinese_translationdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svx/util/hidother.src
+++ b/main/svx/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/source/ui/dbui/addresslistdialog.src
+++ b/main/sw/source/ui/dbui/addresslistdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -124,4 +124,3 @@ ModalDialog DLG_MM_ADDRESSLISTDIALOG
         Text [ en-US ] = "Connecting to data source...";
     };
 };
-

--- a/main/sw/source/ui/dbui/createaddresslistdialog.src
+++ b/main/sw/source/ui/dbui/createaddresslistdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -26,7 +26,7 @@
 #include <helpid.h>
 
 /*-- 13.04.2004 13:58:13---------------------------------------------------
-        
+
   -----------------------------------------------------------------------*/
 ModalDialog DLG_MM_CREATEADDRESSLIST
 {
@@ -170,7 +170,7 @@ ModalDialog DLG_MM_CREATEADDRESSLIST
 };
 
 /*-- 13.04.2004 13:58:13---------------------------------------------------
-        
+
   -----------------------------------------------------------------------*/
 ModelessDialog DLG_MM_FIND_ENTRY
 {
@@ -230,5 +230,3 @@ ModelessDialog DLG_MM_FIND_ENTRY
         Size = MAP_APPFONT ( 50 , 14 ) ;
     };
 };
-
-

--- a/main/sw/source/ui/dbui/dbinsdlg.src
+++ b/main/sw/source/ui/dbui/dbinsdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -259,7 +259,7 @@ ModalDialog DLG_AP_INSERT_DB_SEL
 	{
         Pos = MAP_APPFONT ( 137 , 31 ) ;
         Size = MAP_APPFONT ( 75 , 8 ) ;
-		
+
 		Text [ en-US ] = "Tab~le column(s)" ;
 	};
 	ListBox LB_TABLE_COL
@@ -323,4 +323,3 @@ ModalDialog DLG_AP_INSERT_DB_SEL
 	};
 	Text [ en-US ] = "Insert Database Columns" ;
 };
-

--- a/main/sw/source/ui/dbui/dbtablepreviewdialog.src
+++ b/main/sw/source/ui/dbui/dbtablepreviewdialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -54,4 +54,3 @@ ModalDialog DLG_MM_DBTABLEPREVIEWDIALOG
         Text [ en-US ] = "~Close";
     };
 };
-

--- a/main/sw/source/ui/dbui/mailmergewizard.src
+++ b/main/sw/source/ui/dbui/mailmergewizard.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/source/ui/dbui/mmaddressblockpage.src
+++ b/main/sw/source/ui/dbui/mmaddressblockpage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -75,12 +75,12 @@ TabPage DLG_MM_ADDRESSBLOCK_PAGE
         Hide = TRUE;
         Text[ en-US ] = "Current address list: %1";
     };
-    FixedLine FL_FIRST 
+    FixedLine FL_FIRST
     {
         Pos = MAP_APPFONT ( 6 , 55 ) ;
         Size = MAP_APPFONT ( 248 , 8 ) ;
     };
-    FixedText       FI_SECOND   
+    FixedText       FI_SECOND
     {
         Pos = MAP_APPFONT ( 6 , 66 ) ;
         Size = MAP_APPFONT ( 10 , 8 ) ;
@@ -139,7 +139,7 @@ TabPage DLG_MM_ADDRESSBLOCK_PAGE
         Size = MAP_APPFONT ( 60 , 14 ) ;
         Text[ en-US ] = "Match ~Fields...";
     };
-    FixedLine FL_THIRD 
+    FixedLine FL_THIRD
     {
         Pos = MAP_APPFONT ( 6 , 169 ) ;
         Size = MAP_APPFONT ( 248 , 8 ) ;
@@ -150,19 +150,19 @@ TabPage DLG_MM_ADDRESSBLOCK_PAGE
         Size = MAP_APPFONT ( 10 , 8 ) ;
         Text[ en-US ] = "4.";
     };
-    FixedText       FI_PREVIEW    
+    FixedText       FI_PREVIEW
     {
         Pos = MAP_APPFONT ( 16 , 180 ) ;
         Size = MAP_APPFONT ( 228 , 8 ) ;
         Text[ en-US ] = "Check if the address data matches correctly.";
     };
-    Window          WIN_PREVIEW   
+    Window          WIN_PREVIEW
     {
         Border = TRUE;
         Pos = MAP_APPFONT ( 12 , 191 ) ;
         Size = MAP_APPFONT ( 176 , 46 ) ;
     };
-    FixedText       FI_DOCINDEX   
+    FixedText       FI_DOCINDEX
     {
         Pos = MAP_APPFONT ( 111 , 239 ) ;
         Size = MAP_APPFONT ( 50 , 8 ) ;
@@ -312,8 +312,8 @@ ModalDialog DLG_MM_CUSTOMIZEADDRESSBLOCK
     HelpID = HID_MM_CUSTOMIZEADDRESSBLOCK;
     Size = MAP_APPFONT ( 320 , 176 ) ;
     Moveable = TRUE ;
-   
-    WORKAROUND 
+
+    WORKAROUND
 
     String ST_TITLE_EDIT
     {

--- a/main/sw/source/ui/dbui/mmdocselectpage.src
+++ b/main/sw/source/ui/dbui/mmdocselectpage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -99,6 +99,3 @@ TabPage DLG_MM_DOCSELECT_PAGE
         Border = TRUE;
     };
 };
-
-
-

--- a/main/sw/source/ui/dbui/mmgreetingspage.src
+++ b/main/sw/source/ui/dbui/mmgreetingspage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -28,7 +28,7 @@
         StringList [en-US]=             \
         {                               \
             < "< not available >" ; > ; \
-        };                              
+        };
 
 
 #define GREETINGS_BODY  \
@@ -147,24 +147,24 @@ TabPage DLG_MM_GREETINGS_PAGE
     };
     GREETINGS_BODY
     FixedText       FI_PREVIEW
-    {                                                                               
+    {
         Pos = MAP_APPFONT ( 12 , 168 ) ;
-        Size = MAP_APPFONT ( 242 , 8 ) ;                                            
+        Size = MAP_APPFONT ( 242 , 8 ) ;
         Text[ en-US ] = "Preview";
-    };                                                                              
+    };
     Window          WIN_PREVIEW
-    {                                                                               
+    {
         Pos = MAP_APPFONT ( 12 , 179 );
-        Size = MAP_APPFONT ( 186 , 21 ) ;                                           
+        Size = MAP_APPFONT ( 186 , 21 ) ;
         Border = TRUE;
-    };                                                                              
+    };
     PushButton      PB_ASSIGN
-    {                                                                               
+    {
         HelpID = "sw:PushButton:DLG_MM_GREETINGS_PAGE:PB_ASSIGN";
         Pos = MAP_APPFONT ( 204 , 179 ) ;
-        Size = MAP_APPFONT ( 50 , 14 ) ;                                            
+        Size = MAP_APPFONT ( 50 , 14 ) ;
         Text[ en-US ] = "~Match fields...";
-    };                                                                              
+    };
     FixedText       FI_DOCINDEX
     {
         Pos = MAP_APPFONT ( 121 , 206 ) ;
@@ -193,7 +193,7 @@ TabPage DLG_MM_GREETINGS_PAGE
     };
 };
 
-#undef TOP_OFFSET 
+#undef TOP_OFFSET
 #undef LEFT_OFFSET
 
 #define TOP_OFFSET 0
@@ -207,12 +207,12 @@ ModalDialog DLG_MM_MAILBODY
     Moveable = TRUE ;
     Text [ en-US ] = "E-Mail Message";
     CheckBox    CB_GREETINGLINE
-    {                                                                               
+    {
         HelpID = "sw:CheckBox:DLG_MM_MAILBODY:CB_GREETINGLINE";
-        Pos = MAP_APPFONT ( 6  , 3 ) ;                    
-        Size = MAP_APPFONT ( 242 , 10 ) ;                                           
+        Pos = MAP_APPFONT ( 6  , 3 ) ;
+        Size = MAP_APPFONT ( 242 , 10 ) ;
         Text[ en-US ] = "This e-mail should contain a salutation";
-    };                                                                              
+    };
     GREETINGS_BODY
     FixedText           FT_BODY
     {
@@ -253,5 +253,3 @@ ModalDialog DLG_MM_MAILBODY
         Size = MAP_APPFONT ( 50 , 14 ) ;
     };
 };
-
-

--- a/main/sw/source/ui/dbui/mmlayoutpage.src
+++ b/main/sw/source/ui/dbui/mmlayoutpage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -156,6 +156,3 @@ TabPage DLG_MM_LAYOUT_PAGE
     };
 
 };
-
-
-

--- a/main/sw/source/ui/dbui/mmmergepage.src
+++ b/main/sw/source/ui/dbui/mmmergepage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -98,6 +98,3 @@ TabPage DLG_MM_MERGE_PAGE
         Text [ en-US ] = "Ma~tch case";
     };
 };
-
-
-

--- a/main/sw/source/ui/dbui/mmoutputpage.src
+++ b/main/sw/source/ui/dbui/mmoutputpage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -483,4 +483,3 @@ ModalDialog DLG_MM_QUERY
         Size = MAP_APPFONT ( 50 , 14 ) ;
     };
 };
-

--- a/main/sw/source/ui/dbui/mmoutputtypepage.src
+++ b/main/sw/source/ui/dbui/mmoutputtypepage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -84,6 +84,3 @@ TabPage DLG_MM_OUTPUTTYPE_PAGE
         Text[ en-US ] = "Send e-mail messages to a group of recipients. The e-mail messages can contain a salutation. The e-mail messages can be personalized for each recipient.";
     };
 };
-
-
-

--- a/main/sw/source/ui/dbui/mmpreparemergepage.src
+++ b/main/sw/source/ui/dbui/mmpreparemergepage.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -124,5 +124,3 @@ TabPage DLG_MM_PREPAREMERGE_PAGE
         Text[ en-US ] = "~Edit Document...";
     };
 };
-
-

--- a/main/sw/source/ui/dbui/selectdbtabledialog.src
+++ b/main/sw/source/ui/dbui/selectdbtabledialog.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/source/ui/dialog/docstdlg.src
+++ b/main/sw/source/ui/dialog/docstdlg.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -142,39 +142,3 @@ TabPage TP_DOC_STAT
 		Text [ en-US ] = "~Update" ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/dialog/regionsw.src
+++ b/main/sw/source/ui/dialog/regionsw.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/source/ui/envelp/envelp.src
+++ b/main/sw/source/ui/envelp/envelp.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -48,36 +48,3 @@ String STR_SENDER_TOKENS
 {
 	Text [ en-US ] = "COMPANY;CR;FIRSTNAME; ;LASTNAME;CR;ADDRESS;CR;CITY; ;STATEPROV; ;POSTALCODE;CR;COUNTRY;CR;";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/envelp/envlop.src
+++ b/main/sw/source/ui/envelp/envlop.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -177,33 +177,3 @@ String STR_DOC_TITLE
 {
 	Text [ en-US ] = "Envelope" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/envelp/envprt.src
+++ b/main/sw/source/ui/envelp/envprt.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -262,32 +262,3 @@ Bitmap BMP_VER_RGHT_UPPER_H
 {
 	File = "envvr_u_h.png" ;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/envelp/label.src
+++ b/main/sw/source/ui/envelp/label.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -683,72 +683,3 @@ TabPage TP_BUSINESS_DATA
 		Border = TRUE ;
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/envelp/labfmt.src
+++ b/main/sw/source/ui/envelp/labfmt.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -373,36 +373,3 @@ ModalDialog DLG_SAVE_LABEL
 	};
 	Text [ en-US ] = "Save Label Format";
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/index/multmrk.src
+++ b/main/sw/source/ui/index/multmrk.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #include "index.hrc"

--- a/main/sw/source/ui/misc/numberingtypelistbox.src
+++ b/main/sw/source/ui/misc/numberingtypelistbox.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -56,39 +56,3 @@ Resource STRRES_NUMTYPES
 		};
 	};
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main/sw/source/ui/utlui/poolfmt.src
+++ b/main/sw/source/ui/utlui/poolfmt.src
@@ -89,7 +89,7 @@ String STR_POOLCHR_ENDNOTE_ANCHOR
 	Text [ en-US ] = "Endnote anchor" ;
 };
 
-// HTML styles 
+// HTML styles
 String STR_POOLCHR_HTML_EMPHASIS
 {
 	Text [ en-US ] = "Emphasis" ;

--- a/main/sw/source/ui/web/web.src
+++ b/main/sw/source/ui/web/web.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -75,5 +75,3 @@ String RID_WEBOLE_TOOLBOX
 {
     Text [ en-US ] = "Object/Web" ;
 };
-
-

--- a/main/sw/util/hidother.src
+++ b/main/sw/util/hidother.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -307,22 +307,22 @@ hidspecial HID_INSERT_FILE                                 { HelpID = HID_INSERT
 hidspecial HID_NID_TBL                  { HelpId = HID_NID_TBL; };
 hidspecial HID_NID_FRM                  { HelpId = HID_NID_FRM; };
 hidspecial HID_NID_GRF                  { HelpId = HID_NID_GRF; };
-hidspecial HID_NID_OLE                  { HelpId = HID_NID_OLE; };                  
-hidspecial HID_NID_PGE                  { HelpId = HID_NID_PGE ; };                 
-hidspecial HID_NID_OUTL                 { HelpId = HID_NID_OUTL; };                 
-hidspecial HID_NID_MARK                 { HelpId = HID_NID_MARK; };                 
-hidspecial HID_NID_DRW                  { HelpId = HID_NID_DRW ; };                 
+hidspecial HID_NID_OLE                  { HelpId = HID_NID_OLE; };
+hidspecial HID_NID_PGE                  { HelpId = HID_NID_PGE ; };
+hidspecial HID_NID_OUTL                 { HelpId = HID_NID_OUTL; };
+hidspecial HID_NID_MARK                 { HelpId = HID_NID_MARK; };
+hidspecial HID_NID_DRW                  { HelpId = HID_NID_DRW ; };
 hidspecial HID_NID_CTRL                 { HelpId = HID_NID_CTRL; };
-hidspecial HID_NID_PREV                 { HelpId = HID_NID_PREV; };                 
-hidspecial HID_NID_REG                  { HelpId = HID_NID_REG ; };                 
-hidspecial HID_NID_BKM                  { HelpId = HID_NID_BKM ; };                 
-hidspecial HID_NID_SEL                  { HelpId = HID_NID_SEL     ; };             
-hidspecial HID_NID_FTN                  { HelpId = HID_NID_FTN     ; };             
-hidspecial HID_NID_POSTIT               { HelpId = HID_NID_POSTIT  ; };             
-hidspecial HID_NID_SRCH_REP             { HelpId = HID_NID_SRCH_REP; };             
-hidspecial HID_NID_INDEX_ENTRY          { HelpId = HID_NID_INDEX_ENTRY         ; }; 
-hidspecial HID_NID_TABLE_FORMULA        { HelpId = HID_NID_TABLE_FORMULA       ; }; 
-hidspecial HID_NID_TABLE_FORMULA_ERROR  { HelpID = HID_NID_TABLE_FORMULA_ERROR ; }; 
+hidspecial HID_NID_PREV                 { HelpId = HID_NID_PREV; };
+hidspecial HID_NID_REG                  { HelpId = HID_NID_REG ; };
+hidspecial HID_NID_BKM                  { HelpId = HID_NID_BKM ; };
+hidspecial HID_NID_SEL                  { HelpId = HID_NID_SEL     ; };
+hidspecial HID_NID_FTN                  { HelpId = HID_NID_FTN     ; };
+hidspecial HID_NID_POSTIT               { HelpId = HID_NID_POSTIT  ; };
+hidspecial HID_NID_SRCH_REP             { HelpId = HID_NID_SRCH_REP; };
+hidspecial HID_NID_INDEX_ENTRY          { HelpId = HID_NID_INDEX_ENTRY         ; };
+hidspecial HID_NID_TABLE_FORMULA        { HelpId = HID_NID_TABLE_FORMULA       ; };
+hidspecial HID_NID_TABLE_FORMULA_ERROR  { HelpID = HID_NID_TABLE_FORMULA_ERROR ; };
 hidspecial HID_NID_NEXT                 { HelpID = HID_NID_NEXT  ; };
 hidspecial HID_MM_SELECTDBTABLEDDIALOG_LISTBOX             { HelpID = HID_MM_SELECTDBTABLEDDIALOG_LISTBOX; };
 hidspecial HID_MM_ADDRESSLIST_HB                           { HelpID = HID_MM_ADDRESSLIST_HB ; };
@@ -367,4 +367,3 @@ hidspecial HID_MM_HEADER_10                          { HelpID = HID_MM_HEADER_10
 hidspecial HID_MM_HEADER_11                          { HelpID = HID_MM_HEADER_11;};
 hidspecial HID_MM_HEADER_12                          { HelpID = HID_MM_HEADER_12;};
 hidspecial HID_MM_HEADER_13                          { HelpID = HID_MM_HEADER_13;};
-

--- a/main/ucbhelper/workben/ucbexplorer/ucbexplorer.src
+++ b/main/ucbhelper/workben/ucbexplorer/ucbexplorer.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -144,4 +144,3 @@ String TEXT_TITLEBAR
 {
     Text [ en-US ] = "UCB Explorer" ;
 };
-

--- a/main/wizards/source/imagelists/imagelists.src
+++ b/main/wizards/source/imagelists/imagelists.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -208,4 +208,3 @@ Image IMG_WEB_LAYOUT_FRAMEBOTTOM_HC
 {
 	ImageBitmap = Bitmap { File = "frame_bottom_h.png"; };
 };
-

--- a/main/wizards/source/template/template.src
+++ b/main/wizards/source/template/template.src
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 #define SAMPLES		1000
@@ -351,4 +351,3 @@ String Newsletter + 12
 {
     Text [ en-US ] = "Double-sided";
 };
-


### PR DESCRIPTION
Enforced 3 hooks for `.src` files

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace