### PR TITLE
Fix building Python3 on linux

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -4140,7 +4140,7 @@ elif test -n "$with_system_python" -o -n "$with_system_libs" && \
    python_version=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('VERSION'));"`
    # Python 3.8 and later distinguish building Python modules from linking to the libpython:
    # (https://bugs.python.org/issue36721)
-   # We cannot use test(1) because Python version numbers are floats
+   # We cannot use test(1) because Python version numbers are in the "major.minor.micro" form
    if $PYTHON -c "import sys; v = sys.version_info; g = ((v.major < 3) or ((v.major == 3) and (v.minor < 8))); sys.exit(not g)"; then
        # < 3.8
        PKG_CHECK_MODULES(PYTHON, python-$python_version, PYTHON_PC="TRUE", PYTHON_PC="" )

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -4140,9 +4140,12 @@ elif test -n "$with_system_python" -o -n "$with_system_libs" && \
    python_version=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('VERSION'));"`
    # Python 3.8 and later distinguish building Python modules from linking to the libpython:
    # (https://bugs.python.org/issue36721)
-   if test "$python_version" -lt "3.8"; then
+   # We cannot use test(1) because Python version numbers are floats
+   if $PYTHON -c "import sys; v = sys.version_info; g = ((v.major < 3) or ((v.major == 3) and (v.minor < 8))); sys.exit(not g)"; then
+       # < 3.8
        PKG_CHECK_MODULES(PYTHON, python-$python_version, PYTHON_PC="TRUE", PYTHON_PC="" )
    else
+       # >= 3.8
        PKG_CHECK_MODULES(PYTHON, python-$python_version-embed, PYTHON_PC="TRUE", PYTHON_PC="" )
    fi
    if test "$PYTHON_PC" != "TRUE"; then

--- a/main/external_deps.lst
+++ b/main/external_deps.lst
@@ -194,9 +194,9 @@ if (ENABLE_MEDIAWIKI == YES)
     URL2 = $(OOO_EXTRAS)$(MD5)-$(name)
 
 if (SYSTEM_PYTHON != YES)
-    MD5 = 38c84292658ed4456157195f1c9bcbe1
-    name = Python-2.7.18.tgz
-    URL1 = https://www.python.org/ftp/python/2.7.18/$(name)
+    MD5 = 57f84cbd92d478ceff55217d88a07ded
+    name = Python-3.11.15.tgz
+    URL1 = https://www.python.org/ftp/python/3.11.15/$(name)
     URL2 = $(OOO_EXTRAS)$(MD5)-$(name)
 
 if (SYSTEM_BOOST != YES)

--- a/main/python/makefile.mk
+++ b/main/python/makefile.mk
@@ -45,6 +45,7 @@ TARFILE_NAME=Python-$(PYVERSION)
 TARFILE_MD5=57f84cbd92d478ceff55217d88a07ded
 PATCH_FILES=\
 	python-md5.patch \
+	python-pyexpat.patch \
 	python-solver-before-std.patch \
 	python-$(PYVERSION)-sysbase.patch \
 	python-$(PYVERSION)-nohardlink.patch

--- a/main/python/prj/d.lst
+++ b/main/python/prj/d.lst
@@ -27,6 +27,7 @@ mkdir: %_DEST%\lib%_EXT%\python\importlib
 mkdir: %_DEST%\lib%_EXT%\python\multiprocessing
 mkdir: %_DEST%\lib%_EXT%\python\multiprocessing\dummy
 mkdir: %_DEST%\lib%_EXT%\python\unittest
+mkdir: %_DEST%\lib%_EXT%\python\collections
 mkdir: %_DEST%\lib%_EXT%\python\python3.11\config
 
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\* %_DEST%\lib%_EXT%\python\*
@@ -57,6 +58,7 @@ mkdir: %_DEST%\lib%_EXT%\python\python3.11\config
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\multiprocessing\* %_DEST%\lib%_EXT%\python\multiprocessing\*
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\multiprocessing\dummy\* %_DEST%\lib%_EXT%\python\multiprocessing\dummy\*
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\unittest\* %_DEST%\lib%_EXT%\python\unittest\*
+..\%__SRC%\misc\build\Python-3.11.15\Lib\collections\* %_DEST%\lib%_EXT%\python\collections\*
 ..\%__SRC%\misc\build\Python-3.11.15\Makefile %_DEST%\lib%_EXT%\python\python3.11\config\Makefile
 # TODO: _sysconfigdata filename is platform-mangled (e.g. _sysconfigdata__darwin_darwin.py on macOS,
 # _sysconfigdata__linux_x86_64-linux-gnu.py on Linux). Verify exact name from built tree.

--- a/main/python/prj/d.lst
+++ b/main/python/prj/d.lst
@@ -60,11 +60,15 @@ mkdir: %_DEST%\lib%_EXT%\python\python3.11\config
 ..\%__SRC%\misc\build\Python-3.11.15\Makefile %_DEST%\lib%_EXT%\python\python3.11\config\Makefile
 # TODO: _sysconfigdata filename is platform-mangled (e.g. _sysconfigdata__darwin_darwin.py on macOS,
 # _sysconfigdata__linux_x86_64-linux-gnu.py on Linux). Verify exact name from built tree.
-..\%__SRC%\misc\build\python-inst\lib\python3.11\_sysconfigdata*.py %_DEST%\lib%_EXT%\python\_sysconfigdata.py
+..\%__SRC%\misc\build\python-inst\lib\python3.11\_sysconfigdata__darwin_darwin.py %_DEST%\lib%_EXT%\python\_sysconfigdata.py
+..\%__SRC%\misc\build\python-inst\lib\python3.11\_sysconfigdata__linux_x86_64-linux-gnu.py %_DEST%\lib%_EXT%\python\_sysconfigdata.py
 ..\pyversion.mk %_DEST%\inc%_EXT%\pyversion.mk
 ..\pyversion_dmake.mk %_DEST%\inc%_EXT%\pyversion_dmake.mk
 
+mkdir: %_DEST%\inc%_EXT%\python\cpython
+
 ..\%__SRC%\misc\build\Python-3.11.15\Include\* %_DEST%\inc%_EXT%\python\*
+..\%__SRC%\misc\build\Python-3.11.15\Include\cpython\* %_DEST%\inc%_EXT%\python\cpython\*
 
 #unix ONLY !
 ..\%__SRC%\misc\build\python-inst\bin\python %_DEST%\bin%_EXT%\python

--- a/main/python/python-pyexpat.patch
+++ b/main/python/python-pyexpat.patch
@@ -1,0 +1,11 @@
+--- misc/Python-3.11.15/Modules/Setup	2026-03-03 01:52:57.000000000 +0100
++++ misc/build/Python-3.11.15/Modules/Setup	2026-07-04 12:51:02.908154677 +0200
+@@ -159,7 +159,7 @@
+ 
+ # XML
+ #_elementtree _elementtree.c
+-#pyexpat pyexpat.c
++pyexpat pyexpat.c
+ 
+ # hashing builtins
+ #_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c


### PR DESCRIPTION
These commits should allow to compile Python 3.11.15 on Linux.

However, after applying them, Python macros do not seem to work. But at least, we can get to compile trunk again.