### PR TITLE
Avoid compiling crashrep with -lnsl under Linux

### DIFF
--- a/main/crashrep/source/unx/makefile.mk
+++ b/main/crashrep/source/unx/makefile.mk
@@ -53,7 +53,10 @@ APP1OBJS=$(OBJFILES)
 APP1RPATH=BRAND
 
 .IF "$(OS)" != "FREEBSD" && "$(OS)" != "MACOSX" && "$(OS)"!="NETBSD"
-APP1STDLIBS+=-ldl -lnsl
+APP1STDLIBS+=-ldl
+.IF "$(OS)" != "LINUX"
+APP1STDLIBS+=-lnsl
+.ENDIF
 .ENDIF
 .IF "$(OS)" == "SOLARIS"
 APP1STDLIBS+=-lsocket


### PR DESCRIPTION
Distributions may not ship libnsl any more.

No other module seems to be compiled with `-lnsl` under Linux.

This patch seems to compile on all Linux systems I have at hand. However, further review is appreciated.