### PR TITLE
gha: upgrade to `actions/cache@v5`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -39,7 +39,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
Updated the pre-commit GitHub actions workflow to use version 5

https://github.com/actions/cache/releases/tag/v5.0.0