### PR TITLE
Fix non-system build of Python 3 on Linux

### DIFF
--- a/main/python/prj/d.lst
+++ b/main/python/prj/d.lst
@@ -27,8 +27,10 @@ mkdir: %_DEST%\lib%_EXT%\python\importlib
 mkdir: %_DEST%\lib%_EXT%\python\multiprocessing
 mkdir: %_DEST%\lib%_EXT%\python\multiprocessing\dummy
 mkdir: %_DEST%\lib%_EXT%\python\unittest
+mkdir: %_DEST%\lib%_EXT%\python\collections
 mkdir: %_DEST%\lib%_EXT%\python\python3.11\config
 mkdir: %_DEST%\inc%_EXT%\python\cpython
+mkdir: %_DEST%\lib%_EXT%\python\re
 
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\* %_DEST%\lib%_EXT%\python\*
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\site-packages\* %_DEST%\lib%_EXT%\python\site-packages\*
@@ -58,6 +60,8 @@ mkdir: %_DEST%\inc%_EXT%\python\cpython
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\multiprocessing\* %_DEST%\lib%_EXT%\python\multiprocessing\*
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\multiprocessing\dummy\* %_DEST%\lib%_EXT%\python\multiprocessing\dummy\*
 ..\%__SRC%\misc\build\Python-3.11.15\Lib\unittest\* %_DEST%\lib%_EXT%\python\unittest\*
+..\%__SRC%\misc\build\Python-3.11.15\Lib\collections\* %_DEST%\lib%_EXT%\python\collections\*
+..\%__SRC%\misc\build\Python-3.11.15\Lib\re\* %_DEST%\lib%_EXT%\python\re\*
 ..\%__SRC%\misc\build\Python-3.11.15\Makefile %_DEST%\lib%_EXT%\python\python3.11\config\Makefile
 # _sysconfigdata filename is platform-mangled (e.g. _sysconfigdata__darwin_darwin.py on macOS,
 # _sysconfigdata__linux_x86_64-linux-gnu.py on Linux). On Linux, makefile.mk's BUILD_ACTION


### PR DESCRIPTION
This PR adds missing bits of PR #490 and finally enables Python3 macros on Linux, when not using system Python.