### PR TITLE
pre-commit whitespace clean up for dtd files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,15 @@ repos:
         description: ensures that links to vcs websites are permalinks
       - id: end-of-file-fixer
         description: makes sure files end in a newline and only a newline
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
         description: removes UTF-8 byte order marker
       - id: mixed-line-ending
         description: replaces or checks mixed line ending
-        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
         description: trims trailing whitespace
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/framework/dtd/accelerator.dtd
+++ b/main/framework/dtd/accelerator.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/framework/dtd/event.dtd
+++ b/main/framework/dtd/event.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/framework/dtd/groupuinames.dtd
+++ b/main/framework/dtd/groupuinames.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,25 +7,24 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
 <!ELEMENT groupuinames:template-group-list (groupuinames:template-group*)>
-<!ATTLIST groupuinames:template-group-list xmlns:groupuinames CDATA #FIXED "http://openoffice.org/2006/groupuinames"> 
+<!ATTLIST groupuinames:template-group-list xmlns:groupuinames CDATA #FIXED "http://openoffice.org/2006/groupuinames">
 
 <!ELEMENT groupuinames:template-group>
 <!ATTLIST groupuinames:template-group
 	groupuinames:name CDATA #REQUIRED
 	groupuinames:default-ui-name CDATA #REQUIRED
 >
-

--- a/main/framework/dtd/image.dtd
+++ b/main/framework/dtd/image.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/framework/dtd/menubar.dtd
+++ b/main/framework/dtd/menubar.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/framework/dtd/statusbar.dtd
+++ b/main/framework/dtd/statusbar.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/framework/dtd/toolbar.dtd
+++ b/main/framework/dtd/toolbar.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/helpauthoring/filter/xmlhelp.dtd
+++ b/main/helpauthoring/filter/xmlhelp.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,18 +7,18 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
-<!-- 
+<!--
 Version 03-Feb-2006
   added optional localize attribute to images
 -->

--- a/main/helpcontent2/helpers/xmlhelp.dtd
+++ b/main/helpcontent2/helpers/xmlhelp.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,18 +7,18 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
-<!-- 
+<!--
 Version 03-Feb-2006
   added optional localize attribute to images
 -->

--- a/main/i18npool/source/localedata/data/locale.dtd
+++ b/main/i18npool/source/localedata/data/locale.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 <!-- ............................................................... -->
 <!-- Locale data specification DTD ................................. -->

--- a/main/l10ntools/java/l10nconv/java/com/sun/star/tooling/converter/dtd/xliff.dtd
+++ b/main/l10ntools/java/l10nconv/java/com/sun/star/tooling/converter/dtd/xliff.dtd
@@ -2,7 +2,7 @@
 
 Public Identifier: "-//XLIFF//DTD XLIFF//EN"
 
-  
+
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -10,16 +10,16 @@ Public Identifier: "-//XLIFF//DTD XLIFF//EN"
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
-  
+
 
 
 History of modifications (latest first):
@@ -33,7 +33,7 @@ Apr-19-2001 by YS: Enda+JohnR last changes
 Apr-18-2001 by YS: Removed empty ATTLISTs
 Apr-12-2001 by YS: Changed target* to target+ in trans-match
 Apr-11-2001 by YS: Fixed DOCTYPE id
-Apr-10-2001 by YS: Synchronize from conference call 
+Apr-10-2001 by YS: Synchronize from conference call
 Apr-05-2001 by YS: Synchronize with latest specs
 Apr-04-2001 by YS: Synchronize with latest specs
 Apr-03-2001 by YS: Added name in <prop-group>
@@ -148,7 +148,7 @@ displayed to the end-user.
 
 <?xliff-show-context context-type='value' ?>
 
-Indicates that any <context> element with a context-type set to 'value' should 
+Indicates that any <context> element with a context-type set to 'value' should
 be displayed to the end-user.
 
 -->
@@ -393,7 +393,7 @@ be displayed to the end-user.
 <!ATTLIST mrk
    mtype                CDATA     #REQUIRED
    mid                  NMTOKEN   #IMPLIED
-   comment              CDATA     #IMPLIED   
+   comment              CDATA     #IMPLIED
    ts                   CDATA     #IMPLIED
 >
 
@@ -406,6 +406,3 @@ be displayed to the end-user.
 
 
 <!-- ***** End of DTD ************************************************ -->
-
-
-

--- a/main/migrationanalysis/src/resources/analysis.dtd
+++ b/main/migrationanalysis/src/resources/analysis.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 <!ELEMENT results ( document+ ) >
 <!ATTLIST results generated-by NMTOKEN #REQUIRED >
@@ -68,5 +68,3 @@
 <!ELEMENT note EMPTY >
 <!ATTLIST note index CDATA #REQUIRED >
 <!ATTLIST note value CDATA #REQUIRED >
-
-

--- a/main/officecfg/registry/component-schema.dtd
+++ b/main/officecfg/registry/component-schema.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/officecfg/registry/component-update.dtd
+++ b/main/officecfg/registry/component-update.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/officecfg/registry/data.dtd
+++ b/main/officecfg/registry/data.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/package/dtd/Manifest.dtd
+++ b/main/package/dtd/Manifest.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,21 +7,21 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
 <!ELEMENT manifest:manifest (manifest:file-entry+)>
-<!ATTLIST manifest:manifest xmlns:manifest CDATA #FIXED "http://openoffice.org/2001/manifest"> 
+<!ATTLIST manifest:manifest xmlns:manifest CDATA #FIXED "http://openoffice.org/2001/manifest">
 
 <!ELEMENT manifest:file-entry (manifest:encryption-data?)>
 <!-- manifest:size is usually only specified for encrypted entries -->
@@ -36,7 +36,7 @@
 	manifest:checksum-type CDATA #REQUIRED
 	manifest:checksum CDATA #REQUIRED >
 <!-- algorithm-name specifies the name of the algorithm used to encrypt
-	 the stream, for example Blowfish 
+	 the stream, for example Blowfish
 	 manifest:initialisation-vector is stored encoded in Base64 -->
 <!ELEMENT manifest:algorithm EMPTY>
 <!ATTLIST manifest:algorithm
@@ -45,10 +45,9 @@
 
 <!ELEMENT manifest:key-derivation EMPTY>
 <!-- manifest:key-derivation-name specifies the name of the algorithm used to derive
-	 the key, for example PBKDF2 (see rfc 2898 ) 
+	 the key, for example PBKDF2 (see rfc 2898 )
 	 manifest:salt is stored encoded in Base64 -->
 <!ATTLIST manifest:key-derivation
 	manifest:key-derivation-name CDATA #REQUIRED
 	manifest:salt CDATA #REQUIRED
 	manifest:iteration-count CDATA #REQUIRED>
-

--- a/main/readlicense_oo/docs/readme.dtd
+++ b/main/readlicense_oo/docs/readme.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 <!ELEMENT Readme (Section)+>
 <!ATTLIST Readme

--- a/main/stoc/source/module-description.dtd
+++ b/main/stoc/source/module-description.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -31,9 +31,9 @@
 <!ELEMENT name (#PCDATA)>
 <!ELEMENT description (#PCDATA)>
 <!ELEMENT reference-docu EMPTY >
-<!ATTLIST reference-docu 
+<!ATTLIST reference-docu
 	xmlns:xlink CDATA #FIXED "http://www.w3.org/1999/xlink/Namespace"
-	xlink:type      (simple)        #FIXED "simple" 
+	xlink:type      (simple)        #FIXED "simple"
 	xlink:href      CDATA           #REQUIRED
   	xlink:role      NMTOKEN         #IMPLIED
   	xlink:title   	CDATA           #IMPLIED >

--- a/main/xmerge/java/xmerge/converter.dtd
+++ b/main/xmerge/java/xmerge/converter.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -48,7 +48,7 @@
                                   contains only a "type" element.  This
                                   "type" element specifies the convert-to
                                   mime-type.
-			      
+
      Each converter node may contain these child nodes:
      converter-description      - Descriptive description of the plug-in.
      converter-vendor           - Plug-in vendor name
@@ -63,9 +63,9 @@
                                   exist if the xslt plugin implementation
                                   is to be used.  It is assumed that the
                                   plug-in specified via converter-class-impl
-                                  will make use of this value. 
+                                  will make use of this value.
 				  -->
-     
+
 <!ELEMENT converter  (converter-display-name,
                      converter-description?,
                      converter-vendor?,
@@ -87,4 +87,3 @@
 <!ELEMENT converter-target       EMPTY>
 
 <!ATTLIST converter-target type  CDATA      #REQUIRED>
-

--- a/main/xmerge/source/palmtests/qa-wrapper/results/baseline/xml-base/Blocklist.dtd
+++ b/main/xmerge/source/palmtests/qa-wrapper/results/baseline/xml-base/Blocklist.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -24,7 +24,7 @@
 <!ATTLIST block-list:block-list
 		  block-list:list-name CDATA #REQUIRED>
 <!ELEMENT block-list:block EMPTY>
-<!ATTLIST block-list:block 
+<!ATTLIST block-list:block
 		  block-list:abbreviated-name CDATA #REQUIRED
 		  block-list:package-name CDATA #REQUIRED
 		  block-list:name CDATA #REQUIRED>

--- a/main/xmerge/source/palmtests/qa-wrapper/results/baseline/xml-base/office.dtd
+++ b/main/xmerge/source/palmtests/qa-wrapper/results/baseline/xml-base/office.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/xmerge/source/palmtests/qa/comparator/dtd/Blocklist.dtd
+++ b/main/xmerge/source/palmtests/qa/comparator/dtd/Blocklist.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -24,7 +24,7 @@
 <!ATTLIST block-list:block-list
 		  block-list:list-name CDATA #REQUIRED>
 <!ELEMENT block-list:block EMPTY>
-<!ATTLIST block-list:block 
+<!ATTLIST block-list:block
 		  block-list:abbreviated-name CDATA #REQUIRED
 		  block-list:package-name CDATA #REQUIRED
 		  block-list:name CDATA #REQUIRED>

--- a/main/xmerge/source/palmtests/qa/comparator/dtd/office.dtd
+++ b/main/xmerge/source/palmtests/qa/comparator/dtd/office.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 

--- a/main/xmloff/dtd/Blocklist.dtd
+++ b/main/xmloff/dtd/Blocklist.dtd
@@ -1,5 +1,5 @@
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -24,7 +24,7 @@
 <!ATTLIST block-list:block-list
 		  block-list:list-name CDATA #REQUIRED>
 <!ELEMENT block-list:block EMPTY>
-<!ATTLIST block-list:block 
+<!ATTLIST block-list:block
 		  block-list:abbreviated-name CDATA #REQUIRED
 		  block-list:package-name CDATA #REQUIRED
 		  block-list:name CDATA #REQUIRED>

--- a/main/xmlscript/dtd/dialog.dtd
+++ b/main/xmlscript/dtd/dialog.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -132,7 +132,7 @@
                     dlg:param CDATA #IMPLIED
                     >
 <!-- /deprecated -->
-                        
+
 <!ELEMENT dlg:bulletinboard ((%control;)*)>
 <!ATTLIST dlg:bulletinboard dlg:left %numeric; #IMPLIED
                             dlg:top %numeric; #IMPLIED
@@ -179,7 +179,7 @@
                        dlg:linecount %numeric; #IMPLIED
                        dlg:value CDATA #IMPLIED
                        dlg:hide-inactive-selection %boolean; #IMPLIED
-                       dlg:align (left|center|right) #IMPLIED                       
+                       dlg:align (left|center|right) #IMPLIED
                        >
 
 <!ELEMENT dlg:menulist (dlg:menupopup?, (%event;)*)>
@@ -358,13 +358,13 @@
 			     dlg:readonly %boolean; #IMPLIED
 			     dlg:strict-format %boolean; #IMPLIED
 			     dlg:maxlength %numeric; #IMPLIED
-			     dlg:spin %boolean; #IMPLIED			     
+			     dlg:spin %boolean; #IMPLIED
 			     dlg:align (left|center|right) #IMPLIED
 			     dlg:text CDATA #IMPLIED
 			     dlg:value-default CDATA #IMPLIED
 			     dlg:value-max %numeric; #IMPLIED
 			     dlg:value-min %numeric; #IMPLIED
-			     dlg:value %numeric; #IMPLIED			     
+			     dlg:value %numeric; #IMPLIED
 			     dlg:format-code CDATA #IMPLIED
 			     dlg:format-locale CDATA #IMPLIED
                  dlg:repeat %numeric; #IMPLIED

--- a/main/xmlscript/dtd/libraries.dtd
+++ b/main/xmlscript/dtd/libraries.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -25,17 +25,16 @@
 <!ENTITY % boolean "(true|false)">
 
 <!ELEMENT library:libraries (library:library)*>
-<!ATTLIST library:libraries 
-	xmlns:library CDATA #FIXED "http://openoffice.org/2000/library" 
+<!ATTLIST library:libraries
+	xmlns:library CDATA #FIXED "http://openoffice.org/2000/library"
 	xmlns:xlink CDATA #FIXED "http://www.w3.org/1999/xlink"
 >
 
 <!ELEMENT library:library EMPTY>
-<!ATTLIST library:library 
+<!ATTLIST library:library
 	library:name CDATA #REQUIRED
 	xlink:href CDATA #IMPLIED
 	xlink:type CDATA #IMPLIED
 	library:link %boolean; #REQUIRED
 	library:readonly %boolean; #IMPLIED
 >
-

--- a/main/xmlscript/dtd/library.dtd
+++ b/main/xmlscript/dtd/library.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -25,8 +25,8 @@
 <!ENTITY % boolean "(true|false)">
 
 <!ELEMENT library:library (library:element)*>
-<!ATTLIST library:library 
-	xmlns:library CDATA #FIXED "http://openoffice.org/2000/library" 
+<!ATTLIST library:library
+	xmlns:library CDATA #FIXED "http://openoffice.org/2000/library"
 	library:name CDATA #REQUIRED
 	library:readonly %boolean; #REQUIRED
 	library:passwordprotected %boolean; #REQUIRED
@@ -34,7 +34,6 @@
 >
 
 <!ELEMENT library:element EMPTY>
-<!ATTLIST library:element 
+<!ATTLIST library:element
 	library:name CDATA #REQUIRED
 >
-

--- a/main/xmlscript/dtd/module.dtd
+++ b/main/xmlscript/dtd/module.dtd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--***********************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,16 +8,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  ***********************************************************-->
 
 
@@ -28,4 +28,3 @@
 	script:name CDATA #REQUIRED
 	script:language CDATA #REQUIRED
 >
-


### PR DESCRIPTION
Enforced 3 hooks for dtd files:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace