### PR TITLE
pre-commit auto whitespace cleanup for cs files (#478)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,15 @@ repos:
         description: ensures that links to vcs websites are permalinks
       - id: end-of-file-fixer
         description: makes sure files end in a newline and only a newline
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cs|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$|^ext_libraries/.*$|^test/.*$
       - id: fix-byte-order-marker
         description: removes UTF-8 byte order marker
       - id: mixed-line-ending
         description: replaces or checks mixed line ending
-        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
+        files: \.(asm|asp|bas|c|cl|cmd|common|component|cpp|cs|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xsd|xslt?|ya?ml)$|^main/accessibility/.*$|^main/afms/.*$|^main/animations/.*$|^main/apache-commons/.*$|^test/testgui/.*$
       - id: trailing-whitespace
         description: trims trailing whitespace
-        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$
+        files: (m|M)akefile$|\.(asm|asp|bas|bat|c|cl|cmd|common|component|cpp|cs|cxx|dtd|dxp|el|h|hrc|hxx|idl|in|ini|java|js|lst|m|m4|map|md|mk|mm|mod|old|pas|php|pl|pm|pmk|properties|props|py|rc|rdf|rng|s|sdi|sh|src|template|ulf|vbs|xba|xcs|xcu|xdl|xhp|xlb|xmi|xml|xsd|xslt?|ya?ml)$
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/main/cli_ure/qa/climaker/climaker.cs
+++ b/main/cli_ure/qa/climaker/climaker.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -42,13 +42,13 @@ public class Context: ucss.uno.XComponentContext
         TEST_EXCEPTION,
         CREATION_FAILED
     }
-    
+
     public Context(test_kind k, params object[] args)
     {
         kind = k;
 		factory = new Factory(k, args);
     }
-        
+
     public ucss.lang.XMultiComponentFactory getServiceManager()
     {
         if (kind == test_kind.NO_FACTORY)
@@ -130,7 +130,7 @@ public class Logger
     int m_nErrors;
     public Logger() {
     }
-    
+
 	public String Function
 	{
 		set
@@ -142,7 +142,7 @@ public class Logger
 			return m_sFunction;
 		}
 	}
-    
+
     public void assure(bool b) {
         if (b == false)
         {
@@ -154,7 +154,7 @@ public class Logger
     public void printStatus() {
         Console.WriteLine("\n=====================================");
 
-        
+
         String msg;
         if (m_nErrors > 0)
             msg = "Test failed! " + m_nErrors.ToString() + " Errors.";
@@ -177,7 +177,7 @@ public sealed class Test
 {
     public static int Main(String[] args)
     {
-        
+
 //        System.Diagnostics.Debugger.Launch();
 		try
 		{
@@ -327,7 +327,7 @@ public sealed class Test
         l.assure(s.at17.Length == 0);
         l.assure(s.at18.Length == 0);
     }
- 
+
     public void testFullStruct2(Logger l) {
         //TODO:
         Struct2 s = new Struct2(
@@ -463,10 +463,10 @@ public sealed class Test
             new ucss.uno.DeploymentException("DeploymentException", obj);
         ucss.lang.InvalidListenerException excInvalidListener =
             new ucss.lang.InvalidListenerException("ListenerException", obj);
-        
+
         /* create1 does not specify exceptions. Therefore RuntimeExceptions
            fly through and other exceptions cause a DeploymentException.
-        */            
+        */
         try {
             S1.create1(new Context(Context.test_kind.TEST_EXCEPTION, excRuntime));
         } catch (ucss.uno.RuntimeException e) {
@@ -476,7 +476,7 @@ public sealed class Test
             l.assure(false);
         }
 
-        Context c = new Context(Context.test_kind.TEST_EXCEPTION, excException); 
+        Context c = new Context(Context.test_kind.TEST_EXCEPTION, excException);
         try {
             S1.create1(c);
         } catch (ucss.uno.DeploymentException e) {
@@ -808,7 +808,7 @@ public sealed class Test
         //test
         c = new Context(Context.test_kind.NORMAL);
         try {
-            
+
             PolyStruct2 arg1 = new PolyStruct2(typeof(PolyStruct2), 1);
             PolyStruct2 arg2 = new PolyStruct2(new Any(true), 1);
             PolyStruct2 arg3 = new PolyStruct2(true, 1);
@@ -1008,12 +1008,12 @@ public sealed class Test
 			l.assure( sType == "unoidl.test.cliure.climaker.PolyStruct<" +
 				"unoidl.test.cliure.climaker.PolyStruct<System.Char,uno.Any>," +
 				"unoidl.test.cliure.climaker.PolyStruct2<System.Char>>[][]");
-			
-			
-			
- 
-        } 
-		catch (Exception) 
+
+
+
+
+        }
+		catch (Exception)
 		{
             l.assure(false);
         }
@@ -1070,7 +1070,7 @@ public sealed class Test
         }
         else
             l.assure(false);
-        
+
         //function test must not have the oneway attribute and Exception attribute
         arAttr = typeXTest.GetMethod("test").GetCustomAttributes(false);
         l.assure(arAttr.Length == 0);
@@ -1169,8 +1169,8 @@ public sealed class Test
         else
             l.assure(false);
 
-        
-        //test instantiated polymorphic struct: return value        
+
+        //test instantiated polymorphic struct: return value
 //         Type typeXTest = typeof(XTest);
 //         arAttr = typeXTest.GetMethod("testPolyStruct").ReturnTypeCustomAttributes.GetCustomAttributes(false);
 //         if (arAttr.Length == 1)
@@ -1201,7 +1201,7 @@ public sealed class Test
             l.assure(t1 == t2);
             l.assure(t1.PolymorphicName == name);
             l.assure(t1.OriginalType == typeof(unoidl.test.cliure.climaker.PolyStruct));
-            
+
         }
 
     void testInterface(Logger l)
@@ -1229,7 +1229,7 @@ public sealed class Test
             object aXInterface = new object();
             ucss.lang.XComponent aXComponent = (ucss.lang.XComponent) obj;
             bool[] aSeqBool = {true, false, true};
-            
+
             obj.inParameters(aBool, aByte, aShort, aUShort,
                              aInt, aUInt, aLong, aULong,
                              aFloat, aDouble, aChar, aString,
@@ -1308,7 +1308,7 @@ public sealed class Test
                                 ref inoutFloat, ref inoutDouble, ref inoutChar, ref inoutString,
                                 ref inoutType, ref inoutAny, ref inoutEnum2, ref inoutStruct1,
                                 ref inoutXInterface, ref inoutXComponent, ref inoutSeqBool);
-				
+
             l.assure(aBool == inoutBool);
             l.assure(aByte == inoutByte);
             l.assure(aShort == inoutShort);
@@ -1425,7 +1425,7 @@ public sealed class Test
         {
             l.assure(e.Message.IndexOf("Any") != -1);
         }
-        
+
 
         try
         {

--- a/main/cli_ure/qa/climaker/testobjects.cs
+++ b/main/cli_ure/qa/climaker/testobjects.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -50,9 +50,9 @@ class Component:uno.util.WeakComponentBase, XTest
             m_args[i+1] = args[i];
         }
     }
-    
+
 	public Any[] Args {
-		get	
+		get
 		{
             return m_args;
 		}
@@ -171,7 +171,7 @@ class Component:uno.util.WeakComponentBase, XTest
         aXInterface = m_XInterface;
         aXComponent = m_XComponent;
         seqBool = m_seqBool;
-            
+
     }
 
     //returns the values which have been set in a previous call
@@ -195,7 +195,7 @@ class Component:uno.util.WeakComponentBase, XTest
         byte _byte = aByte;
         aByte = m_Byte;
         m_Byte = _byte;
-        
+
         short _short = aShort;
         aShort = m_Short;
         m_Short = _short;
@@ -211,7 +211,7 @@ class Component:uno.util.WeakComponentBase, XTest
         uint _uint = aUInt;
         aUInt = m_UInt;
         m_UInt = _uint;
-        
+
         long _long = aLong;
         aLong = m_Long;
         m_Long = _long;
@@ -219,7 +219,7 @@ class Component:uno.util.WeakComponentBase, XTest
         ulong _ulong = aULong;
         aULong = m_ULong;
         m_ULong = _ulong;
-        
+
         float _f = aFloat;
         aFloat = m_Float;
         m_Float = _f;
@@ -227,7 +227,7 @@ class Component:uno.util.WeakComponentBase, XTest
         double _d = aDouble;
         aDouble = m_Double;
         m_Double = _d;
-        
+
         char _char = aChar;
         aChar = m_Char;
         m_Char = _char;
@@ -251,7 +251,7 @@ class Component:uno.util.WeakComponentBase, XTest
         Struct1 _struct1 = aStruct;
         aStruct = m_Struct1;
         m_Struct1 = _struct1;
-        
+
         object _obj = aXInterface;
         aXInterface = m_XInterface;
         m_XInterface = _obj;
@@ -269,7 +269,7 @@ class Component:uno.util.WeakComponentBase, XTest
     {
         return m_Bool;
     }
-    
+
     public byte retByte()
     {
         return m_Byte;
@@ -279,22 +279,22 @@ class Component:uno.util.WeakComponentBase, XTest
     {
         return m_Short;
     }
-    
+
     public ushort retUShort()
     {
         return m_UShort;
     }
-    
+
     public int retLong()
     {
         return m_Int;
     }
-    
+
     public uint retULong()
     {
         return m_UInt;
     }
-    
+
     public long retHyper()
     {
         return m_Long;
@@ -309,27 +309,27 @@ class Component:uno.util.WeakComponentBase, XTest
     {
         return m_Float;
     }
-    
+
     public double retDouble()
     {
         return m_Double;
     }
-    
+
     public char retChar()
     {
         return m_Char;
     }
-    
+
     public string retString()
     {
         return m_String;
     }
-    
+
     public Type retType()
     {
         return m_Type;
     }
-    
+
     public uno.Any retAny()
     {
         return m_Any;
@@ -343,7 +343,7 @@ class Component:uno.util.WeakComponentBase, XTest
     {
         return m_Struct1;
     }
-    
+
     public object retXInterface()
     {
         return m_XInterface;
@@ -549,7 +549,7 @@ class Component:uno.util.WeakComponentBase, XTest
         }
     }
 
-    
+
 
 
 
@@ -578,7 +578,5 @@ class Component:uno.util.WeakComponentBase, XTest
     object m_XInterface;
     unoidl.com.sun.star.lang.XComponent m_XComponent;
     bool[] m_seqBool;
-    
+
 }
-
-

--- a/main/cli_ure/source/basetypes/assembly.cs
+++ b/main/cli_ure/source/basetypes/assembly.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 [assembly:System.Reflection.AssemblyDescription( "CLI-UNO: Language Binding specific types" )]

--- a/main/cli_ure/source/basetypes/uno/Any.cs
+++ b/main/cli_ure/source/basetypes/uno/Any.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,14 +39,14 @@ public struct Any
     private Type _type;
 
     public static Any VOID = new Any(typeof(void), null);
-    
+
     private static void checkArgs(Type type, Object value)
     {
         //value can only be null if type == void
-        if (type == null 
-			|| (value == null 
-                && type != typeof(void) 
-                && type != typeof(object) 
+        if (type == null
+			|| (value == null
+                && type != typeof(void)
+                && type != typeof(object)
                 && type.IsInterface == false))
             throw new System.Exception(
                 "uno.Any: Constructor called with illegal arguments!");
@@ -86,7 +86,7 @@ public struct Any
         _type = type;
         _value = value;
     }
-    
+
     public Type Type
     {
         get
@@ -104,7 +104,7 @@ public struct Any
             return _value;
         }
     }
-    
+
     public Any(char value): this(typeof(char), value)
     {
     }
@@ -116,7 +116,7 @@ public struct Any
     public Any(byte value): this(typeof(byte), value)
     {
     }
-    
+
     public Any(short value): this(typeof(short), value)
     {
     }
@@ -166,7 +166,7 @@ public struct Any
         msg.Append("}");
         return msg.ToString();
     }
-    
+
     public bool hasValue()
     {
         if (Type == null || Type == typeof(void))
@@ -200,8 +200,7 @@ public struct Any
     public override int GetHashCode()
     {
         return Type.GetHashCode() ^ (Value != null ? Value.GetHashCode() : 0);
-    }   
+    }
 }
 
 }
-

--- a/main/cli_ure/source/basetypes/uno/BoundAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/BoundAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -39,4 +39,3 @@ public sealed class BoundAttribute: System.Attribute
 }
 
 }
-

--- a/main/cli_ure/source/basetypes/uno/ExceptionAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/ExceptionAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -62,5 +62,4 @@ public sealed class ExceptionAttribute: System.Attribute
     private Type[] m_raises;
 }
 
-} 
-
+}

--- a/main/cli_ure/source/basetypes/uno/OnewayAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/OnewayAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -36,4 +36,3 @@ public sealed class OnewayAttribute: System.Attribute
 
 }
 }
-

--- a/main/cli_ure/source/basetypes/uno/ParameterizedTypeAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/ParameterizedTypeAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -60,5 +60,4 @@ public sealed class ParameterizedTypeAttribute: System.Attribute
     private string m_parameter;
 }
 
-} 
-
+}

--- a/main/cli_ure/source/basetypes/uno/PolymorphicType.cs
+++ b/main/cli_ure/source/basetypes/uno/PolymorphicType.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -41,27 +41,27 @@ namespace uno {
     as simple string when creating an instance of PolymorphicType. Usually one
     only needs a PolymorphicType when a polymporphic type is put into an
     uno.Any. For example, let's assume there is a idl type PolyStruct:
-    
+
     module test {
     struct PolyStruct< T >
     {
         T member;
     };
     };
-    
+
     Then one would use it in C# in this way:
 
     uno.Any myAny = new uno.Any( PolymorphicType.GetType(
         typeof(PolyStruct),  "unoidl.test.PolyStruct<System.Boolean>"),
         new PolyStruct(true));
 
-    or if one has a sequence of polymorphic structs:        
+    or if one has a sequence of polymorphic structs:
 
     uno.Any myAny = new uno.Any( PolymorphicType.GetType(
         typeof(PolyStruct),  "unoidl.test.PolyStruct<System.Boolean>[]"),
         new PolyStruct[] {new PolyStruct(true)} );
 
-        
+
     To get a new instance of PolymorphicType one uses the static method
     PolymorphicType.GetType. The method ensures that there is only one instance
     for each distinct name. For example, if GetType is called multiple times with
@@ -78,25 +78,25 @@ namespace uno {
     Here are a couple of possible strings:
 
     unoidl.test.PolyStruct<System.Int32>
-    unoidl.test.PolyStruct<System.Char[]> 
+    unoidl.test.PolyStruct<System.Char[]>
     unoidl.test.PolyStruct<System.Int64>[]
     unoidl.test.PolyStruct<unoidl.test.PolyStruct<System.Int64>>
     unoidl.test.PolyStruct<unoidl.test.PolyStruct<System.Int64[]>[]>[]
- 
+
     In the future, when the CLI supports templates, we will probably adapt the cli-uno
-    bridge accordingly to use real template types. Then this class will become obsolete.    
+    bridge accordingly to use real template types. Then this class will become obsolete.
  */
 public class PolymorphicType: Type
 {
     private Type m_base;
     private string m_type_name;
-    
+
     private static Hashtable m_ht_types = Hashtable.Synchronized(new Hashtable(256));
 
     /** provides a unique instance of this class.
-      
+
        This function returns null if the specified type is no polymorphic struct.
-       
+
        @param type
        the type of the polymorphic struct. For example, created by
        <code>typeof(unoidl.com.sun.star.beans.Defaulted)</code>
@@ -121,8 +121,8 @@ public class PolymorphicType: Type
 			//unfortunately we cannot check if it is a real polymorphic struct here.
 			if ( ! elementType.IsClass)
 				return null;
-                   
-            
+
+
         }
         else if (Attribute.GetCustomAttribute(type, typeof(uno.TypeParametersAttribute))
             == null)
@@ -163,8 +163,8 @@ public class PolymorphicType: Type
             return m_base;
         }
     }
-            
-    
+
+
     //implementations of abstract methods and properties from base class
     public override string Name
     {
@@ -173,7 +173,7 @@ public class PolymorphicType: Type
             return m_base.Name;
         }
     }
-    
+
     public override Assembly Assembly
     {
         get
@@ -197,7 +197,7 @@ public class PolymorphicType: Type
             return m_base.BaseType;
         }
     }
-    
+
     public override string FullName
     {
         get
@@ -264,7 +264,7 @@ public class PolymorphicType: Type
         Type attributeType,
         bool inherit)
     {
-        return m_base.GetCustomAttributes(attributeType, inherit);        
+        return m_base.GetCustomAttributes(attributeType, inherit);
     }
 
     public override bool IsDefined(

--- a/main/cli_ure/source/basetypes/uno/TypeArgumentsAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/TypeArgumentsAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -29,7 +29,7 @@ namespace uno
 /** is used to mark a parameterized UNO entity(i.e. struct)
     to be an instantiation of a
     template with the specified type arguments.
-    
+
     <p>Currently only UNO structs can have type parameters.</p>
 
     <pre>
@@ -76,5 +76,4 @@ public sealed class TypeArgumentsAttribute: System.Attribute
     private Type[] m_arguments;
 }
 
-} 
-
+}

--- a/main/cli_ure/source/basetypes/uno/TypeParametersAttribute.cs
+++ b/main/cli_ure/source/basetypes/uno/TypeParametersAttribute.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -57,5 +57,4 @@ public sealed class TypeParametersAttribute: System.Attribute
     private string[] m_parameters;
 }
 
-} 
-
+}

--- a/main/cli_ure/source/ure/assembly.cs
+++ b/main/cli_ure/source/ure/assembly.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 [assembly:System.Reflection.AssemblyDescription( "CLI-UNO Runtime Library" )]

--- a/main/cli_ure/source/ure/uno/util/DisposeGuard.cs
+++ b/main/cli_ure/source/ure/uno/util/DisposeGuard.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -33,16 +33,16 @@ namespace uno.util
 public struct DisposeGuard : IDisposable
 {
     private XComponent m_xComponent;
-    
+
     /** ctor.
-        
+
         @param obj target object
     */
     public DisposeGuard( XComponent obj )
     {
         m_xComponent = obj;
     }
-    
+
     /** System.IDisposable impl
     */
     public void Dispose()

--- a/main/cli_ure/source/ure/uno/util/WeakAdapter.cs
+++ b/main/cli_ure/source/ure/uno/util/WeakAdapter.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -27,7 +27,7 @@ using unoidl.com.sun.star.lang;
 
 namespace uno.util
 {
-    
+
 /** An XAdapter implementation that holds a weak reference
     (System.WeakReference) to an object.
     Clients can register listeners (unoidl.com.sun.star.lang.XReference)
@@ -42,9 +42,9 @@ public class WeakAdapter : XAdapter
     // contains XReference objects registered by addReference
     private delegate void XReference_dispose();
     private XReference_dispose m_XReference_dispose;
-    
+
     /** ctor.
-        
+
         @param obj the object that is to be held weakly
     */
     public WeakAdapter( Object obj )
@@ -52,14 +52,14 @@ public class WeakAdapter : XAdapter
         m_weakRef = new WeakReference( obj );
         m_XReference_dispose = null;
     }
-    
+
     /** Called by the XWeak implementation (WeakBase) when it is being
         finalized.  It is only being called once.
         The registererd XReference listeners are notified. On notification
         they are  to unregister themselves. The notification is thread-safe.
         However, it is possible to add a listener during the notification
         process, which will never receive a notification.
-        To prevent this, one would have to synchronize this method with 
+        To prevent this, one would have to synchronize this method with
         the addReference method. But this can result in deadlocks in a
         multithreaded environment.
     */
@@ -74,12 +74,12 @@ public class WeakAdapter : XAdapter
         if (null != call)
             call();
     }
-    
+
     // XAdapter impl
-    
+
     /** Called to obtain a hard reference o the object which is kept weakly
         by this instance.
-        
+
         @return hard reference to the object
     */
     public Object queryAdapted()
@@ -88,7 +88,7 @@ public class WeakAdapter : XAdapter
     }
     /** Called by clients to register listener which are notified when the
         weak object is dying.
-        
+
         @param xReference a listener
     */
     public void removeReference( XReference xReference )
@@ -100,7 +100,7 @@ public class WeakAdapter : XAdapter
         }
     }
     /** Called by clients to unregister listeners.
-        
+
         @param xReference a listener
     */
     public void addReference( XReference xReference )

--- a/main/cli_ure/source/ure/uno/util/WeakBase.cs
+++ b/main/cli_ure/source/ure/uno/util/WeakBase.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -40,14 +40,14 @@ public class WeakBase : XWeak, XTypeProvider
     // Contains all WeakAdapter which have been created in this class
     // They have to be notified when this object dies
     private WeakAdapter m_adapter = null;
-    
+
     protected static Hashtable s_types = new Hashtable();
     protected static Hashtable s_impl_ids = new Hashtable();
-    
+
     // XWeak impl
     /** The returned XAdapter implementation can be used to keap a
         weak reference to this object.
-        
+
         @return a weak adapter
     */
     public XAdapter queryAdapter()
@@ -62,7 +62,7 @@ public class WeakBase : XWeak, XTypeProvider
         }
         return m_adapter;
     }
-    
+
     /** Overrides of Object.Finalize method.
         When there are no references to this object anymore, then the
         garbage collector calls this method, thereby causing the adapter
@@ -74,12 +74,12 @@ public class WeakBase : XWeak, XTypeProvider
         if (null != m_adapter)
             m_adapter.referentDying();
     }
-    
+
     // XTypeProvider impl
-    
+
     /** Returns an array of Type objects which represent all implemented
         UNO interfaces of this object.
-       
+
        @return Type objects of all implemented interfaces.
     */
     public Type [] getTypes()
@@ -113,11 +113,11 @@ public class WeakBase : XWeak, XTypeProvider
         }
         return types;
     }
-    
+
     /** Provides an identifier that represents the set of UNO interfaces
         implemented by this class.  All instances of this class which run
         in the same CLR return the same array.
-        
+
         @return identifier as array of bytes
     */
     public byte [] getImplementationId()
@@ -132,13 +132,13 @@ public class WeakBase : XWeak, XTypeProvider
                 Int32 hash = GetHashCode();
                 String name = type.FullName;
                 Int32 len= name.Length;
-                
+
                 id = new byte[ 4 + (2 * len) ];
                 id[ 0 ]= (byte) (hash & 0xff);
                 id[ 1 ]= (byte) ((hash >> 8) & 0xff);
                 id[ 2 ]= (byte) ((hash >> 16) & 0xff);
                 id[ 3 ]= (byte) ((hash >> 24) & 0xff);
-                
+
                 for ( Int32 pos = 0; pos < len; ++pos )
                 {
                     UInt16 c = Convert.ToUInt16( name[ pos ] );
@@ -150,7 +150,7 @@ public class WeakBase : XWeak, XTypeProvider
         }
         return id;
     }
-    
+
     // System.Object
     public override String ToString()
     {
@@ -171,4 +171,3 @@ public class WeakBase : XWeak, XTypeProvider
 }
 
 }
-

--- a/main/cli_ure/source/ure/uno/util/WeakComponentBase.cs
+++ b/main/cli_ure/source/ure/uno/util/WeakComponentBase.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -43,7 +43,7 @@ public class WeakComponentBase : WeakBase, XComponent
     private bool m_disposed = false;
 
     /** Indicates whether object is already disposed.
-        
+
         @return
                 true, if object has been disposed
     */
@@ -66,7 +66,7 @@ public class WeakComponentBase : WeakBase, XComponent
                 "object already disposed!", this );
         }
     }
-    
+
     ~WeakComponentBase()
     {
         bool doDispose;
@@ -79,21 +79,21 @@ public class WeakComponentBase : WeakBase, XComponent
             dispose();
         }
     }
-    
+
     /** Override to perform extra clean-up work. Provided for subclasses.
         It is called during dispose()
     */
     protected void preDisposing()
     {
     }
-    
+
     /** Override to become notified right before the disposing action is
         performed.
     */
     protected void postDisposing()
     {
     }
-    
+
     // XComponent impl
     /** This method is called by the owner of this object to explicitly
         dispose it.  This implementation of dispose() first notifies this object
@@ -174,7 +174,7 @@ public class WeakComponentBase : WeakBase, XComponent
     }
     /** Revokes an event listener from being notified when this object
         is disposed.
-        
+
         @param xListener event listener
     */
     public void removeEventListener( XEventListener xListener )

--- a/main/cli_ure/workbench/dynload/dynload.cs
+++ b/main/cli_ure/workbench/dynload/dynload.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 using System;
@@ -32,7 +32,7 @@ class DynLoad
     {
         connect(args);
     }
-    
+
 /** Connect to a running office that is accepting connections.
         @return  The ServiceManager to instantiate office components. */
     static private XMultiServiceFactory connect( string[] args )
@@ -45,12 +45,12 @@ class DynLoad
         XComponentContext xContext =
             uno.util.Bootstrap.defaultBootstrap_InitialComponentContext(
                  args[ 0 ] + "/uno.ini", ht.GetEnumerator() );
-        
+
         if (xContext != null)
             Console.WriteLine("Successfully created XComponentContext\n");
         else
             Console.WriteLine("Could not create XComponentContext\n");
-       
+
        return null;
     }
 }

--- a/main/odk/examples/CLI/CSharp/Spreadsheet/GeneralTableSample.cs
+++ b/main/odk/examples/CLI/CSharp/Spreadsheet/GeneralTableSample.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -48,7 +48,7 @@ public class GeneralTableSample : SpreadsheetDocHelper
     }
 
 // ________________________________________________________________
-    
+
     public GeneralTableSample( String[] args ) : base( args )
     {
     }

--- a/main/odk/examples/CLI/CSharp/Spreadsheet/SpreadsheetDocHelper.cs
+++ b/main/odk/examples/CLI/CSharp/Spreadsheet/SpreadsheetDocHelper.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -77,14 +77,14 @@ public class SpreadsheetDocHelper : System.IDisposable
         // Collection of sheets
         unoidl.com.sun.star.sheet.XSpreadsheets xSheets =
             mxDocument.getSheets();
-        
+
         unoidl.com.sun.star.container.XIndexAccess xSheetsIA =
             (unoidl.com.sun.star.container.XIndexAccess) xSheets;
-        
+
         unoidl.com.sun.star.sheet.XSpreadsheet xSheet =
             (unoidl.com.sun.star.sheet.XSpreadsheet)
               xSheetsIA.getByIndex( nIndex ).Value;
-        
+
         return xSheet;
     }
 
@@ -98,12 +98,12 @@ public class SpreadsheetDocHelper : System.IDisposable
         // Collection of sheets
         unoidl.com.sun.star.sheet.XSpreadsheets xSheets =
             mxDocument.getSheets();
-        
+
         xSheets.insertNewByName( aName, nIndex );
         unoidl.com.sun.star.sheet.XSpreadsheet xSheet =
             (unoidl.com.sun.star.sheet.XSpreadsheet)
               xSheets.getByName( aName ).Value;
-        
+
         return xSheet;
     }
 
@@ -172,7 +172,7 @@ public class SpreadsheetDocHelper : System.IDisposable
 
     /** Draws a colored border around the range and writes the headline
         in the first cell.
-        
+
         @param xSheet  The XSpreadsheet interface of the spreadsheet.
         @param aRange  The address of the cell range (or a named range).
         @param aHeadline  The headline text. */
@@ -182,7 +182,7 @@ public class SpreadsheetDocHelper : System.IDisposable
     {
         unoidl.com.sun.star.beans.XPropertySet xPropSet = null;
         unoidl.com.sun.star.table.XCellRange xCellRange = null;
-        
+
         // draw border
         xCellRange = xSheet.getCellRangeByName( aRange );
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
@@ -211,7 +211,7 @@ public class SpreadsheetDocHelper : System.IDisposable
         xCellRange = xSheet.getCellRangeByPosition(
             aAddr.StartColumn,
             aAddr.StartRow, aAddr.EndColumn, aAddr.StartRow );
-        
+
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
         xPropSet.setPropertyValue(
             "CellBackColor", new uno.Any( (Int32) 0x99CCFF ) );
@@ -310,7 +310,7 @@ public class SpreadsheetDocHelper : System.IDisposable
 
     /** Returns a list of addresses of all cell ranges contained in the
         collection.
-        
+
         @param xRangesIA  The XIndexAccess interface of the collection.
         @return  A string containing the cell range address list. */
     public String getCellRangeListString(
@@ -336,9 +336,9 @@ public class SpreadsheetDocHelper : System.IDisposable
         @return  The ServiceManager to instantiate office components. */
     private XMultiServiceFactory connect( String [] args )
     {
-        
+
         m_xContext = uno.util.Bootstrap.bootstrap();
-        
+
         return (XMultiServiceFactory) m_xContext.getServiceManager();
     }
 
@@ -353,7 +353,7 @@ public class SpreadsheetDocHelper : System.IDisposable
     {
         XComponentLoader aLoader = (XComponentLoader)
             mxMSFactory.createInstance( "com.sun.star.frame.Desktop" );
-        
+
         XComponent xComponent = aLoader.loadComponentFromURL(
             "private:factory/scalc", "_blank", 0,
             new unoidl.com.sun.star.beans.PropertyValue[0] );

--- a/main/odk/examples/CLI/CSharp/Spreadsheet/SpreadsheetSample.cs
+++ b/main/odk/examples/CLI/CSharp/Spreadsheet/SpreadsheetSample.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -49,7 +49,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         : base( args )
     {
     }
-    
+
     /** This sample function performs all changes on the document. */
     public void doSampleFunctions()
     {
@@ -106,7 +106,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         unoidl.com.sun.star.text.XTextContent xContent =
             (unoidl.com.sun.star.text.XTextContent) aHyperlinkObj;
         xText.insertTextContent( xTextCursor, xContent, false );
-        
+
         // --- Query the separate paragraphs. ---
         unoidl.com.sun.star.container.XEnumerationAccess xParaEA =
             (unoidl.com.sun.star.container.XEnumerationAccess) xCell;
@@ -132,8 +132,8 @@ public class SpreadsheetSample : SpreadsheetDocHelper
             }
             Console.WriteLine( "Paragraph text: " + aText );
         }
-        
-        
+
+
         // --- Change cell properties. ---
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCell;
         // from styles.CharacterProperties
@@ -149,8 +149,8 @@ public class SpreadsheetSample : SpreadsheetDocHelper
             "IsCellBackgroundTransparent", new uno.Any( false ) );
         xPropSet.setPropertyValue(
             "CellBackColor", new uno.Any( (Int32) 0x99CCFF ) );
-        
-        
+
+
         // --- Get cell address. ---
         unoidl.com.sun.star.sheet.XCellAddressable xCellAddr =
             (unoidl.com.sun.star.sheet.XCellAddressable) xCell;
@@ -160,8 +160,8 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         aText += ";  Row=" + aAddress.Row;
         aText += ";  Sheet=" + aAddress.Sheet;
         Console.WriteLine( aText );
-    
-    
+
+
         // --- Insert an annotation ---
         unoidl.com.sun.star.sheet.XSheetAnnotationsSupplier xAnnotationsSupp =
         (unoidl.com.sun.star.sheet.XSheetAnnotationsSupplier) xSheet;
@@ -656,7 +656,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         xCellRange = xSheet.getCellRangeByName( "D2:F2" );
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
         xPropSet.setPropertyValue( "CellStyle", new uno.Any( aStyleName ) );
-        
+
         xCellRange = xSheet.getCellRangeByName( "A3:G3" );
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
         xPropSet.setPropertyValue( "CellStyle", new uno.Any( aStyleName ) );
@@ -668,7 +668,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
             (unoidl.com.sun.star.sheet.XCellFormatRangesSupplier) xCellRange;
         xRangeIA = xFormatSupp.getCellFormatRanges();
         Console.WriteLine( getCellRangeListString( xRangeIA ) );
-        
+
         // Ranges sorted in SheetCellRanges containers
         Console.WriteLine( "\nService UniqueCellFormatRanges:" );
         unoidl.com.sun.star.sheet.XUniqueCellFormatRangesSupplier
@@ -687,7 +687,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
                 "Container " + (nIndex + 1) + ": " +
                 getCellRangeListString( xRangeIA ) );
         }
-        
+
 
         // --- Table auto formats ---
         // get the global collection of table auto formats,
@@ -697,7 +697,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
             "com.sun.star.sheet.TableAutoFormats" );
         unoidl.com.sun.star.container.XNameContainer xAutoFormatsNA =
             (unoidl.com.sun.star.container.XNameContainer) aAutoFormatsObj;
-        
+
         // create a new table auto format and insert into the container
         String aAutoFormatName =  "Temp_Example";
         bool bExistsAlready = xAutoFormatsNA.hasByName( aAutoFormatName );
@@ -772,7 +772,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         unoidl.com.sun.star.sheet.XSheetConditionalEntries xEntries =
             (unoidl.com.sun.star.sheet.XSheetConditionalEntries)
               xPropSet.getPropertyValue( "ConditionalFormat" ).Value;
-        
+
         // create a condition and apply it to the range
         unoidl.com.sun.star.beans.PropertyValue[] aCondition =
             new unoidl.com.sun.star.beans.PropertyValue[3];
@@ -842,7 +842,7 @@ public class SpreadsheetSample : SpreadsheetDocHelper
         // --- Document properties ---
         unoidl.com.sun.star.beans.XPropertySet xPropSet =
             (unoidl.com.sun.star.beans.XPropertySet) getDocument();
-        
+
         String aText = "Value of property IsIterationEnabled: ";
         aText +=
             (Boolean) xPropSet.getPropertyValue( "IsIterationEnabled" ).Value;
@@ -896,14 +896,14 @@ public class SpreadsheetSample : SpreadsheetDocHelper
             new uno.Any(
                 typeof (unoidl.com.sun.star.beans.XPropertySet),
                 xValidPropSet ) );
-        
+
 
         // --- Scenarios ---
         uno.Any [][] aValues = {
             new uno.Any [] { uno.Any.VOID, uno.Any.VOID },
             new uno.Any [] { uno.Any.VOID, uno.Any.VOID }
         };
-        
+
         aValues[ 0 ][ 0 ] = new uno.Any( (Double) 11 );
         aValues[ 0 ][ 1 ] = new uno.Any( (Double) 12 );
         aValues[ 1 ][ 0 ] = new uno.Any( "Test13" );

--- a/main/odk/examples/CLI/CSharp/Spreadsheet/ViewSample.cs
+++ b/main/odk/examples/CLI/CSharp/Spreadsheet/ViewSample.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -52,7 +52,7 @@ public class ViewSample : SpreadsheetDocHelper
         : base( args )
     {
     }
-    
+
 // ________________________________________________________________
 
     /** This sample function performs all changes on the view. */
@@ -63,7 +63,7 @@ public class ViewSample : SpreadsheetDocHelper
             (unoidl.com.sun.star.frame.XModel) xDoc;
         unoidl.com.sun.star.frame.XController xController =
             xModel.getCurrentController();
- 
+
         // --- Spreadsheet view ---
         // freeze the first column and first two rows
         unoidl.com.sun.star.sheet.XViewFreezable xFreeze =
@@ -87,7 +87,7 @@ public class ViewSample : SpreadsheetDocHelper
             "IsCellBackgroundTransparent", new uno.Any( false ) );
         xRangeProp.setPropertyValue(
             "CellBackColor", new uno.Any( (Int32) 0xFFFFCC ) );
- 
+
         // --- View settings ---
         // change the view to display green grid lines
         unoidl.com.sun.star.beans.XPropertySet xProp =

--- a/main/testtools/source/bridgetest/cli/cli_bridgetest_inprocess.cs
+++ b/main/testtools/source/bridgetest/cli/cli_bridgetest_inprocess.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -37,7 +37,7 @@ internal class Factory :
     private String m_service;
     private Type m_type;
     private System.Reflection.ConstructorInfo m_ctor;
-    
+
     public Factory( Type type, String service )
     {
         m_service = service;
@@ -45,12 +45,12 @@ internal class Factory :
         m_ctor = type.GetConstructor(
             new Type [] { typeof (XComponentContext) } );
     }
-    
+
     public Object createInstanceWithContext( XComponentContext xContext )
     {
         return m_ctor.Invoke( new Object [] { xContext } );
     }
-    
+
     public Object createInstanceWithArgumentsAndContext(
         uno.Any [] args, XComponentContext xContext )
     {
@@ -93,8 +93,8 @@ public class BridgeTest
 						"\n\ncli_bridgetest_inprocess [bootstrap file] \n\n"
 						+ "bootstrap file \n"
 						+ "\t contains the entries UNO_TYPES and UNO_SERVICES.\n"
-						+ "\t If a file is not provided than it is assumed that a\n" 
-						+ "\t cli_bridgetest_inprocess.ini file can be found in the\n " 
+						+ "\t If a file is not provided than it is assumed that a\n"
+						+ "\t cli_bridgetest_inprocess.ini file can be found in the\n "
 						+ "\t current working directory.\n"
 						);
 					return 0;
@@ -109,7 +109,7 @@ public class BridgeTest
             XComponentContext xContext =
                 Bootstrap.defaultBootstrap_InitialComponentContext(
                     bootstrap_ini, null );
-        
+
             using (new uno.util.DisposeGuard( (XComponent) xContext ))
             {
                 XSet xSet = (XSet) xContext.getServiceManager();
@@ -143,7 +143,7 @@ public class BridgeTest
                         new Factory(
                             typeof (vb_bridetest.BridgeTest),
                             "com.sun.star.test.bridge.cli_uno.VbBridgeTest" ) ) );
-            
+
                 // I.
                 // direct unbridged test
                 // get client object via singleton entry
@@ -157,12 +157,12 @@ public class BridgeTest
                 xClient.run(
                     new String [] {
                     "com.sun.star.test.bridge.cli_uno.CsTestObject" } );
-                
+
                 // II:
                 // uno -ro uno_services.rdb -ro uno_types.rdb
                 //     -s com.sun.star.test.bridge.BridgeTest
                 //     -- com.sun.star.test.bridge.cli_uno.TestObject
-            
+
                 // get native client
                 test_client =
                     xContext.getServiceManager().createInstanceWithContext(
@@ -175,12 +175,12 @@ public class BridgeTest
                     new String [] {
                     "com.sun.star.test.bridge.cli_uno.CsTestObject",
 					"noCurrentContext"} );
-            
-                // III:        
+
+                // III:
                 // uno -ro uno_services.rdb -ro uno_types.rdb
                 //     -s com.sun.star.test.bridge.cli_uno.BridgeTest
                 //     -- com.sun.star.test.bridge.CppTestObject
-            
+
                 // get CLI client
                 test_client =
                     xContext.getServiceManager().createInstanceWithContext(
@@ -193,7 +193,7 @@ public class BridgeTest
                 xClient.run(
                     new String [] { "com.sun.star.test.bridge.CppTestObject" } );
 
-                // IV:        
+                // IV:
                 // uno -ro uno_services.rdb -ro uno_types.rdb
                 //     -s com.sun.star.test.bridge.cli_uno.VbBridgeTest
                 //     -- com.sun.star.test.bridge.CppTestObject
@@ -227,8 +227,8 @@ public class BridgeTest
 //                     "com.sun.star.test.bridge.cli_uno.VbTestObject" } );
 
                 // VI:
-                // uno -ro uno_services.rdb -ro uno_types.rdb 
-                // -s com.sun.star.test.bridge.cli_uno.CppBridgeTest 
+                // uno -ro uno_services.rdb -ro uno_types.rdb
+                // -s com.sun.star.test.bridge.cli_uno.CppBridgeTest
                 // -- com.sun.star.test.bridge.CppTestObject
                 test_client =
                     xContext.getServiceManager().createInstanceWithContext(
@@ -248,7 +248,7 @@ public class BridgeTest
             System.Console.WriteLine( exc );
             return -1;
         }
-        
+
         GC.WaitForPendingFinalizers();
         System.Console.WriteLine( "====> all tests ok." );
         return 0;

--- a/main/testtools/source/bridgetest/cli/cli_cs_bridgetest.cs
+++ b/main/testtools/source/bridgetest/cli/cli_cs_bridgetest.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -1018,7 +1018,7 @@ static bool raiseException(XBridgeTest xLBT )
 			throw;
 		}
 		catch (System.Exception exc)
-		{	
+		{
 			throw new unoidl.com.sun.star.uno.RuntimeException(
 				"cli_cs_bridgetest.cs: unexpected exception occurred in XMain::run. Original exception: " +
 				exc.GetType().Name + "\n Message: " + exc.Message , null);

--- a/main/testtools/source/bridgetest/cli/cli_cs_multi.cs
+++ b/main/testtools/source/bridgetest/cli/cli_cs_multi.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -111,5 +111,3 @@ public class Multi: unoidl.test.testtools.bridgetest.XMulti
 };
 
 } } }
-
-

--- a/main/testtools/source/bridgetest/cli/cli_cs_testobj.cs
+++ b/main/testtools/source/bridgetest/cli/cli_cs_testobj.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -152,7 +152,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
         /*INOUT*/ref TestDataElements io_testDataElements )
     {
         Debug.WriteLine( "##### " + GetType().FullName + ".setValues2:" + io_any );
-        
+
         _bool             = io_bool;
         _char             = io_char;
         _byte             = io_byte;
@@ -198,7 +198,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
         /*OUT*/out TestDataElements o_testDataElements )
     {
         Debug.WriteLine( "##### " + GetType().FullName + ".getValues" );
-        
+
         o_bool             = _bool;
         o_char             = _char;
         o_byte             = _byte;
@@ -608,8 +608,8 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
     /* Attention: Debugging this code (probably in mixed mode) may lead to exceptions
      * which do not occur when running normally (Visual Studio 2003)
      */
-    public void testConstructorsService(XComponentContext context) 
-	{ 
+    public void testConstructorsService(XComponentContext context)
+	{
 		Constructors.create1(context,
 			true,
 			0x80, // -128 in C++,
@@ -629,9 +629,9 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
 			new byte[] { 0x80}, // in C++ the value is compared with SAL_MIN_INT8 which is -128
 			new short[] { Int16.MinValue },
 			new UInt16[] { UInt16.MaxValue },
-			new Int32[] {Int32.MinValue},  
+			new Int32[] {Int32.MinValue},
 			new UInt32[] { UInt32.MaxValue },
-			new long[] { Int64.MinValue }, 
+			new long[] { Int64.MinValue },
 			new UInt64[] { UInt64.MaxValue },
 			new float[] { 0.123f },
 			new double[] { 0.456 },
@@ -711,7 +711,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
                      typeof(TestPolyStruct),
                      "unoidl.test.testtools.bridgetest.TestPolyStruct<uno.Any>"),
                  new TestPolyStruct(new Any(true))),
-             new Any(typeof(object), null) 
+             new Any(typeof(object), null)
 		);
 
 
@@ -767,8 +767,8 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
 
     //test the returned interface
     xMulti.fn11(1);
-    
-    
+
+
     }
 
     public XCurrentContextChecker getCurrentContextChecker()
@@ -780,7 +780,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
     {
         return arg;
     }
-  
+
     public  void  transportPolyHyper(/*[in][out]*/ ref TestPolyStruct arg)
     {
     }
@@ -795,7 +795,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
     {
         return new TestPolyStruct(unoidl.test.testtools.bridgetest.TestBadEnum.M);
     }
-    
+
     public TestPolyStruct getNullPolyLong()
     {
         return new TestPolyStruct();
@@ -886,7 +886,7 @@ public class BridgeTestObject : WeakBase, XRecursiveCall, XBridgeTest2
         }
         return "";
     }
-    
+
     public int RaiseAttr1
     {
         get { throw new RuntimeException(); }

--- a/main/testtools/source/cliversioning/runtests.cs
+++ b/main/testtools/source/cliversioning/runtests.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -49,7 +49,7 @@ public class RunTests
         //cliversion.Version class
 		foreach (FileInfo fiTemp in fi)
 		{
-			if (fiTemp.Extension != ".dll" 
+			if (fiTemp.Extension != ".dll"
                 || ! fiTemp.Name.StartsWith("version"))
 				continue;
 

--- a/main/testtools/source/cliversioning/version.cs
+++ b/main/testtools/source/cliversioning/version.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -34,7 +34,7 @@ public class Version
     public Version()
     {
 		try
-		{	
+		{
 //			System.Diagnostics.Debugger.Launch();
 
 			//link with cli_ure.dll
@@ -47,7 +47,7 @@ public class Version
 		}
 		catch (System.Exception )
 		{
-			//This exception is thrown if we link with a library which is not 
+			//This exception is thrown if we link with a library which is not
 			//available
 			throw;
 		}
@@ -291,14 +291,14 @@ class SpreadsheetDocHelper : System.IDisposable
         // Collection of sheets
         unoidl.com.sun.star.sheet.XSpreadsheets xSheets =
             mxDocument.getSheets();
-        
+
         unoidl.com.sun.star.container.XIndexAccess xSheetsIA =
             (unoidl.com.sun.star.container.XIndexAccess) xSheets;
-        
+
         unoidl.com.sun.star.sheet.XSpreadsheet xSheet =
             (unoidl.com.sun.star.sheet.XSpreadsheet)
               xSheetsIA.getByIndex( nIndex ).Value;
-        
+
         return xSheet;
     }
 
@@ -312,12 +312,12 @@ class SpreadsheetDocHelper : System.IDisposable
         // Collection of sheets
         unoidl.com.sun.star.sheet.XSpreadsheets xSheets =
             mxDocument.getSheets();
-        
+
         xSheets.insertNewByName( aName, nIndex );
         unoidl.com.sun.star.sheet.XSpreadsheet xSheet =
             (unoidl.com.sun.star.sheet.XSpreadsheet)
               xSheets.getByName( aName ).Value;
-        
+
         return xSheet;
     }
 
@@ -386,7 +386,7 @@ class SpreadsheetDocHelper : System.IDisposable
 
     /** Draws a colored border around the range and writes the headline
         in the first cell.
-        
+
         @param xSheet  The XSpreadsheet interface of the spreadsheet.
         @param aRange  The address of the cell range (or a named range).
         @param aHeadline  The headline text. */
@@ -396,7 +396,7 @@ class SpreadsheetDocHelper : System.IDisposable
     {
         unoidl.com.sun.star.beans.XPropertySet xPropSet = null;
         unoidl.com.sun.star.table.XCellRange xCellRange = null;
-        
+
         // draw border
         xCellRange = xSheet.getCellRangeByName( aRange );
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
@@ -425,7 +425,7 @@ class SpreadsheetDocHelper : System.IDisposable
         xCellRange = xSheet.getCellRangeByPosition(
             aAddr.StartColumn,
             aAddr.StartRow, aAddr.EndColumn, aAddr.StartRow );
-        
+
         xPropSet = (unoidl.com.sun.star.beans.XPropertySet) xCellRange;
         xPropSet.setPropertyValue(
             "CellBackColor", new uno.Any( (Int32) 0x99CCFF ) );
@@ -524,7 +524,7 @@ class SpreadsheetDocHelper : System.IDisposable
 
     /** Returns a list of addresses of all cell ranges contained in the
         collection.
-        
+
         @param xRangesIA  The XIndexAccess interface of the collection.
         @return  A string containing the cell range address list. */
     public String getCellRangeListString(
@@ -550,9 +550,9 @@ class SpreadsheetDocHelper : System.IDisposable
         @return  The ServiceManager to instantiate office components. */
     private XMultiServiceFactory connect()
     {
-        
+
         m_xContext = uno.util.Bootstrap.bootstrap();
-        
+
         return (XMultiServiceFactory) m_xContext.getServiceManager();
     }
 
@@ -567,7 +567,7 @@ class SpreadsheetDocHelper : System.IDisposable
     {
         XComponentLoader aLoader = (XComponentLoader)
             mxMSFactory.createInstance( "com.sun.star.frame.Desktop" );
-        
+
         XComponent xComponent = aLoader.loadComponentFromURL(
             "private:factory/scalc", "_blank", 0,
             new unoidl.com.sun.star.beans.PropertyValue[0] );
@@ -593,7 +593,7 @@ class SpreadsheetDocHelper : System.IDisposable
             {
                 //This exception may be thrown because shutting down OOo using
                 //XDesktop terminate does not really work. In the case of the
-                //Exception OOo will still terminate. 
+                //Exception OOo will still terminate.
             }
         }
     }

--- a/main/testtools/source/performance/cli_testobj_performance.cs
+++ b/main/testtools/source/performance/cli_testobj_performance.cs
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -36,7 +36,7 @@ namespace testobj
 public class PerformanceTestObject : ServiceBase, XPerformanceTest
 {
     private XComponentContext m_xContext;
-    
+
     public PerformanceTestObject( XComponentContext xContext )
     {
         m_xContext = xContext;
@@ -44,9 +44,9 @@ public class PerformanceTestObject : ServiceBase, XPerformanceTest
     public PerformanceTestObject()
     {
     }
-    
-    private int      _long;   
-    private long     _hyper;    
+
+    private int      _long;
+    private long     _hyper;
     private float    _float;
     private double   _double;
     private String   _string = "";
@@ -54,7 +54,7 @@ public class PerformanceTestObject : ServiceBase, XPerformanceTest
     private Any   _any;
     private Object[]   _interface_sequence = new Object[0];
     private ComplexTypes _complexTypes = new ComplexTypes();
-    
+
     // Attributes
     public int getLong_attr() { return _long; }
     public void setLong_attr( int _long_attr ) { _long = _long_attr; }
@@ -74,7 +74,7 @@ public class PerformanceTestObject : ServiceBase, XPerformanceTest
     public void setSequence_attr(Object[] _sequence_attr ) { _interface_sequence = _sequence_attr; }
     public ComplexTypes getStruct_attr() { return _complexTypes; }
     public void setStruct_attr( ComplexTypes _struct_attr ) { _complexTypes = _struct_attr; }
-    
+
     // Methods
     public void async() {}
     public void sync(  ) {}
@@ -90,7 +90,7 @@ public class PerformanceTestObject : ServiceBase, XPerformanceTest
     public float getFloat() { return _float; }
     public void setFloat( /*IN*/float f ) { _float = f; }
     public double getDouble(  ) { return _double; }
-    public void setDouble( /*IN*/double f ) { _double = f; }    
+    public void setDouble( /*IN*/double f ) { _double = f; }
     public String getString(  ) { return _string; }
     public void setString( /*IN*/String s ) { _string = s; }
     public Object getInterface(  ) { return _xInterface; }
@@ -108,7 +108,7 @@ public class PerformanceTestObject : ServiceBase, XPerformanceTest
     }
     public ComplexTypes getStruct(  ) { return _complexTypes; }
     public void setStruct( /*IN*/ComplexTypes c ) { _complexTypes = c; }
-    public void raiseRuntimeException(  ) { throw new RuntimeException(); }    
+    public void raiseRuntimeException(  ) { throw new RuntimeException(); }
 }
 
 }


### PR DESCRIPTION
Enforced 3 hooks for cs files:

- end-of-file-fixer
- mixed-line-ending
- trailing-whitespace