### PR TITLE
Add Python `.venv` to `.gitignore`; Run pre-commit to fix trailing whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ main/winaccessibility/source/UAccCOMIDL/dlldata.c
 
 # RepoRevision hash file
 /main/solenv/inc/reporevision.lst
+
+# Python
+.venv

--- a/main/vcl/source/control/spinfld.cxx
+++ b/main/vcl/source/control/spinfld.cxx
@@ -1041,7 +1041,7 @@ void SpinField::Draw( OutputDevice* pDev, const Point& rPos, const Size& rSize, 
 		pDev->SetMapMode();
 
 		if ( eOutDevType == OUTDEV_PRINTER )
-		{ 
+		{
 			StyleSettings aStyleSettings = aOldSettings.GetStyleSettings();
 			aStyleSettings.SetFaceColor( COL_LIGHTGRAY );
 			aStyleSettings.SetButtonTextColor( COL_BLACK );


### PR DESCRIPTION
We use codespell and pre-commit both Python packages installed from the requirements-dev.txt file.

Usually for basic Python projects my IDE PyCharm auto sets up a .venv folder

And pre-commit was failing a minor issue