### PR TITLE
pre-commit auto whitespace clean up for template files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,15 @@ repos:
         description: ensures that links to vcs websites are permalinks
       - id: end-of-file-fixer
         description: makes sure files end in a newline and only a newline
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
         description: removes UTF-8 byte order marker
       - id: mixed-line-ending
         description: replaces or checks mixed line ending
-        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
         description: trims trailing whitespace
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|pas|php|pl|pm|pmk|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/helpcontent2/helpers/linkmakefile.template
+++ b/main/helpcontent2/helpers/linkmakefile.template
@@ -19,7 +19,6 @@
 #
 #**************************************************************
 
-
 # edit to match directory level
 PRJ		= %prj%
 # same for all makefiles in "helpcontent2"

--- a/main/helpcontent2/helpers/linkmakefile.template
+++ b/main/helpcontent2/helpers/linkmakefile.template
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,20 +7,20 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
 
-# edit to match directory level 
+# edit to match directory level
 PRJ		= %prj%
 # same for all makefiles in "helpcontent2"
 PRJNAME = helpcontent2

--- a/main/helpcontent2/helpers/makefile.template
+++ b/main/helpcontent2/helpers/makefile.template
@@ -1,5 +1,5 @@
 #**************************************************************
-#  
+#
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -7,19 +7,19 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#  
+#
 #**************************************************************
 
-# edit to match directory level 
+# edit to match directory level
 PRJ		= %prj%
 # same for all makefiles in "helpcontent2"
 PRJNAME = helpcontent2
@@ -39,7 +39,7 @@ MODULE  = %module%
 # this list matches the *.xhp files to process
 XHPFILES = \
 %xhpfiles%
-	
+
 # --- Targets ------------------------------------------------------
 
 .INCLUDE :  target.mk

--- a/main/odk/setsdkenv_windows.template
+++ b/main/odk/setsdkenv_windows.template
@@ -1,5 +1,5 @@
 rem *************************************************************
-rem  
+rem
 rem  Licensed to the Apache Software Foundation (ASF) under one
 rem  or more contributor license agreements.  See the NOTICE file
 rem  distributed with this work for additional information
@@ -7,16 +7,16 @@ rem  regarding copyright ownership.  The ASF licenses this file
 rem  to you under the Apache License, Version 2.0 (the
 rem  "License"); you may not use this file except in compliance
 rem  with the License.  You may obtain a copy of the License at
-rem  
+rem
 rem    http://www.apache.org/licenses/LICENSE-2.0
-rem  
+rem
 rem  Unless required by applicable law or agreed to in writing,
 rem  software distributed under the License is distributed on an
 rem  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 rem  KIND, either express or implied.  See the License for the
 rem  specific language governing permissions and limitations
 rem  under the License.
-rem  
+rem
 rem *************************************************************
 @echo off
 REM This script sets all environment variables, which


### PR DESCRIPTION
Enforced 3 hooks for template files:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace