### PR TITLE
pre-commit whitespace clean up for `sdi` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,12 @@ repos:
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        files: \.(asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/sc/sdi/app.sdi
+++ b/main/sc/sdi/app.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
 interface StarCalc
 [
@@ -85,5 +85,3 @@ shell ScModule
 {
 			import StarCalc[Automation];
 }
-
-

--- a/main/sc/sdi/cellsh.sdi
+++ b/main/sc/sdi/cellsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
  // ===========================================================================
 interface CellSelection
@@ -45,7 +45,7 @@ interface CellSelection
 	SID_OPENDLG_FUNCTION		[ ExecMethod = Execute; StateMethod = GetCellState; ]
 	SID_INS_FUNCTION			[ ExecMethod = ExecuteEdit; StateMethod = GetState; ]
 
-    // no Exec/StateMethod needed, but SfxDispatcher complains if the slot is not included in the shell 
+    // no Exec/StateMethod needed, but SfxDispatcher complains if the slot is not included in the shell
     SID_VALIDITY_REFERENCE []
 
 	// Datenbank-Operationen {
@@ -418,4 +418,3 @@ shell ScCellShell : ScFormatShell
 {
 	import Cell[Automation];
 }
-

--- a/main/sc/sdi/docsh.sdi
+++ b/main/sc/sdi/docsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/sdi/drawsh.sdi
+++ b/main/sc/sdi/drawsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -100,7 +100,7 @@ interface TableDraw
 
     // For the sidebar
 	SID_ATTR_TRANSFORM_WIDTH	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ]
-    SID_ATTR_TRANSFORM_HEIGHT	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ] 
+    SID_ATTR_TRANSFORM_HEIGHT	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ]
     SID_ATTR_TRANSFORM_POS_X	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ]
     SID_ATTR_TRANSFORM_POS_Y	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ]
     SID_ATTR_TRANSFORM_ANGLE	[ StateMethod = GetDrawAttrStateForIFBX; Export = FALSE; ]

--- a/main/sc/sdi/drtxtob.sdi
+++ b/main/sc/sdi/drtxtob.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -83,7 +83,7 @@ interface TableDrawText
 	SID_ALIGNCENTERHOR			[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ALIGNRIGHT				[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ALIGNBLOCK				[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
-	
+
 	SID_ATTR_PARA_ADJUST_LEFT				[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_ADJUST_CENTER			    [ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_ADJUST_RIGHT				[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
@@ -91,7 +91,7 @@ interface TableDrawText
 	SID_ATTR_PARA_LRSPACE                   [ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_LINESPACE                 [ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_ULSPACE                   [ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
-	
+
 	SID_ATTR_PARA_LINESPACE_10	[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_LINESPACE_15	[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_ATTR_PARA_LINESPACE_20	[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]

--- a/main/sc/sdi/editsh.sdi
+++ b/main/sc/sdi/editsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -72,7 +72,7 @@ interface TableText
 	SID_ATTR_CHAR_KERNING		[ ExecMethod = ExecuteAttr; StateMethod = GetAttrState; Export = FALSE; ]
 	SID_CELL_FORMAT_RESET	[ ExecMethod = Execute; StateMethod = GetState; Export = FALSE; ]
 	SID_CHAR_DLG			[ ExecMethod = Execute; StateMethod = GetState; Export = FALSE; ]
-	SID_CHAR_DLG_EFFECT		[ ExecMethod = Execute; StateMethod = GetState; Export = FALSE; ] 
+	SID_CHAR_DLG_EFFECT		[ ExecMethod = Execute; StateMethod = GetState; Export = FALSE; ]
 	SID_TOGGLE_REL			[ ExecMethod = Execute; StateMethod = GetState; Export = FALSE; ]
 
 	SID_HYPERLINK_SETLINK	[ ExecMethod = Execute; Export = FALSE; ]
@@ -104,4 +104,3 @@ shell ScEditShell
 {
 	import TableText;
 }
-

--- a/main/sc/sdi/formatsh.sdi
+++ b/main/sc/sdi/formatsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
  // ===========================================================================
 interface TableFont
@@ -147,5 +147,3 @@ shell ScFormatShell
 //	import Interior ".Interior";
 	import TableFont ".Font";
 }
-
-

--- a/main/sc/sdi/graphsh.sdi
+++ b/main/sc/sdi/graphsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -145,4 +145,3 @@ shell ScGraphicShell : ScDrawShell
 {
 	import GraphSelection;
 }
-

--- a/main/sc/sdi/mediash.sdi
+++ b/main/sc/sdi/mediash.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/sdi/pgbrksh.sdi
+++ b/main/sc/sdi/pgbrksh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
  // ===========================================================================
 shell ScPageBreakShell

--- a/main/sc/sdi/pivotsh.sdi
+++ b/main/sc/sdi/pivotsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/sdi/prevwsh.sdi
+++ b/main/sc/sdi/prevwsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sc/sdi/scalc.sdi
+++ b/main/sc/sdi/scalc.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -7800,7 +7800,7 @@ SfxVoidItem ShareDocument SID_SHARE_DOC
 SvxColorItem TabBgColor FID_TAB_SET_TAB_BG_COLOR
 
 [
-    // flags: 
+    // flags:
     AutoUpdate = FALSE,
     Cachable = Cachable,
     FastCall = FALSE,
@@ -7815,7 +7815,7 @@ SvxColorItem TabBgColor FID_TAB_SET_TAB_BG_COLOR
 
     Readonly = FALSE,
 
-    // config: 
+    // config:
     AccelConfig = TRUE,
     MenuConfig = TRUE,
     StatusBarConfig = FALSE,

--- a/main/sc/sdi/scslots.sdi
+++ b/main/sc/sdi/scslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -71,4 +71,3 @@ ModulePrefix( "Sc" )
 	include "mediash.sdi"
 
 }
-

--- a/main/sc/sdi/tabpopsh.sdi
+++ b/main/sc/sdi/tabpopsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -24,4 +24,3 @@ shell ScTabPopShell
 {
 	//	nix drin
 }
-

--- a/main/sc/sdi/tabvwsh.sdi
+++ b/main/sc/sdi/tabvwsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,19 +7,19 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
- 
+
 
 
  // ===========================================================================
@@ -278,5 +278,3 @@ shell ScTabViewShell
 	SID_TBXCTL_INSOBJ		[ ExecMethod = ExecTbx; StateMethod = GetTbxState; ]
 
 }
-
-

--- a/main/sd/sdi/ViewShellBase.sdi
+++ b/main/sd/sdi/ViewShellBase.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sd/sdi/_docsh.sdi
+++ b/main/sd/sdi/_docsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -77,4 +77,3 @@ interface DrawDocument
 		StateMethod = GetState;
 	]
 }
-

--- a/main/sd/sdi/_drvwsh.sdi
+++ b/main/sd/sdi/_drvwsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -237,22 +237,22 @@ interface DrawView
         ExecMethod = FuTemporary ;
         StateMethod = GetDrawAttrState ;
     ]
-	SID_ATTR_TRANSFORM_ROT_X	
+	SID_ATTR_TRANSFORM_ROT_X
 	[
         ExecMethod = FuTemporary ;
         StateMethod = GetDrawAttrState ;
     ]
-	SID_ATTR_TRANSFORM_ROT_Y	
+	SID_ATTR_TRANSFORM_ROT_Y
 	[
         ExecMethod = FuTemporary ;
         StateMethod = GetDrawAttrState ;
     ]
-    SID_ATTR_TRANSFORM_PROTECT_POS	
+    SID_ATTR_TRANSFORM_PROTECT_POS
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetDrawAttrState ;
     ]
-	SID_ATTR_TRANSFORM_PROTECT_SIZE	
+	SID_ATTR_TRANSFORM_PROTECT_SIZE
 	[
         ExecMethod = FuTemporary ;
         StateMethod = GetDrawAttrState ;
@@ -803,7 +803,7 @@ interface DrawView
         ExecMethod = FuPermanent ;
         StateMethod = GetMenuState ;
     ]
-    
+
     SID_OBJECT_CROP // ole : no, status : play rec
     [
         ExecMethod = FuPermanent ;
@@ -2386,13 +2386,13 @@ interface DrawView
         ExecMethod = FuSupport ;
         StateMethod = GetMenuState ;
     ]
-    
+
     SID_FORMATPAINTBRUSH //
     [
         ExecMethod = FuPermanent ;
         StateMethod = GetMenuState ;
     ]
- 
+
     SID_HEADER_AND_FOOTER // ole : no, status : ?
     [
         ExecMethod = ExecCtrl ;
@@ -2410,13 +2410,13 @@ interface DrawView
         ExecMethod = ExecCtrl ;
         StateMethod = GetMenuState ;
 	]
-	
+
 	SID_MASTER_LAYOUTS
 	[
 		ExecMethod = ExecCtrl ;
 		StateMethod = GetMenuState ;
 	]
-	
+
     SID_OPT_LOCALE_CHANGED // ole : no, status : ?
     [
         ExecMethod = ExecCtrl ;
@@ -2467,7 +2467,7 @@ interface DrawView
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetMenuState ;
-    ]   
+    ]
     SID_EXTRUSION_DIRECTION_FLOATER
     [
         ExecMethod = FuTemporary ;
@@ -2567,17 +2567,17 @@ interface DrawView
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetMenuState ;
-    ]   
+    ]
     SID_DRAW_FONTWORK
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetMenuState ;
-    ]    
+    ]
     SID_DRAW_FONTWORK_VERTICAL
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetMenuState ;
-    ]    
+    ]
     SID_DRAWTBX_CS_BASIC
     [
         ExecMethod = FuPermanent ;
@@ -2612,7 +2612,7 @@ interface DrawView
     [
         ExecMethod = FuPermanent ;
         StateMethod = GetMenuState ;
-    ]   
+    ]
     SID_AVMEDIA_PLAYER // ole : yes, status : ?
     [
         ExecMethod = FuTemporary ;
@@ -2737,16 +2737,16 @@ interface DrawView
     SID_TABLE_VERT_NONE
     [
         ExecMethod = ExecutePropPanelAttr ;
-        StateMethod = GetStatePropPanelAttr ;		
+        StateMethod = GetStatePropPanelAttr ;
     ]
     SID_TABLE_VERT_CENTER
     [
         ExecMethod = ExecutePropPanelAttr ;
-        StateMethod = GetStatePropPanelAttr ;	
+        StateMethod = GetStatePropPanelAttr ;
     ]
     SID_TABLE_VERT_BOTTOM
     [
         ExecMethod = ExecutePropPanelAttr ;
-        StateMethod = GetStatePropPanelAttr ;	
+        StateMethod = GetStatePropPanelAttr ;
     ]
 }

--- a/main/sd/sdi/app.sdi
+++ b/main/sd/sdi/app.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface StarImpress
@@ -102,4 +102,3 @@ shell SdModule
 {
 	import StarImpress[Automation];
 }
-

--- a/main/sd/sdi/docshell.sdi
+++ b/main/sd/sdi/docshell.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sd/sdi/drbezob.sdi
+++ b/main/sd/sdi/drbezob.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -82,4 +82,3 @@ shell BezierObjectBar
 		StateMethod = GetAttrState;
 	]
 }
-

--- a/main/sd/sdi/drgrfob.sdi
+++ b/main/sd/sdi/drgrfob.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 shell GraphicObjectBar

--- a/main/sd/sdi/drtxtob.sdi
+++ b/main/sd/sdi/drtxtob.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -166,7 +166,7 @@ shell TextObjectBar
 		StateMethod = GetAttrState;
 	]
 
-	SID_ATTR_CHAR_KERNING   
+	SID_ATTR_CHAR_KERNING
 	[
 		ExecMethod = Execute;
 		StateMethod = GetCharState;
@@ -241,5 +241,5 @@ shell TextObjectBar
         StateMethod = GetAttrState ;
     ]
 
-	
+
 }

--- a/main/sd/sdi/drviewsh.sdi
+++ b/main/sd/sdi/drviewsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -212,12 +212,12 @@ interface ImpressEditView : DrawView
 	[
 		ExecMethod = ExecuteAnnotation;
 		StateMethod = GetAnnotationState;
-	]	
+	]
 	SID_DELETEALLBYAUTHOR_POSTIT
 	[
 		ExecMethod = ExecuteAnnotation;
 		StateMethod = GetAnnotationState;
-	]	
+	]
 }
 
 shell DrawViewShell

--- a/main/sd/sdi/grdocsh.sdi
+++ b/main/sd/sdi/grdocsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sd/sdi/grviewsh.sdi
+++ b/main/sd/sdi/grviewsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -77,7 +77,7 @@ shell GraphicViewShell
 	[
 		ExecMethod = ExecuteAnnotation;
 		StateMethod = GetAnnotationState;
-	]	
+	]
 	SID_DELETEALLBYAUTHOR_POSTIT
 	[
 		ExecMethod = ExecuteAnnotation;

--- a/main/sd/sdi/outlnvsh.sdi
+++ b/main/sd/sdi/outlnvsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -76,7 +76,7 @@ interface OutlineView
     [
         ExecMethod = FuTemporary ;
         StateMethod = GetStatusBarState ;
-    ]    
+    ]
 	SID_ZOOM_OUT // ole : no, status : play rec
 	[
 		ExecMethod = FuTemporary ;
@@ -538,4 +538,3 @@ shell OutlineViewShell
 {
     import OutlineView[Automation];
 }
-

--- a/main/sd/sdi/sdgslots.sdi
+++ b/main/sd/sdi/sdgslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -98,4 +98,3 @@ ModulePrefix( "Sd" )
 		include "mediaob.sdi"
 		include "tables.sdi"
 }
-

--- a/main/sd/sdi/sdnew.sdi
+++ b/main/sd/sdi/sdnew.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 //--------------------------------------------------------------------------
@@ -77,22 +77,22 @@ SvxObjectItem RulerObject SID_RULER_OBJECT
 SfxBoolItem OutputQualityContrast SID_OUTPUT_QUALITY_CONTRAST
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
 	Asynchron;
 
-	Readonly = FALSE, 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	Readonly = FALSE,
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]

--- a/main/sd/sdi/sdraw.sdi
+++ b/main/sd/sdi/sdraw.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 //--------------------------------------------------------------------------
@@ -7156,26 +7156,26 @@ SfxVoidItem TaskPaneEditMaster SID_TP_EDIT_MASTER
 
 SfxVoidItem TaskPaneInsertPage SID_INSERTPAGE_LAYOUT_MENU
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
     Readonly = TRUE,
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_INSERT;
 ]
 

--- a/main/sd/sdi/sdslots.sdi
+++ b/main/sd/sdi/sdslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -99,5 +99,5 @@ ModulePrefix( "Sd" )
         include "SlideSorterController.sdi"
         include "ViewShellBase.sdi"
 		include "mediaob.sdi"
-		include "tables.sdi"	
+		include "tables.sdi"
         }

--- a/main/sd/sdi/tables.sdi
+++ b/main/sd/sdi/tables.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,7 +27,7 @@ shell TableObjectBar
     [
         ExecMethod = Execute ;
         StateMethod = GetState ;
-    ]  
+    ]
 	SID_FRAME_LINESTYLE
 	[
 		ExecMethod = Execute;
@@ -38,7 +38,7 @@ shell TableObjectBar
 		ExecMethod = Execute;
 		StateMethod = GetAttrState;
 	]
-	SID_ATTR_BORDER	
+	SID_ATTR_BORDER
 	[
 		ExecMethod = Execute;
 		StateMethod = GetAttrState;
@@ -146,4 +146,3 @@ shell TableObjectBar
 		StateMethod = GetState;
 	]
 }
-

--- a/main/sfx2/sdi/appslots.sdi
+++ b/main/sfx2/sdi/appslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -280,4 +280,3 @@ shell SfxModule
 }
 
 // eof ------------------------------------------------------------------------
-

--- a/main/sfx2/sdi/docslots.sdi
+++ b/main/sfx2/sdi/docslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sfx2/sdi/frmslots.sdi
+++ b/main/sfx2/sdi/frmslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -116,7 +116,7 @@ interface Window
 		ExecMethod = ChildWindowExecute ;
 		StateMethod = ChildWindowState ;
 	]
-	
+
 	// Pre-defined docking window slots (usable by internal docking windows)
 	SID_DOCKWIN_0
 	[
@@ -174,7 +174,7 @@ interface Window
     - sfx2/source/dialog/dockwin.cxx
     - sfx2/sdi/frmslots.sdi
     - sfx2/inc/sfx2/sfxsids.hrc
-    
+
 	SID_DOCKWIN_10
 	[
 		ExecMethod = ChildWindowExecute ;
@@ -452,4 +452,3 @@ shell SfxViewFrame
 		StateMethod = GetState_Impl ;
     ]
 }
-

--- a/main/sfx2/sdi/sfxitems.sdi
+++ b/main/sfx2/sdi/sfxitems.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
     item void       SfxVoidItem;
@@ -108,4 +108,3 @@
     };
     item SfxScriptOrganizer SfxScriptOrganizerItem;
 	item String     SvxClipboardFmtItem;	//! Dummy
-

--- a/main/sfx2/sdi/sfxslots.sdi
+++ b/main/sfx2/sdi/sfxslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -38,4 +38,3 @@ SlotIdFile( "sfx2/sfx.hrc" )
 	include "appslots.sdi"
 
 }
-

--- a/main/sfx2/sdi/viwslots.sdi
+++ b/main/sfx2/sdi/viwslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/starmath/sdi/smath.sdi
+++ b/main/starmath/sdi/smath.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,40 +7,40 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
 SfxVoidItem Adjust SID_ADJUST
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -48,24 +48,24 @@ SfxVoidItem Adjust SID_ADJUST
 SfxVoidItem ChangeAlignment SID_ALIGN
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_FORMAT;
 ]
 
@@ -73,24 +73,24 @@ SfxVoidItem ChangeAlignment SID_ALIGN
 SfxVoidItem ChangeDistance SID_DISTANCE
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_FORMAT;
 ]
 
@@ -98,24 +98,24 @@ SfxVoidItem ChangeDistance SID_DISTANCE
 SfxVoidItem ChangeFont SID_FONT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_FORMAT;
 ]
 
@@ -123,24 +123,24 @@ SfxVoidItem ChangeFont SID_FONT
 SfxVoidItem ChangeFontSize SID_FONTSIZE
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_FORMAT;
 ]
 
@@ -148,24 +148,24 @@ SfxVoidItem ChangeFontSize SID_FONTSIZE
 SfxVoidItem CommandWindow SID_CMDBOXWINDOW
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_VIEW;
 ]
 
@@ -173,24 +173,24 @@ SfxVoidItem CommandWindow SID_CMDBOXWINDOW
 SfxVoidItem Preferences SID_PREFERENCES
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_OPTIONS;
 ]
 
@@ -198,26 +198,26 @@ SfxVoidItem Preferences SID_PREFERENCES
 SfxStringItem ConfigName SID_TEXT
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_VIEW;
 ]
 
@@ -225,24 +225,24 @@ SfxStringItem ConfigName SID_TEXT
 SfxVoidItem CopyObject SID_COPYOBJECT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_EDIT;
 ]
 
@@ -250,24 +250,24 @@ SfxVoidItem CopyObject SID_COPYOBJECT
 SfxVoidItem Draw SID_DRAW
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -275,24 +275,24 @@ SfxVoidItem Draw SID_DRAW
 SfxVoidItem FitInWindow SID_FITINWINDOW
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -300,24 +300,24 @@ SfxVoidItem FitInWindow SID_FITINWINDOW
 SfxBoolItem FormelCursor SID_FORMULACURSOR
 ()
 [
-	/* flags: */  
-	AutoUpdate = TRUE, 
-	Cachable = Cachable, 
-	FastCall = TRUE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = TRUE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = TRUE,
+	Cachable = Cachable,
+	FastCall = TRUE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = TRUE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_MATH;
 ]
 
@@ -325,26 +325,26 @@ SfxBoolItem FormelCursor SID_FORMULACURSOR
 SfxInt16Item Graphic SID_GAPHIC_SM
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_MATH;
 ]
 
@@ -352,24 +352,24 @@ SfxInt16Item Graphic SID_GAPHIC_SM
 SfxVoidItem InsertCommand SID_INSERTCOMMAND
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Asynchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_INSERT;
 ]
 
@@ -377,24 +377,24 @@ SfxVoidItem InsertCommand SID_INSERTCOMMAND
 SfxVoidItem InsertConfigName SID_INSERTTEXT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Asynchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_INSERT;
 ]
 
@@ -402,24 +402,24 @@ SfxVoidItem InsertConfigName SID_INSERTTEXT
 SfxBoolItem ImportFormula SID_IMPORT_FORMULA
 (SfxStringItem Name SID_IMPORT_FORMULA,SfxStringItem Filter FN_PARAM_1)
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Asynchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_INSERT;
 ]
 
@@ -452,24 +452,24 @@ SfxBoolItem ImportMathMLClipboard SID_IMPORT_MATHML_CLIPBOARD
 SfxVoidItem LoadSymbols SID_LOADSYMBOLS
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Asynchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_OPTIONS;
 ]
 
@@ -477,26 +477,26 @@ SfxVoidItem LoadSymbols SID_LOADSYMBOLS
 SfxStringItem ModifyStatus SID_MODIFYSTATUS
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = TRUE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = TRUE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_VIEW;
 ]
 
@@ -504,24 +504,24 @@ SfxStringItem ModifyStatus SID_MODIFYSTATUS
 SfxVoidItem NextError SID_NEXTERR
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_NAVIGATOR;
 ]
 
@@ -529,24 +529,24 @@ SfxVoidItem NextError SID_NEXTERR
 SfxVoidItem NextMark SID_NEXTMARK
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_NAVIGATOR;
 ]
 
@@ -554,24 +554,24 @@ SfxVoidItem NextMark SID_NEXTMARK
 SfxVoidItem PasteObject SID_PASTEOBJECT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_EDIT;
 ]
 
@@ -579,24 +579,24 @@ SfxVoidItem PasteObject SID_PASTEOBJECT
 SfxVoidItem PrevError SID_PREVERR
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_NAVIGATOR;
 ]
 
@@ -604,24 +604,24 @@ SfxVoidItem PrevError SID_PREVERR
 SfxVoidItem PrevMark SID_PREVMARK
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_NAVIGATOR;
 ]
 
@@ -629,26 +629,26 @@ SfxVoidItem PrevMark SID_PREVMARK
 SfxBoolItem RedrawAutomatic SID_AUTO_REDRAW
 
 [
-	/* flags: */  
+	/* flags: */
 	AutoUpdate = TRUE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -656,24 +656,24 @@ SfxBoolItem RedrawAutomatic SID_AUTO_REDRAW
 SfxVoidItem SaveSymbols SID_SAVESYMBOLS
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_OPTIONS;
 ]
 
@@ -681,24 +681,24 @@ SfxVoidItem SaveSymbols SID_SAVESYMBOLS
 SfxVoidItem SetPaperSize SID_GETEDITTEXT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_MATH;
 ]
 
@@ -706,24 +706,24 @@ SfxVoidItem SetPaperSize SID_GETEDITTEXT
 SfxVoidItem SymbolCatalogue SID_SYMBOLS_CATALOGUE
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_OPTIONS;
 ]
 
@@ -731,24 +731,24 @@ SfxVoidItem SymbolCatalogue SID_SYMBOLS_CATALOGUE
 SfxVoidItem Symbols SID_SYMBOLS
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = TRUE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = TRUE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_OPTIONS;
 ]
 
@@ -756,26 +756,26 @@ SfxVoidItem Symbols SID_SYMBOLS
 SfxBoolItem Textmode SID_TEXTMODE
 
 [
-	/* flags: */  
-	AutoUpdate = TRUE, 
+	/* flags: */
+	AutoUpdate = TRUE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -783,26 +783,26 @@ SfxBoolItem Textmode SID_TEXTMODE
 SfxStringItem TextStatus SID_TEXTSTATUS
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = TRUE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = TRUE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_VIEW;
 ]
 
@@ -810,24 +810,24 @@ SfxStringItem TextStatus SID_TEXTSTATUS
 SfxVoidItem ToolBowWindow SID_TOOLBOXWINDOW
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = FALSE, 
-	MenuConfig = FALSE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = FALSE, 
+	/* config: */
+	AccelConfig = FALSE,
+	MenuConfig = FALSE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = FALSE,
 	GroupId = GID_VIEW;
 ]
 
@@ -835,26 +835,26 @@ SfxVoidItem ToolBowWindow SID_TOOLBOXWINDOW
 SfxBoolItem ToolBox SID_TOOLBOX
 
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
 	Cachable = Cachable,
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = FALSE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = FALSE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	Readonly = FALSE, 
+	Readonly = FALSE,
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -862,24 +862,24 @@ SfxBoolItem ToolBox SID_TOOLBOX
 SfxVoidItem View100 SID_VIEW100
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -887,24 +887,24 @@ SfxVoidItem View100 SID_VIEW100
 SfxVoidItem View200 SID_VIEW200
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -912,24 +912,24 @@ SfxVoidItem View200 SID_VIEW200
 SfxVoidItem View50 SID_VIEW050
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -937,24 +937,24 @@ SfxVoidItem View50 SID_VIEW050
 SfxVoidItem ZoomIn SID_ZOOMIN
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
 
@@ -962,24 +962,23 @@ SfxVoidItem ZoomIn SID_ZOOMIN
 SfxVoidItem ZoomOut SID_ZOOMOUT
 ()
 [
-	/* flags: */  
-	AutoUpdate = FALSE, 
-	Cachable = Cachable, 
-	FastCall = FALSE, 
-	HasCoreId = FALSE, 
-	HasDialog = FALSE, 
-	ReadOnlyDoc = TRUE, 
-	Toggle = FALSE, 
-	Container = FALSE, 
-	RecordAbsolute = FALSE, 
+	/* flags: */
+	AutoUpdate = FALSE,
+	Cachable = Cachable,
+	FastCall = FALSE,
+	HasCoreId = FALSE,
+	HasDialog = FALSE,
+	ReadOnlyDoc = TRUE,
+	Toggle = FALSE,
+	Container = FALSE,
+	RecordAbsolute = FALSE,
 	RecordPerSet;
 	Synchron;
 
-	/* config: */ 
-	AccelConfig = TRUE, 
-	MenuConfig = TRUE, 
-	StatusBarConfig = FALSE, 
-	ToolBoxConfig = TRUE, 
+	/* config: */
+	AccelConfig = TRUE,
+	MenuConfig = TRUE,
+	StatusBarConfig = FALSE,
+	ToolBoxConfig = TRUE,
 	GroupId = GID_VIEW;
 ]
-

--- a/main/starmath/sdi/smitems.sdi
+++ b/main/starmath/sdi/smitems.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -587,5 +587,3 @@ item SvxZoom SvxZoomItem;
 //-------------------------------------------------------------------------
 
 item SbxObject SvxTabStopItem;
-
-

--- a/main/svx/sdi/fmslots.sdi
+++ b/main/svx/sdi/fmslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -763,4 +763,3 @@ shell FmFormShell
 		StateMethod = GetState ;
     ]
 }
-

--- a/main/svx/sdi/svx.sdi
+++ b/main/svx/sdi/svx.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -7791,7 +7791,7 @@ SfxVoidItem OutlineBullet SID_OUTLINE_BULLET
 ]
 
 SfxUInt16Item SetNumber FN_SVX_SET_NUMBER
-[	
+[
 	/* flags: */
 	AutoUpdate = TRUE,
 	Cachable = Cachable,
@@ -7817,7 +7817,7 @@ SfxUInt16Item SetNumber FN_SVX_SET_NUMBER
 
 //--------------------------------------------------------------------------
 SfxUInt16Item SetBullet FN_SVX_SET_BULLET
-[	
+[
 	/* flags: */
 	AutoUpdate = TRUE,
 	Cachable = Cachable,
@@ -15283,7 +15283,7 @@ SfxVoidItem PrepareMailExport SID_MAIL_PREPAREEXPORT
 
     /* status: */
     SlotType = SfxBoolItem
-    
+
     /* config: */
     AccelConfig = FALSE,
     MenuConfig = FALSE,

--- a/main/svx/sdi/svxitems.sdi
+++ b/main/svx/sdi/svxitems.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/svx/sdi/svxslots.sdi
+++ b/main/svx/sdi/svxslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -70,4 +70,3 @@ SlotIdFile( "svxslots.hrc" )
 	}
 */
 }
-

--- a/main/svx/sdi/xoitems.sdi
+++ b/main/svx/sdi/xoitems.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -73,7 +73,7 @@ struct XFillHatch
 	SvxHatchStyle		Style			MID_HATCH_STYLE;
 	INT32				Color			MID_HATCH_COLOR;
 	INT32				Distance		MID_HATCH_DISTANCE;
-	INT32				Angle			MID_HATCH_ANGLE;	
+	INT32				Angle			MID_HATCH_ANGLE;
 };
 item XFillHatch XFillHatchItem;
 

--- a/main/sw/sdi/_annotsh.sdi
+++ b/main/sw/sdi/_annotsh.sdi
@@ -182,13 +182,13 @@ interface _Annotation
 		ExecMethod = Exec;
 		StateMethod = GetState ;
 	]
-	
+
 	SID_ATTR_PARA_LINESPACE
 	[
 		ExecMethod = Exec;
 		StateMethod = GetState ;
 	]
-	
+
 	SID_ATTR_PARA_ULSPACE
 	[
 		ExecMethod = Exec;
@@ -215,7 +215,7 @@ interface _Annotation
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR" ;
 	]
- 
+
 	SID_ATTR_CHAR_COLOR // api:
 	[
 		ExecMethod = Exec;
@@ -229,7 +229,7 @@ interface _Annotation
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR" ;
 	]
-	
+
 	SID_ATTR_CHAR_WEIGHT // api:
 	[
 		ExecMethod = Exec ;
@@ -278,7 +278,7 @@ interface _Annotation
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR" ;
 	]
-	
+
 	SID_ATTR_CHAR_LANGUAGE // status(final|play)
 	[
 		ExecMethod = Execute ;
@@ -401,4 +401,4 @@ interface _Annotation
 		ExecMethod = ExecSearch ;
 		Export = FALSE ;
 	]
-} 
+}

--- a/main/sw/sdi/_beziers.sdi
+++ b/main/sw/sdi/_beziers.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -121,4 +121,3 @@ interface _Bezier : Base
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-

--- a/main/sw/sdi/_docsh.sdi
+++ b/main/sw/sdi/_docsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -123,5 +123,3 @@ interface BaseTextDocument
         StateMethod = GetState;
     ]
 }
-
-

--- a/main/sw/sdi/_drwbase.sdi
+++ b/main/sw/sdi/_drwbase.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -131,5 +131,3 @@ interface BaseTextDrawBase
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-
-

--- a/main/sw/sdi/_formsh.sdi
+++ b/main/sw/sdi/_formsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -36,5 +36,3 @@ interface BaseTextDrawForm
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-
-

--- a/main/sw/sdi/_frmsh.sdi
+++ b/main/sw/sdi/_frmsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -100,13 +100,13 @@ interface BaseTextFrame
     [
         StateMethod = GetDrawAttrStateTextFrame;
     ]
-    
+
     //UUUU
     SID_HATCH_LIST
     [
         StateMethod = GetDrawAttrStateTextFrame;
     ]
-    
+
     //UUUU
     SID_BITMAP_LIST
     [
@@ -419,5 +419,3 @@ interface BaseTextFrame
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-
-

--- a/main/sw/sdi/_grfsh.sdi
+++ b/main/sw/sdi/_grfsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -66,14 +66,14 @@ interface BaseTextGraphic
 		StateMethod = GetAttrState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TWAIN_TRANSFER
 	[
 		ExecMethod = Execute ;
 		StateMethod = GetAttrState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	FN_GRAPHIC_MIRROR_ON_EVEN_PAGES // status(final|play|rec)
 	[
 		ExecMethod = Execute ;
@@ -215,4 +215,3 @@ interface BaseTextGraphic
         ]
 
 }
-

--- a/main/sw/sdi/_listsh.sdi
+++ b/main/sw/sdi/_listsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -104,4 +104,3 @@ interface BaseTextList
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-

--- a/main/sw/sdi/_mediash.sdi
+++ b/main/sw/sdi/_mediash.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/sdi/_tabsh.sdi
+++ b/main/sw/sdi/_tabsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -403,4 +403,3 @@ interface BaseTextTable
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
 }
-

--- a/main/sw/sdi/_textsh.sdi
+++ b/main/sw/sdi/_textsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -60,7 +60,7 @@ interface BaseText
     SID_ATTR_BRUSH_CHAR // status()
 	[
 		ExecMethod = Execute ;
-		StateMethod = GetTxtCtrlState ; 
+		StateMethod = GetTxtCtrlState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 
@@ -99,7 +99,7 @@ interface BaseText
 		ExecMethod = Execute ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    //#outline level,add by zhaojianwei 
+    //#outline level,add by zhaojianwei
     SID_ATTR_PARA_OUTLINE_LEVEL
     [
 		ExecMethod = Execute ;
@@ -821,7 +821,7 @@ interface BaseText
 	]
 	SID_OUTLINE_BULLET // status(final|play)
 	[
-		ExecMethod = ExecEnterNum ;		
+		ExecMethod = ExecEnterNum ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 
@@ -1644,6 +1644,3 @@ interface BaseText
     ]
 
 }  //ende interface text
-
-
-

--- a/main/sw/sdi/_viewsh.sdi
+++ b/main/sw/sdi/_viewsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -98,7 +98,7 @@ interface BaseTextEditView
     [
         ExecMethod = ExecViewOptions ;
         StateMethod = StateViewOptions ;
-    ]       
+    ]
     FN_PRINT_LAYOUT
     [
         ExecMethod = ExecViewOptions ;
@@ -410,7 +410,7 @@ interface BaseTextEditView
 		ExecMethod = ExecTabWin ;
     	StateMethod = StateTabWin ;
 	]
-		
+
     SID_ATTR_PAGE_COLUMN
     [
         ExecMethod = ExecTabWin ;
@@ -654,7 +654,7 @@ interface BaseTextEditView
     ]
 
       //Extra/Optionen/Ansicht
-        //Wird zusammen zum Property ViewSettings  
+        //Wird zusammen zum Property ViewSettings
     FN_VIEW_HIDDEN_PARA
     [
         ExecMethod = ExecViewOptions ;
@@ -677,7 +677,7 @@ interface BaseTextEditView
         Cachable;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     FN_VIEW_BOUNDS // status()
     [
         ExecMethod = ExecViewOptions ;
@@ -802,4 +802,3 @@ interface GlobalContents
 	]
 
 }
-

--- a/main/sw/sdi/annotsh.sdi
+++ b/main/sw/sdi/annotsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -53,22 +53,22 @@ interface Annotation : _Annotation
 		StateMethod = StateDisableItems ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TWAIN_SELECT
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_TWAIN_TRANSFER
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	 SID_INSERT_GRAPHIC
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_AUTOSPELL_CHECK
 	[
 		ExecMethod = Exec;
@@ -91,42 +91,42 @@ interface Annotation : _Annotation
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     FN_INSERT_HARDHYPHEN // status()
     [
         ExecMethod = Exec ;
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     FN_INSERT_HARD_SPACE // status(final|play)
     [
         ExecMethod = Exec ;
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_INSERT_RLM
     [
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_INSERT_LRM
     [
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_INSERT_ZWSP
     [
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_INSERT_ZWNBSP
     [
         ExecMethod = Exec ;
@@ -140,7 +140,7 @@ interface Annotation : _Annotation
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_ATTR_PARA_RIGHT_TO_LEFT
     [
         ExecMethod = Exec ;
@@ -154,20 +154,20 @@ interface Annotation : _Annotation
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TEXTDIRECTION_TOP_TO_BOTTOM
 	[
 		ExecMethod = Exec ;
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_VERTICALTEXT_STATE
 	[
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_CTLFONT_STATE
     [
 		StateMethod = GetState ;
@@ -180,98 +180,98 @@ interface Annotation : _Annotation
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_TRANSLITERATE_TITLE_CASE
     [
         ExecMethod = ExecTransliteration;
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
     SID_TRANSLITERATE_TOGGLE_CASE
     [
         ExecMethod = ExecTransliteration;
         StateMethod = NoState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
     ]
-    
+
 	SID_TRANSLITERATE_UPPER
 	[
 		ExecMethod = ExecTransliteration;
 		StateMethod = NoState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TRANSLITERATE_LOWER
 	[
 		ExecMethod = ExecTransliteration;
 		StateMethod = NoState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TRANSLITERATE_HALFWIDTH
 	[
 		ExecMethod = ExecTransliteration;
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TRANSLITERATE_FULLWIDTH
 	[
 		ExecMethod = ExecTransliteration;
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TRANSLITERATE_HIRAGANA
 	[
 		ExecMethod = ExecTransliteration;
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_TRANSLITERATE_KATAGANA
 	[
 		ExecMethod = ExecTransliteration;
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_ATTR_CHAR_WORDLINEMODE // status(final|play)
 	[
         ExecMethod = Exec ;
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_ATTR_CHAR_RELIEF
 	[
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_ATTR_CHAR_LANGUAGE // status(final|play)
 	[
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_ATTR_CHAR_KERNING // status(final|play)
 	[
         ExecMethod = Exec ;
         StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_ATTR_CHAR_AUTOKERN // // status(final|play)
 	[
         ExecMethod = Exec ;
-        StateMethod = GetState ;	
+        StateMethod = GetState ;
         DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_ATTR_CHAR_ESCAPEMENT // status(final|play)
 	[
         ExecMethod = Exec ;
@@ -289,22 +289,22 @@ interface Annotation : _Annotation
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_STYLE_FAMILY2
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_STYLE_FAMILY3
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_STYLE_FAMILY4
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_STYLE_FAMILY5
 	[
 		StateMethod = StateDisableItems ;
@@ -314,7 +314,7 @@ interface Annotation : _Annotation
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_STYLE_UPDATE_BY_EXAMPLE // status()
 	[
 		StateMethod = StateDisableItems ;
@@ -348,12 +348,12 @@ interface Annotation : _Annotation
 	[
 		StateMethod = StateStatusLine ;
 	]
-	
+
 	FN_STAT_TEMPLATE
 	[
 		StateMethod = StateStatusLine ;
 	]
-	
+
 	SID_LANGUAGE_STATUS
 	[
 		ExecMethod = ExecLingu ;

--- a/main/sw/sdi/beziersh.sdi
+++ b/main/sw/sdi/beziersh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -127,5 +127,3 @@ shell SwBezierShell: SwBaseShell
 {
 	import TextBezier[Automation];
 }
-
-

--- a/main/sw/sdi/docsh.sdi
+++ b/main/sw/sdi/docsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -76,4 +76,3 @@ shell SwGlosDocShell : SwDocShell
 		StateMethod = GetState ;
 	]
 }
-

--- a/main/sw/sdi/drawsh.sdi
+++ b/main/sw/sdi/drawsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -61,7 +61,7 @@ interface TextDraw : TextDrawBase
 		StateMethod = GetDrawAttrState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
 	SID_ATTR_LINE_TRANSPARENCE
 	[
 		Export = FALSE;
@@ -105,12 +105,12 @@ interface TextDraw : TextDrawBase
     [
         StateMethod = GetDrawAttrState ;
     ]
-    
+
     SID_HATCH_LIST
     [
         StateMethod = GetDrawAttrState ;
     ]
-    
+
     SID_BITMAP_LIST
     [
         StateMethod = GetDrawAttrState ;
@@ -263,7 +263,7 @@ interface TextDraw : TextDrawBase
 		StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-	
+
     SID_EXTRUSION_TOOGLE
     [
         ExecMethod = Execute ;
@@ -298,7 +298,7 @@ interface TextDraw : TextDrawBase
     [
         ExecMethod = Execute ;
         StateMethod = GetState ;
-    ]   
+    ]
     SID_EXTRUSION_DIRECTION_FLOATER
     [
         ExecMethod = Execute ;
@@ -393,7 +393,7 @@ interface TextDraw : TextDrawBase
     [
         ExecMethod = Execute ;
         StateMethod = GetState ;
-    ]   
+    ]
     SID_INSERT_GRAPHIC
     [
         // #123922# Add Exec and State methods for the case where Graphic DrawObjects are selected (SdrGrafObj)
@@ -404,7 +404,7 @@ interface TextDraw : TextDrawBase
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_TWAIN_TRANSFER
 	[
 		StateMethod = StateDisableItems ;
@@ -502,7 +502,7 @@ shell SwDrawShell : SwDrawBaseShell
 	[
 		ExecMethod = Execute;
 	]
-	
+
 	SID_OPEN_XML_FILTERSETTINGS // ole : no, status : ?
     [
         ExecMethod = Execute ;
@@ -518,5 +518,3 @@ shell SwDrawShell : SwDrawBaseShell
 		ExecMethod = Execute ;
 	]
 }
-
-

--- a/main/sw/sdi/drwbassh.sdi
+++ b/main/sw/sdi/drwbassh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -41,4 +41,3 @@ shell SwDrawBaseShell: SwBaseShell
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-

--- a/main/sw/sdi/drwtxtsh.sdi
+++ b/main/sw/sdi/drwtxtsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -215,13 +215,13 @@ interface TextDrawText
 		ExecMethod = Execute ;
 		StateMethod = GetState ;
 	]
-	
+
 	SID_ATTR_PARA_LINESPACE // api:
 	[
 		ExecMethod = Execute ;
 		StateMethod = GetState ;
 	]
-	
+
 	SID_ATTR_PARA_ULSPACE
 	[
 		ExecMethod = Execute ;
@@ -546,7 +546,7 @@ interface TextDrawText
         StateMethod = GetState ;
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
-    
+
     SID_LANGUAGE_STATUS
     [
         ExecMethod = Execute;
@@ -565,7 +565,7 @@ interface TextDrawText
 	[
 		ExecMethod = Execute ;
 	]
-	
+
 	SID_OPEN_XML_FILTERSETTINGS // ole : no, status : ?
     [
         ExecMethod = Execute ;
@@ -589,7 +589,7 @@ interface TextDrawText
 	[
 		StateMethod = StateDisableItems ;
 	]
-	
+
 	SID_TWAIN_TRANSFER
 	[
 		StateMethod = StateDisableItems ;
@@ -689,4 +689,3 @@ shell SwDrawTextShell
 		import TextDrawText[Automation];
 		import TextDrawFont ".DrawFont";
 }
-

--- a/main/sw/sdi/formsh.sdi
+++ b/main/sw/sdi/formsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -32,5 +32,3 @@ shell SwDrawFormShell : SwDrawBaseShell
 {
 	import TextDrawForm[Automation];
 }
-
-

--- a/main/sw/sdi/frmsh.sdi
+++ b/main/sw/sdi/frmsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -49,4 +49,3 @@ shell SwFrameShell : SwBaseShell
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-

--- a/main/sw/sdi/grfsh.sdi
+++ b/main/sw/sdi/grfsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -36,5 +36,3 @@ shell SwGrfShell : SwBaseShell
 {
 	import TextGraphic[Automation];
 }
-
-

--- a/main/sw/sdi/listsh.sdi
+++ b/main/sw/sdi/listsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -35,5 +35,3 @@ shell SwListShell : SwBaseShell
 {
 		import TextList[Automation];
 }
-
-

--- a/main/sw/sdi/mediash.sdi
+++ b/main/sw/sdi/mediash.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 

--- a/main/sw/sdi/olesh.sdi
+++ b/main/sw/sdi/olesh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -33,5 +33,3 @@ shell SwOleShell: SwFrameShell
 {
 	import TextOLEObject[Automation];
 }
-
-

--- a/main/sw/sdi/sidebar.sdi
+++ b/main/sw/sdi/sidebar.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface Sidebar [ Automation = FALSE; ]
@@ -31,5 +31,3 @@ interface Sidebar [ Automation = FALSE; ]
 	SID_ATTR_TRANSFORM_PROTECT_POS	[ StateMethod = GetDrawAttrStateForIFBX;]
 	SID_ATTR_TRANSFORM_PROTECT_SIZE	[ StateMethod = GetDrawAttrStateForIFBX;]
 }
-
-

--- a/main/sw/sdi/switems.sdi
+++ b/main/sw/sdi/switems.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -75,4 +75,3 @@ struct ViewLayout
     BOOL    BookMode        MID_VIEWLAYOUT_BOOKMODE;
 };
 item ViewLayout SvxViewLayoutItem;
-

--- a/main/sw/sdi/swslots.sdi
+++ b/main/sw/sdi/swslots.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -118,5 +118,3 @@ ModulePrefix( "Sw" )
 	include "annotsh.sdi"
 
 }
-
-

--- a/main/sw/sdi/tabsh.sdi
+++ b/main/sw/sdi/tabsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -60,4 +60,3 @@ shell SwTableShell : SwBaseShell
 {
 		import TextTable[Automation];
 }
-

--- a/main/sw/sdi/textsh.sdi
+++ b/main/sw/sdi/textsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -117,4 +117,3 @@ shell SwTextShell : SwBaseShell
 {
 	import Text[Automation];
 }
-

--- a/main/sw/sdi/viewsh.sdi
+++ b/main/sw/sdi/viewsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -318,5 +318,3 @@ shell SwPagePreView
 {
 	import TextPrintPreview[Automation];
 }
-
-

--- a/main/sw/sdi/wbasesh.sdi
+++ b/main/sw/sdi/wbasesh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -37,4 +37,3 @@ shell SwWebBaseShell
 		import Shadow "Shadow";
 
 }
-

--- a/main/sw/sdi/wbeziers.sdi
+++ b/main/sw/sdi/wbeziers.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -30,5 +30,3 @@ shell SwBezierShell: SwBaseShell
 {
 	import Bezier[Automation];
 }
-
-

--- a/main/sw/sdi/wdocsh.sdi
+++ b/main/sw/sdi/wdocsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -53,4 +53,3 @@ shell SwWebGlosDocShell : SwWebDocShell
 		StateMethod = GetState ;
 	]
 }
-

--- a/main/sw/sdi/wdrwbase.sdi
+++ b/main/sw/sdi/wdrwbase.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface WebDrawBase : BaseTextDrawBase
@@ -40,5 +40,3 @@ shell SwWebDrawBaseShell: SwBaseShell
 		DisableFlags="SW_DISABLE_ON_PROTECTED_CURSOR";
 	]
 }
-
-

--- a/main/sw/sdi/wformsh.sdi
+++ b/main/sw/sdi/wformsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -32,5 +32,3 @@ shell SwWebDrawFormShell : SwWebDrawBaseShell
 {
 	import WebDrawForm[Automation];
 }
-
-

--- a/main/sw/sdi/wfrmsh.sdi
+++ b/main/sw/sdi/wfrmsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface WebFrame : BaseTextFrame
@@ -34,5 +34,3 @@ shell SwWebFrameShell : SwBaseShell
 {
 		import WebFrame[Automation];
 }
-
-

--- a/main/sw/sdi/wgrfsh.sdi
+++ b/main/sw/sdi/wgrfsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface WebGraphic : BaseTextGraphic
@@ -33,5 +33,3 @@ shell SwWebGrfShell : SwBaseShell
 {
 		import WebGraphic[Automation];
 }
-
-

--- a/main/sw/sdi/wlistsh.sdi
+++ b/main/sw/sdi/wlistsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,4 +34,3 @@ shell SwWebListShell : SwBaseShell
 {
 		import WebList[Automation];
 }
-

--- a/main/sw/sdi/wolesh.sdi
+++ b/main/sw/sdi/wolesh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -35,5 +35,3 @@ shell SwWebOleShell : SwWebFrameShell
 {
 		import WebOLEObject[Automation];
 }
-
-

--- a/main/sw/sdi/wrtapp.sdi
+++ b/main/sw/sdi/wrtapp.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -48,7 +48,7 @@ interface StarWriter
 		DisableFlags="SW_DISABLE_ON_MAILBOX_EDITOR";
 	]
 
-	FN_XFORMS_INIT  // #i31958# 
+	FN_XFORMS_INIT  // #i31958#
 	[
 		ExecMethod = ExecOther ;
 		StateMethod = StateOther ;
@@ -65,7 +65,7 @@ interface StarWriter
 		ExecMethod = ExecOther ;
 		StateMethod = StateOther ;
 	]
-    
+
     FN_MAILMERGE_WIZARD
     [
         ExecMethod = ExecOther ;
@@ -83,4 +83,3 @@ shell SwModule
 {
 	import StarWriter[Automation];
 }
-

--- a/main/sw/sdi/wtabsh.sdi
+++ b/main/sw/sdi/wtabsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -33,4 +33,3 @@ shell SwWebTableShell : SwBaseShell
 {
 		import WebTable[Automation];
 }
-

--- a/main/sw/sdi/wtextsh.sdi
+++ b/main/sw/sdi/wtextsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 interface WebText : BaseText
@@ -40,4 +40,3 @@ shell SwWebTextShell : SwBaseShell
 {
 	import WebText[Automation];
 }
-

--- a/main/sw/sdi/wviewsh.sdi
+++ b/main/sw/sdi/wviewsh.sdi
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -193,7 +193,3 @@ shell SwSrcView
 {
 		import WebSourceView [Automation];
 }
-
-
-
-


### PR DESCRIPTION
Enforce 3 hooks:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace