### PR TITLE
Bump `actions/checkout` to `v6`

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check Out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v6.0.0