### PR TITLE
General spelling clean up

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -450,10 +450,7 @@ collpase
 colmuned
 colse
 colums
-comand
 comando
-comaparison
-comaprison
 comared
 comares
 combained
@@ -659,7 +656,6 @@ definied
 definifiton
 definitivly
 defint
-defualt
 defult
 degenrate
 degress
@@ -690,20 +686,17 @@ dependeny
 dependicies
 depenent
 depent
-deprication
 dequed
 dereferencable
 deregisteres
 deregistrated
 dergeistered
 deriver
-dertermine
 dervied
 dervived
 desaster
 descritor
 descritpro
-descrption
 desctop
 desctructed
 desctructor
@@ -715,7 +708,6 @@ desribing
 desroyer
 destanation
 destinaion
-destionation
 destop
 destory
 destorying

--- a/main/dbaccess/source/ext/macromigration/migrationengine.cxx
+++ b/main/dbaccess/source/ext/macromigration/migrationengine.cxx
@@ -1065,7 +1065,7 @@ namespace dbmm
             const Reference< XNameAccess >& _rxContainer, const ::rtl::OUString& _rContainerLoc,
             SubDocuments& _out_rDocs, const SubDocumentType _eType, size_t& _io_counter )
         {
-            const ::rtl::OUString sHierarhicalBase(
+            const ::rtl::OUString sHierarchicalBase(
                 _rContainerLoc.getLength()  ?   ::rtl::OUStringBuffer( _rContainerLoc ).appendAscii( "/" ).makeStringAndClear()
                                             :   ::rtl::OUString() );
 
@@ -1076,7 +1076,7 @@ namespace dbmm
                 )
             {
                 Any aElement( _rxContainer->getByName( *elementName ) );
-                ::rtl::OUString sElementName( ::rtl::OUStringBuffer( sHierarhicalBase ).append( *elementName ) );
+                ::rtl::OUString sElementName( ::rtl::OUStringBuffer( sHierarchicalBase ).append( *elementName ) );
 
                 Reference< XNameAccess > xSubContainer( aElement, UNO_QUERY );
                 if ( xSubContainer.is() )
@@ -1086,7 +1086,7 @@ namespace dbmm
                 else
                 {
                     Reference< XCommandProcessor > xCommandProcessor( aElement, UNO_QUERY );
-                    OSL_ENSURE( xCommandProcessor.is(), "lcl_collectHierarchicalElementNames_throw: no container, and no comand processor? What *is* it, then?!" );
+                    OSL_ENSURE( xCommandProcessor.is(), "lcl_collectHierarchicalElementNames_throw: no container, and no command processor? What *is* it, then?!" );
                     if ( xCommandProcessor.is() )
                     {
                         _out_rDocs.push_back( SubDocument( xCommandProcessor, sElementName, _eType, ++_io_counter ) );

--- a/main/l10ntools/java/jpropex/build.xml
+++ b/main/l10ntools/java/jpropex/build.xml
@@ -117,7 +117,7 @@
     <target name="compile" depends="prepare,res">
 	<javac destdir="${build.class}"
 	       debug="${debug}"
-               deprecation="${deprication}"
+               deprecation="${deprecation}"
 	       optimize="${optimize}"
 	       classpathref="classpath">
             <src path="${java.dir}"/>

--- a/main/l10ntools/java/l10nconv/build.xml
+++ b/main/l10ntools/java/l10nconv/build.xml
@@ -119,7 +119,7 @@
     <target name="compile" depends="prepare,res">
 	<javac destdir="${build.class}"
 	       debug="${debug}"
-               deprecation="${deprication}"
+               deprecation="${deprecation}"
 	       optimize="${optimize}"
 	       classpathref="classpath">
             <src path="${java.dir}"/>

--- a/main/l10ntools/java/receditor/build.xml
+++ b/main/l10ntools/java/receditor/build.xml
@@ -117,7 +117,7 @@
     <target name="compile" depends="prepare,res">
 	<javac destdir="${build.class}"
 	       debug="${debug}"
-               deprecation="${deprication}"
+               deprecation="${deprecation}"
 	       optimize="${optimize}"
 	       classpathref="classpath">
             <src path="${java.dir}"/>

--- a/main/offapi/com/sun/star/configuration/backend/XSchemaHandler.idl
+++ b/main/offapi/com/sun/star/configuration/backend/XSchemaHandler.idl
@@ -55,7 +55,7 @@ published interface XSchemaHandler: ::com::sun::star::uno::XInterface
 
 	/** receives notification that a schema description is started.
 
-		<p> The schema descrption may comprise components templates or both.
+		<p> The schema description may comprise components templates or both.
 		</p>
 
 		@throws com::sun::star::configuration::backend::MalformedDataException

--- a/main/offapi/com/sun/star/xml/crypto/XXMLEncryption.idl
+++ b/main/offapi/com/sun/star/xml/crypto/XXMLEncryption.idl
@@ -48,7 +48,7 @@ module com { module sun { module star { module xml { module crypto {
  * <p>The encrypter or decrypter concrete a key by retrieve security context
  * and encryption template.</p>
  *
- * <p>In some cases, the encrypter or decrypter can dertermine and locate the
+ * <p>In some cases, the encrypter or decrypter can determine and locate the
  * EncrytedKey from the encryption template by dereference the RetrievalMethod
  * inside EncryptedData.</p>
  *

--- a/main/offapi/com/sun/star/xml/crypto/XXMLEncryptionTemplate.idl
+++ b/main/offapi/com/sun/star/xml/crypto/XXMLEncryptionTemplate.idl
@@ -45,8 +45,8 @@ module com { module sun { module star { module xml { module crypto {
  * EncryptedData or EncryptedKey. Empty entities are not allowed in a encryption
  * template when performing decryption.</p>
  *
- * <p>In some cases, the encrypter or decrypter can dertermine and locate the
- * EncrytedKey from the encryption template by dereference the RetrievalMethod
+ * <p>In some cases, the encrypter or decrypter can determine and locate the
+ * EncryptedKey from the encryption template by dereference the RetrievalMethod
  * inside EncryptedData.</p>
  *
  * <p>In some cases, the EncryptedKey need to be clearly pointed out by the

--- a/main/offapi/com/sun/star/xml/crypto/XXMLSignature.idl
+++ b/main/offapi/com/sun/star/xml/crypto/XXMLSignature.idl
@@ -40,12 +40,12 @@ module com { module sun { module star { module xml { module crypto {
 /**
  * Interface of XML signature
  *
- * <p>This interface represents a xml signer or vertifier.</p>
+ * <p>This interface represents a xml signer or verifier.</p>
  *
- * <p>The signer or vertifier concrete a key by retrieve signature context and
+ * <p>The signer or verifier concrete a key by retrieve signature context and
  * signature template.</p>
  *
- * <p>In some cases, the signer or vertifier can dertermine and locate the
+ * <p>In some cases, the signer or verifier can determine and locate the
  * contents to be signed from the signature template by dereference the URI.</p>
  *
  * <p>In some cases, the contents to be signed need to be clearly pointed out by

--- a/main/offapi/com/sun/star/xml/crypto/XXMLSignatureTemplate.idl
+++ b/main/offapi/com/sun/star/xml/crypto/XXMLSignatureTemplate.idl
@@ -45,7 +45,7 @@ module com { module sun { module star { module xml { module crypto {
  * entities include digest value and signature value. Empty entities are not
  * allowed in a signature template when performing validation.</p>
  *
- * <p>In some cases, the signer or vertifier can dertermine and locate the
+ * <p>In some cases, the signer or verifier can determine and locate the
  * contents to be signed from the template by dereference the URI.</p>
  *
  * <p>With the help of signature context, the signer or verifier specifies the

--- a/main/officecfg/registry/data/org/openoffice/Office/TableWizard.xcu
+++ b/main/officecfg/registry/data/org/openoffice/Office/TableWizard.xcu
@@ -5259,7 +5259,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">
@@ -5699,7 +5699,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">
@@ -5982,7 +5982,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">
@@ -6729,7 +6729,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">
@@ -6987,7 +6987,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">
@@ -9133,7 +9133,7 @@
 
 							</prop>
 							<prop oor:name="ShortName">
-								<value xml:lang="en-US">Descrption</value>
+								<value xml:lang="en-US">Description</value>
 
 							</prop>
 							<prop oor:name="Type">

--- a/main/sc/source/ui/vba/vbafont.cxx
+++ b/main/sc/source/ui/vba/vbafont.cxx
@@ -240,7 +240,7 @@ ScVbaFont::setColorIndex( const uno::Any& _colorindex ) throw( uno::RuntimeExcep
 
 	if ( !nIndex || ( nIndex == excel::XlColorIndex::xlColorIndexAutomatic ) )
         {
-		nIndex = 1;  // check defualt ( assume black )
+		nIndex = 1;  // check default ( assume black )
                 ScVbaFont_BASE::setColorIndex( uno::makeAny( nIndex ) );
         }
         else

--- a/main/shell/source/unix/misc/open-url.c
+++ b/main/shell/source/unix/misc/open-url.c
@@ -64,7 +64,7 @@ void logMessage( char* msg)
     fclose( log);
 }
 
-// dump comand line arguments
+// dump command line arguments
 void dumpArgs( int argc, char *argv[] )
 {
     int	i;

--- a/main/shell/source/unix/misc/senddoc.c
+++ b/main/shell/source/unix/misc/senddoc.c
@@ -64,7 +64,7 @@ void logMessage( char* msg)
     fclose( log);
 }
 
-// dump comand line arguments
+// dump command line arguments
 void dumpArgs( int argc, char *argv[] )
 {
     int	i;

--- a/main/sw/source/core/docnode/ndcopy.cxx
+++ b/main/sw/source/core/docnode/ndcopy.cxx
@@ -231,7 +231,7 @@ SwCntntNode* SwTxtNode::MakeCopy( SwDoc* pDoc, const SwNodeIndex& rIdx ) const
 	// the Copy-Textnode is the Node with the Text, the Copy-Attrnode is the
 	// node with the collection and hard attributes. Normally ist the same
 	// node, but if insert a glossary without formatting, then the Attrnode
-	// is the prev node of the destionation position in dest. document.
+	// is the prev node of the destination position in dest. document.
 	SwTxtNode* pCpyTxtNd = (SwTxtNode*)this;
 	SwTxtNode* pCpyAttrNd = pCpyTxtNd;
 

--- a/main/sw/source/filter/ww8/ww8atr.cxx
+++ b/main/sw/source/filter/ww8/ww8atr.cxx
@@ -1876,7 +1876,7 @@ void WW8Export::OutputField( const SwField* pFld, ww::eField eFldType,
 
         if ( bHandleBookmark )
         {
-            // retrieve reference destionation - the name of the bookmark
+            // retrieve reference destination - the name of the bookmark
             String aLinkStr;
             const sal_uInt16 nSubType = pFld->GetSubType();
             const SwGetRefField& rRFld = *(static_cast<const SwGetRefField*>(pFld));

--- a/main/tools/source/fsys/dirent.cxx
+++ b/main/tools/source/fsys/dirent.cxx
@@ -2102,7 +2102,7 @@ DirEntry DirEntry::TempName( DirEntryKind eKind ) const
         char *ret_val;
         size_t i;
 
-        // dertermine Directory, Prefix and Extension
+        // determine Directory, Prefix and Extension
         char pfx[6];
         char ext[5];
         const char *dir;

--- a/main/xmerge/java/pexcel/src/main/java/org/openoffice/xmerge/converter/xml/sxc/pexcel/records/ExtendedFormat.java
+++ b/main/xmerge/java/pexcel/src/main/java/org/openoffice/xmerge/converter/xml/sxc/pexcel/records/ExtendedFormat.java
@@ -84,7 +84,7 @@ org.openoffice.xmerge.converter.xml.OfficeConstants {
 	}
 
 	/**
- 	 * Constructs a pocket Excel Document using defualt values and sets the
+ 	 * Constructs a pocket Excel Document using default values and sets the
 	 * font index using the specified attribute
  	 *
  	 * @param	ixfnt	index of the font this format should use
@@ -276,7 +276,7 @@ org.openoffice.xmerge.converter.xml.OfficeConstants {
     /**
 	 * Compare two ExtendedFormat to see if the font index is the same
 	 *
-	 * @param rhs the ExtendedFormat to be used in the comaprison
+	 * @param rhs the ExtendedFormat to be used in the comparison
 	 * @return boolean if the two are the same otherwise false
 	 */
 	public boolean compareTo(ExtendedFormat rhs) {

--- a/main/xmerge/java/pexcel/src/main/java/org/openoffice/xmerge/converter/xml/sxc/pexcel/records/formula/Token.java
+++ b/main/xmerge/java/pexcel/src/main/java/org/openoffice/xmerge/converter/xml/sxc/pexcel/records/formula/Token.java
@@ -28,7 +28,7 @@ package org.openoffice.xmerge.converter.xml.sxc.pexcel.records.formula;
  * A Token is the basic building block of any formula.
  * A Token can be of four types (Operator, Operand, Function with fixed
  * arguments and function with a variable number of arguments. Each type can
- * have numerous id's. Thetypes are define in <code>ParseToken</code> and the
+ * have numerous id's. The types are define in <code>ParseToken</code> and the
  * id's are defined in <code>TokenConstants</code>. The other member variables
  * are priority which is returned from the <code>PrecedenceTable</code>, the
  * value which is the String equivalent of the token (eg. "+", "$A$12", "SUM")
@@ -61,7 +61,7 @@ public class Token implements ParseToken {
 	/**
 	 * Checks if the current token is an operator
 	 *
-	 * @return A <code>boolean</code> result of the comaparison
+	 * @return A <code>boolean</code> result of the comparison
 	 */
 	public boolean isOperator() {
 		return type == ParseToken.TOKEN_OPERATOR;
@@ -70,7 +70,7 @@ public class Token implements ParseToken {
 	/**
 	 * Checks if the current token is an operand
 	 *
-	 * @return A <code>boolean</code> result of the comaparison
+	 * @return A <code>boolean</code> result of the comparison
 	 */
 	public boolean isOperand() {
 		return type == ParseToken.TOKEN_OPERAND;
@@ -79,7 +79,7 @@ public class Token implements ParseToken {
 	/**
 	 * Checks if the current token is a function
 	 *
-	 * @return A <code>boolean</code> result of the comaparison
+	 * @return A <code>boolean</code> result of the comparison
 	 */
 	public boolean isFunction() {
 		return (type==ParseToken.TOKEN_FUNCTION_FIXED) || (type==ParseToken.TOKEN_FUNCTION_VARIABLE);

--- a/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/util/ColourConverter.java
+++ b/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/util/ColourConverter.java
@@ -30,7 +30,7 @@ import java.awt.Color;
  * Utility class mapping RGB colour specifications to the colour indices used
  * in the Pocket PC. The original converter was written for use with Pocket
  * Word it was later put into the utils so Pocket excel could use this code
- * also. For this reason the defualt values are those used by Pocket Word but
+ * also. For this reason the default values are those used by Pocket Word but
  * a colour table can be passed in through the constructor to map the 16
  * values to a colour table.
  *

--- a/main/xmloff/inc/xmloff/xmlexppr.hxx
+++ b/main/xmloff/inc/xmloff/xmlexppr.hxx
@@ -120,10 +120,10 @@ public:
 					::com::sun::star::beans::XPropertySet > rPropSet ) const
 					{ return _Filter(rPropSet, sal_False); }
 
-	/** Like Filter(), excepti that:
+	/** Like Filter(), except that:
 	  * - only properties that have the map flag MID_FLAG_DEFAULT_ITEM_EXPORT
 	  *   set are exported,
-	  * - instead of the property's value, its defualt value is exported.
+	  * - instead of the property's value, its default value is exported.
 	  */
 	::std::vector< XMLPropertyState > FilterDefaults(
 			const ::com::sun::star::uno::Reference<


### PR DESCRIPTION
General typos fixes:

- code comments
- fixed "const" naming typo
- fixed "OSL_ENSURE" message
- fixed "build.xml" variable naming
- "TableWizard.xcu" fixes "ShortName" property
- clean up codespell ignored words list