### PR TITLE
pre-commit whitespace clean up for asm files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,15 @@ repos:
         description: ensures that links to vcs websites are permalinks
       - id: end-of-file-fixer
         description: makes sure files end in a newline and only a newline
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
         description: removes UTF-8 byte order marker
       - id: mixed-line-ending
         description: replaces or checks mixed line ending
-        files: \.(asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
         description: trims trailing whitespace
-        files: (m|M)akefile$|\.(asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/basic/source/runtime/wnt.asm
+++ b/main/basic/source/runtime/wnt.asm
@@ -1,5 +1,5 @@
 ;**************************************************************
-;  
+;
 ;  Licensed to the Apache Software Foundation (ASF) under one
 ;  or more contributor license agreements.  See the NOTICE file
 ;  distributed with this work for additional information
@@ -7,16 +7,16 @@
 ;  to you under the Apache License, Version 2.0 (the
 ;  "License"); you may not use this file except in compliance
 ;  with the License.  You may obtain a copy of the License at
-;  
+;
 ;    http://www.apache.org/licenses/LICENSE-2.0
-;  
+;
 ;  Unless required by applicable law or agreed to in writing,
 ;  software distributed under the License is distributed on an
 ;  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 ;  KIND, either express or implied.  See the License for the
 ;  specific language governing permissions and limitations
 ;  under the License.
-;  
+;
 ;**************************************************************
 
 .386

--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/call.asm
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/call.asm
@@ -6,16 +6,16 @@
 ; to you under the Apache License, Version 2.0 (the
 ; "License"); you may not use this file except in compliance
 ; with the License.  You may obtain a copy of the License at
-; 
+;
 ;   http://www.apache.org/licenses/LICENSE-2.0
-; 
+;
 ; Unless required by applicable law or agreed to in writing,
 ; software distributed under the License is distributed on an
 ; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 ; KIND, either express or implied.  See the License for the
 ; specific language governing permissions and limitations
 ; under the License.
-; 
+;
 
 
 typelib_TypeClass_VOID equ 0
@@ -79,7 +79,7 @@ privateSnippetExecutor PROC FRAME
 	.ALLOCSTACK(48)
 	.ENDPROLOG
 
-	; 4th param: sal_uInt64 *pRegisterReturn 
+	; 4th param: sal_uInt64 *pRegisterReturn
 	lea r9, -8[rbp]
 
 	; 3rd param: sal_Int32 nVtableOffset
@@ -177,7 +177,7 @@ copyStack:
 
 stackIsEmpty:
 	sub rsp, 32       ; we still need shadow space
-	
+
 callMethod:
 	; Find the method pointer
 	mov rax, 16[rbp]


### PR DESCRIPTION
Enforced 3 hooks for asm files:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace