### PR TITLE
Makefile: Add createwordlist target to regenerate the ignored words list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 PYTHON := $(shell command -v python || command -v python3 || echo python)
 PIP := $(PYTHON) -m pip
 
-.PHONY: check checkinstall checkupdate install
+.PHONY: check checkinstall checkupdate createwordlist install
 
 check: checkinstall
 	@echo "Running pre-commit checks..."
@@ -31,6 +31,10 @@ checkinstall: install
 checkupdate:
 	@echo "Updating pre-commit hooks..."
 	pre-commit autoupdate
+
+createwordlist: install
+	@echo "Regenerating the ignored words list codespell.txt"
+	codespell --skip='./extras' | cut -f2 -d' ' | tr A-Z a-z | sort | uniq > .github/linters/codespell.txt
 
 install:
 	@echo "Installing dependencies..."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
+codespell
 pre-commit


### PR DESCRIPTION
codespell is a popular Python package:

https://pypi.org/project/codespell/

We already run codespell with pre-commit.

This addition to the Makefile is for tooling and developer productivity.

Helpful when doing a local cleanup of the spelling