### PR TITLE
Win64 bridge backport

### DIFF
--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/call.asm
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/call.asm
@@ -6,16 +6,16 @@
 ; to you under the Apache License, Version 2.0 (the
 ; "License"); you may not use this file except in compliance
 ; with the License.  You may obtain a copy of the License at
-; 
+;
 ;   http://www.apache.org/licenses/LICENSE-2.0
-; 
+;
 ; Unless required by applicable law or agreed to in writing,
 ; software distributed under the License is distributed on an
 ; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 ; KIND, either express or implied.  See the License for the
 ; specific language governing permissions and limitations
 ; under the License.
-; 
+;
 
 
 typelib_TypeClass_VOID equ 0
@@ -79,7 +79,7 @@ privateSnippetExecutor PROC FRAME
 	sub	rsp, 48
 	.ENDPROLOG
 
-	; 4th param: sal_uInt64 *pRegisterReturn 
+	; 4th param: sal_uInt64 *pRegisterReturn
 	lea r9, -8[rbp]
 
 	; 3rd param: sal_Int32 nVtableOffset
@@ -183,7 +183,7 @@ populateArgumentRegisters:
 
 	.ENDPROLOG
 
-	
+
 callMethod:
 	; Find the method pointer
 	mov rax, 16[rbp]

--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/cpp2uno.cxx
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/cpp2uno.cxx
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -371,7 +371,7 @@ unsigned char * codeSnippet(
     //  rsp+08 +----------------------------+ -------
     //         | return address             |
     //  rsp--> +----------------------------+
-    // 
+    //
     //
 
     // When it doubt about correctness,

--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/cpp2uno.cxx
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/cpp2uno.cxx
@@ -301,13 +301,18 @@ extern "C" typelib_TypeClass cpp_vtable_call(
 
 		                if ( pInterface )
 		                {
-		                    ::uno_any_construct( reinterpret_cast<uno_Any *>( pCallStack[1] ),
+		                    // pCallStack is "ret addr, this, [ret *], params", so the
+		                    // hidden return buffer is [2]; [1] is `this`.  Writing the
+		                    // Any to [1] overwrote the proxy object and left the
+		                    // caller's return buffer untouched, so the caller then
+		                    // destructed an uninitialised Any.
+		                    ::uno_any_construct( reinterpret_cast<uno_Any *>( pCallStack[2] ),
 												 &pInterface, pTD, cpp_acquire );
 
 		                    pInterface->release();
 		                    TYPELIB_DANGER_RELEASE( pTD );
 
-		                    reinterpret_cast<void **>( pRegisterReturn )[0] = pCallStack[1];
+		                    reinterpret_cast<void **>( pRegisterReturn )[0] = pCallStack[2];
 		                    eRet = typelib_TypeClass_ANY;
 		                    break;
 		                }

--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/except.cxx
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/except.cxx
@@ -1,5 +1,5 @@
 /**************************************************************
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  *************************************************************/
 
 
@@ -486,7 +486,7 @@ ExceptionInfos::~ExceptionInfos() throw ()
 #if OSL_DEBUG_LEVEL > 1
 	OSL_TRACE( "> freeing exception infos... <\n" );
 #endif
-    
+
 	MutexGuard aGuard( _aMutex );
 	for ( t_string2PtrMap::const_iterator iPos( _allRaiseInfos.begin() );
           iPos != _allRaiseInfos.end(); ++iPos )
@@ -608,7 +608,7 @@ int mscx_filterCppException(
     // handle only C++ exceptions:
 	if (pRecord == 0 || pRecord->ExceptionCode != MSVC_ExceptionCode)
         return EXCEPTION_CONTINUE_SEARCH;
-    
+
 #if _MSC_VER < 1300 // MSVC -6
     bool rethrow = (pRecord->NumberParameters < 4 ||
                     pRecord->ExceptionInformation[ 2 ] == 0);
@@ -633,7 +633,7 @@ int mscx_filterCppException(
     // rethrow: handle only C++ exceptions:
 	if (pRecord == 0 || pRecord->ExceptionCode != MSVC_ExceptionCode)
         return EXCEPTION_CONTINUE_SEARCH;
-    
+
     if (pRecord->NumberParameters == 4 &&
 //  		pRecord->ExceptionInformation[ 0 ] == MSVC_magic_number &&
 		pRecord->ExceptionInformation[ 1 ] != 0 &&
@@ -655,7 +655,7 @@ int mscx_filterCppException(
                             baseAddress + pType->_pTypeInfo )->_m_d_name,
                         RTL_TEXTENCODING_ASCII_US ) );
 				OUString aUNOname( toUNOname( aRTTIname ) );
-                
+
 				typelib_TypeDescription * pExcTypeDescr = 0;
 				typelib_typedescription_getByName(
                     &pExcTypeDescr, aUNOname.pData );
@@ -699,7 +699,7 @@ int mscx_filterCppException(
 #endif
 					typelib_typedescription_release( pExcTypeDescr );
 				}
-                
+
 				return EXCEPTION_EXECUTE_HANDLER;
 			}
 		}
@@ -719,4 +719,3 @@ int mscx_filterCppException(
 }
 
 #pragma pack(pop)
-

--- a/main/bridges/source/cpp_uno/msvc_win64_x86-64/uno2cpp.cxx
+++ b/main/bridges/source/cpp_uno/msvc_win64_x86-64/uno2cpp.cxx
@@ -105,29 +105,34 @@ static void cpp_call(
 			uno_copyAndConvertData( pCppArgs[nPos] = alloca( 8 ), pUnoArgs[nPos], pParamTypeDescr,
 									pThis->getBridge()->getUno2Cpp() );
 
+			// pCppArgs[nPos] is the alloca(8) temp above, i.e. a POINTER to the
+			// converted value -- the value is *pCppArgs[nPos].  Using
+			// &pCppArgs[nPos] would read the array slot instead, passing the
+			// temp's address as the argument.  (That form is correct only in the
+			// complex/ref branch below, where the pointer IS the argument.)
 			switch (pParamTypeDescr->eTypeClass)
 			{
 			case typelib_TypeClass_HYPER:
 			case typelib_TypeClass_UNSIGNED_HYPER:
-				*pStack++ = *(sal_uInt64*)&pCppArgs[nPos];
+				*pStack++ = *(sal_uInt64*)pCppArgs[nPos];
 				break;
 			case typelib_TypeClass_LONG:
 			case typelib_TypeClass_UNSIGNED_LONG:
 			case typelib_TypeClass_ENUM:
-				*pStack++ = *(sal_uInt32*)&pCppArgs[nPos];
+				*pStack++ = *(sal_uInt32*)pCppArgs[nPos];
 				break;
 			case typelib_TypeClass_SHORT:
 			case typelib_TypeClass_UNSIGNED_SHORT:
 			case typelib_TypeClass_CHAR:
-				*pStack++ = *(sal_uInt16*)&pCppArgs[nPos];
+				*pStack++ = *(sal_uInt16*)pCppArgs[nPos];
 				break;
 			case typelib_TypeClass_BOOLEAN:
 			case typelib_TypeClass_BYTE:
-				*pStack++ = *(sal_uInt8*)&pCppArgs[nPos];
+				*pStack++ = *(sal_uInt8*)pCppArgs[nPos];
 				break;
 			case typelib_TypeClass_FLOAT:
 			case typelib_TypeClass_DOUBLE:
-				*pStack++ = *(sal_uInt64*)&pCppArgs[nPos]; // verbatim!
+				*pStack++ = *(sal_uInt64*)pCppArgs[nPos]; // verbatim!
                 break;
             default:
                 break;
@@ -164,7 +169,8 @@ static void cpp_call(
 				// no longer needed
 				TYPELIB_DANGER_RELEASE( pParamTypeDescr );
 			}
-			*pStack++ = *(sal_uInt64*)&pCppArgs[nPos];
+			// here the POINTER is the argument (complex value passed by ref)
+			*pStack++ = (sal_uInt64)pCppArgs[nPos];
 		}
 	}
 


### PR DESCRIPTION
Fixes issues with the python script provider. It did not work on 64 bit. The following patches fixes that.
now it should work on x64 and x84 version on windows.