### PR TITLE
java: replace obsolete dependencies on xml-apis and Xerces.

### DIFF
--- a/main/filter/source/xsltvalidate/makefile.mk
+++ b/main/filter/source/xsltvalidate/makefile.mk
@@ -32,19 +32,7 @@ XCLASSPATH+=":$(XML_CLASSPATH)"
 CLASSDIR!:=$(CLASSDIR)$/$(TARGET)
 #USE_UDK_EXTENDED_MANIFESTFILE=TRUE
 #USE_EXTENDED_MANIFESTFILE=TRUE
-JARFILES 		= ridl.jar unoil.jar jurt.jar juh.jar crimson.jar
-
-.IF "$(SYSTEM_XALAN)" == "YES"
-EXTRAJARFILES += $(XALAN_JAR)
-.ELSE
-JARFILES += xalan.jar
-.ENDIF
-
-.IF "$(SYSTEM_XML_APIS)" == "YES"
-EXTRAJARFILES += $(XML_APIS_JAR)
-.ELSE
-JARFILES += xml-apis.jar
-.ENDIF
+JARFILES 		= ridl.jar unoil.jar jurt.jar juh.jar
 
 JAVAFILES		= $(subst,$(CLASSDIR)$/, $(subst,.class,.java $(JAVACLASSFILES)))
 CUSTOMMANIFESTFILE = Manifest

--- a/main/reportbuilder/java/com/sun/star/report/pentaho/output/OfficeDocumentReportTarget.java
+++ b/main/reportbuilder/java/com/sun/star/report/pentaho/output/OfficeDocumentReportTarget.java
@@ -37,7 +37,6 @@ import com.sun.star.report.pentaho.model.OfficeStyles;
 import com.sun.star.report.pentaho.model.OfficeStylesCollection;
 import com.sun.star.report.pentaho.styles.LengthCalculator;
 import com.sun.star.report.pentaho.styles.StyleMapper;
-import com.sun.org.apache.xerces.internal.parsers.DOMParser;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.transform.OutputKeys;
@@ -45,6 +44,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -1054,9 +1054,8 @@ public abstract class OfficeDocumentReportTarget extends AbstractReportTarget
             try
             {
                 inputStream = getInputRepository().createInputStream("meta.xml");
-                DOMParser dOMParser = new DOMParser();
-                dOMParser.parse(new InputSource(inputStream));
-                Document document = dOMParser.getDocument();
+                Document document = DocumentBuilderFactory.newInstance()
+                        .newDocumentBuilder().parse(new InputSource(inputStream));
                 NodeList nl = document.getElementsByTagName("document-meta/meta/generator");
                 Node node = document.getFirstChild().getFirstChild().getFirstChild().getFirstChild();
                 String creator = node.getNodeValue();

--- a/main/scripting/java/com/sun/star/script/framework/container/XMLParserFactory.java
+++ b/main/scripting/java/com/sun/star/script/framework/container/XMLParserFactory.java
@@ -26,9 +26,12 @@ package com.sun.star.script.framework.container;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
-import java.lang.reflect.Method;
 
 import javax.xml.parsers.*;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -95,79 +98,9 @@ public class XMLParserFactory {
         }
 
         public void write(Document doc, OutputStream out) throws IOException {
-            Class clazz = doc.getClass();
-            String name = clazz.getName();
-
-            // depending on the class of the Document object use introspection
-            // to invoke the appropriate methods for writing the XML
-            // this code is based on the code used by the NetBeans
-            // class XMLUtilImpl in the openide module
             try {
-                if (name.equals("com.sun.xml.tree.XmlDocument") ||
-                    name.equals("org.apache.crimson.tree.XmlDocument")) {
-
-                    // these DOM implementations are self writing
-                    Method write;
-                    write = clazz.getDeclaredMethod("write",
-                        new Class[] {OutputStream.class});
-                    write.invoke(doc, new Object[] {out});
-                }
-                else {
-                    // try xerces serialize package using introspection
-                    ClassLoader cl = this.getClass().getClassLoader();
-
-                    Class serializerClass = null;
-                    Class formatterClass = null;
-
-                    try {
-                        serializerClass = Class.forName(
-                            "org.apache.xml.serialize.XMLSerializer", true, cl);
-                        formatterClass = Class.forName(
-                            "org.apache.xml.serialize.OutputFormat", true, cl);
-                    } catch (ClassNotFoundException cnfe) {
-                        String prefix = "com.sun.org.apache.xml.internal.";
-
-                        serializerClass = Class.forName(
-                            prefix +  "serialize.XMLSerializer" , true, cl);
-                        formatterClass = Class.forName(
-                            prefix + "serialize.OutputFormat", true, cl);
-                    }
-
-                    Object serializerObject = serializerClass.newInstance();
-                    Object formatterObject = formatterClass.newInstance();
-
-                    // improve output readability using the OutputFormat class
-                    Method method = null;
-                    method = formatterClass.getMethod("setMethod",
-                        new Class[] {String.class});
-                    method.invoke(formatterObject, new Object[] {"xml"});
-                    method = formatterClass.getMethod("setIndenting",
-                        new Class[] {Boolean.TYPE});
-                    method.invoke(formatterObject, new Object[] {Boolean.TRUE});
-
-                    // now set up an instance of XMLSerializer with our
-                    // OutputStream and serialize our Document
-                    method = serializerClass.getMethod("setOutputByteStream",
-                        new Class[] {OutputStream.class});
-                    method.invoke(serializerObject, new Object[] {out});
-                    method = serializerClass.getMethod("setOutputFormat",
-                        new Class[] {formatterClass});
-                    method.invoke(serializerObject,
-                        new Object[] {formatterObject});
-
-                    method = serializerClass.getMethod("asDOMSerializer",
-                        new Class[0]);
-                    Object impl = method.invoke(serializerObject,
-                        new Object[0]);
-
-                    method = impl.getClass().getMethod("serialize",
-                        new Class[] {Document.class});
-                    method.invoke(impl, new Object[] {doc});
-                }
-            } catch (NoSuchMethodException ex) {
-                throw new IOException(ex.getMessage());
-            } catch (ClassNotFoundException ex) {
-                throw new IOException(ex.getMessage());
+                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.transform(new DOMSource(doc), new StreamResult(out));
             } catch (Exception ex) {
                 throw new IOException(ex.getMessage());
             }

--- a/main/solenv/inc/antsettings.mk
+++ b/main/solenv/inc/antsettings.mk
@@ -26,7 +26,7 @@
 
 ANT_LIB*:=$(ANT_HOME)/lib
 
-ANT_CLASSPATH:=$(ANT_LIB)/xercesImpl.jar$(PATH_SEPERATOR)$(ANT_LIB)/xml-apis.jar$(PATH_SEPERATOR)$(ANT_LIB)/ant.jar
+ANT_CLASSPATH:=$(ANT_LIB)/ant.jar
 
 # PATH_SEPERATOR won't work here as it is defined
 # as ; for windows (all shells)

--- a/main/toolkit/test/accessibility/jawb.mf
+++ b/main/toolkit/test/accessibility/jawb.mf
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Main-Class: AccessibilityWorkBench
-Class-Path: classes.jar ridl.jar unoil.jar jurt.jar juh.jar java_uno.jar xt.jar xml-apis.jar
+Class-Path: classes.jar ridl.jar unoil.jar jurt.jar juh.jar java_uno.jar xt.jar

--- a/main/xmerge/java/xmerge/build.xml
+++ b/main/xmerge/java/xmerge/build.xml
@@ -28,12 +28,9 @@
     <import file="${SRC_ROOT}/solenv/ant/aoo-ant.xml"/>
 
     <target name="init-project">
-        <property name="jar.classpath" value="xml-apis.jar xercesImpl.jar serializer.jar"/>
         <property name="jar.manifest" value="manifest.mf"/>
 
         <path id="main.classpath">
-<!--            <pathelement location="${OUTDIR}/bin/xml-apis.jar"/> -->
-<!--            <pathelement location="${OUTDIR}/bin/xercesImpl.jar"/> -->
             <pathelement location="${OUTDIR}/bin/unoil.jar"/>
             <pathelement location="${OUTDIR}/bin/ridl.jar"/>
             <pathelement location="${OUTDIR}/bin/juh.jar"/>

--- a/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/converter/dom/DOMDocument.java
+++ b/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/converter/dom/DOMDocument.java
@@ -25,7 +25,6 @@ package org.openoffice.xmerge.converter.dom;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -232,9 +231,6 @@ public class DOMDocument
      *  <p>Write out a <code>org.w3c.dom.Document</code> object into a
      *  <code>byte</code> array.</p>
      *
-     *  <p>TODO: remove dependency on com.sun.xml.tree.XmlDocument
-     *  package!</p>
-     *
      *  @param  doc  DOM <code>Document</code> object.
      *
      *  @return  <code>byte</code> array of DOM <code>Document</code>
@@ -244,115 +240,18 @@ public class DOMDocument
      */
     private byte[] docToBytes(Document doc)
         throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        java.lang.reflect.Constructor con;
-        java.lang.reflect.Method meth;
-
-        String domImpl = doc.getClass().getName();
-
-        System.err.println("type b " + domImpl);
-
-        /*
-         * We may have multiple XML parsers in the Classpath.
-         * Depending on which one is first, the actual type of
-         * doc may vary.  Need a way to find out which API is being
-         * used and use an appropriate serialization method.
-         */
         try {
-            // First of all try for JAXP 1.0
-            if (domImpl.equals("com.sun.xml.tree.XmlDocument")) {
-                System.out.println("Using JAXP");
-                Class jaxpDoc = Class.forName("com.sun.xml.tree.XmlDocument");
-
-                // The method is in the XMLDocument class itself, not a helper
-                meth = jaxpDoc.getMethod("write",
-                            new Class[] { Class.forName("java.io.OutputStream") } );
-
-                meth.invoke(doc, new Object [] { baos } );
-            }
-	    else if (domImpl.equals("org.apache.crimson.tree.XmlDocument"))
-	    {
-		 System.out.println("Using Crimson");
-		 Class crimsonDoc = Class.forName("org.apache.crimson.tree.XmlDocument");
-		 // The method is in the XMLDocument class itself, not a helper
-                meth = crimsonDoc.getMethod("write",
-                            new Class[] { Class.forName("java.io.OutputStream") } );
-
-                meth.invoke(doc, new Object [] { baos } );
-	    }
-            else if (domImpl.equals("org.apache.xerces.dom.DocumentImpl")
-            || domImpl.equals("org.apache.xerces.dom.DeferredDocumentImpl")) {
-                System.out.println("Using Xerces");
-                // Try for Xerces
-                Class xercesSer =
-                        Class.forName("org.apache.xml.serialize.XMLSerializer");
-
-                // Get the OutputStream constructor
-                // May want to use the OutputFormat parameter at some stage too
-                con = xercesSer.getConstructor(new Class []
-                        { Class.forName("java.io.OutputStream"),
-                          Class.forName("org.apache.xml.serialize.OutputFormat") } );
-
-
-                // Get the serialize method
-                meth = xercesSer.getMethod("serialize",
-                            new Class [] { Class.forName("org.w3c.dom.Document") } );
-
-
-                // Get an instance
-                Object serializer = con.newInstance(new Object [] { baos, null } );
-
-
-                // Now call serialize to write the document
-                meth.invoke(serializer, new Object [] { doc } );
-            }
-            else if (domImpl.equals("gnu.xml.dom.DomDocument")) {
-                System.out.println("Using GNU");
-
-                Class gnuSer = Class.forName("gnu.xml.dom.ls.DomLSSerializer");
-
-                // Get the serialize method
-                meth = gnuSer.getMethod("serialize",
-                            new Class [] { Class.forName("org.w3c.dom.Node"),
-                            Class.forName("java.io.OutputStream") } );
-
-                // Get an instance
-                Object serializer = gnuSer.newInstance();
-
-                // Now call serialize to write the document
-                meth.invoke(serializer, new Object [] { doc, baos } );
-            }
-            else {
-                // We dont have another parser
-                try {
-                        DOMSource domSource = new DOMSource(doc);
-                        StringWriter writer = new StringWriter();
-                        StreamResult result = new StreamResult(writer);
-                        TransformerFactory tf = TransformerFactory.newInstance();
-                        Transformer transformer = tf.newTransformer();
-                        transformer.transform(domSource, result);
-                        return writer.toString().getBytes();
-                    }
-                catch (Exception e) {
-                    // We don't have another parser
-                    throw new IOException("No appropriate API (JAXP/Xerces) to serialize XML document: " + domImpl);
-                }
-            }
-        }
-        catch (ClassNotFoundException cnfe) {
-            throw new IOException(cnfe.toString());
+            DOMSource domSource = new DOMSource(doc);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            StreamResult result = new StreamResult(output);
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.transform(domSource, result);
+            return output.toByteArray();
         }
         catch (Exception e) {
-            // We may get some other errors, but the bottom line is that
-            // the steps being executed no longer work
-            throw new IOException(e.toString());
+            throw new IOException("Unable to serialize XML document: " + e);
         }
-
-        byte bytes[] = baos.toByteArray();
-
-        return bytes;
     }
 
 

--- a/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/converter/xml/OfficeDocument.java
+++ b/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/converter/xml/OfficeDocument.java
@@ -28,9 +28,8 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.BufferedReader;
 import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.InputStreamReader;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Iterator;
@@ -840,9 +839,6 @@ public abstract class OfficeDocument
      *  <p>Write out a <code>org.w3c.dom.Document</code> object into a
      *  <code>byte</code> array.</p>
      *
-     *  <p>TODO: remove dependency on com.sun.xml.tree.XmlDocument
-     *  package!</p>
-     *
      *  @param  doc  DOM <code>Document</code> object.
      *
      *  @return  <code>byte</code> array of DOM <code>Document</code>
@@ -852,118 +848,18 @@ public abstract class OfficeDocument
      */
     static byte[] docToBytes(Document doc)
         throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        java.lang.reflect.Constructor con;
-        java.lang.reflect.Method meth;
-
-        String domImpl = doc.getClass().getName();
-
-        /*
-         * We may have multiple XML parsers in the Classpath.
-         * Depending on which one is first, the actual type of
-         * doc may vary.  Need a way to find out which API is being
-         * used and use an appropriate serialization method.
-         */
-
         try {
-            // First of all try for JAXP 1.0
-            if (domImpl.equals("com.sun.xml.tree.XmlDocument")) {
-
-                Debug.log(Debug.INFO, "Using JAXP");
-
-                Class jaxpDoc = Class.forName("com.sun.xml.tree.XmlDocument");
-
-                // The method is in the XMLDocument class itself, not a helper
-                meth = jaxpDoc.getMethod("write",
-                            new Class[] { Class.forName("java.io.OutputStream") } );
-
-                meth.invoke(doc, new Object [] { baos } );
-            }
-	     else if (domImpl.equals("org.apache.crimson.tree.XmlDocument"))
-	    {
-                Debug.log(Debug.INFO, "Using Crimson");
-
-		 Class crimsonDoc = Class.forName("org.apache.crimson.tree.XmlDocument");
-		 // The method is in the XMLDocument class itself, not a helper
-                meth = crimsonDoc.getMethod("write",
-                            new Class[] { Class.forName("java.io.OutputStream") } );
-
-                meth.invoke(doc, new Object [] { baos } );
-	    }
-            else if (domImpl.equals("org.apache.xerces.dom.DocumentImpl")
-            || domImpl.equals("org.apache.xerces.dom.DeferredDocumentImpl")) {
-
-                Debug.log(Debug.INFO, "Using Xerces");
-
-                // Try for Xerces
-                Class xercesSer =
-                        Class.forName("org.apache.xml.serialize.XMLSerializer");
-
-                // Get the OutputStream constructor
-                // May want to use the OutputFormat parameter at some stage too
-                con = xercesSer.getConstructor(new Class []
-                        { Class.forName("java.io.OutputStream"),
-                          Class.forName("org.apache.xml.serialize.OutputFormat") } );
-
-
-                // Get the serialize method
-                meth = xercesSer.getMethod("serialize",
-                            new Class [] { Class.forName("org.w3c.dom.Document") } );
-
-
-                // Get an instance
-                Object serializer = con.newInstance(new Object [] { baos, null } );
-
-
-                // Now call serialize to write the document
-                meth.invoke(serializer, new Object [] { doc } );
-            }
-            else if (domImpl.equals("gnu.xml.dom.DomDocument")) {
-                Debug.log(Debug.INFO, "Using GNU");
-
-                Class gnuSer = Class.forName("gnu.xml.dom.ls.DomLSSerializer");
-
-                // Get the serialize method
-                meth = gnuSer.getMethod("serialize",
-                            new Class [] { Class.forName("org.w3c.dom.Node"),
-                            Class.forName("java.io.OutputStream") } );
-
-                // Get an instance
-                Object serializer = gnuSer.newInstance();
-
-                // Now call serialize to write the document
-                meth.invoke(serializer, new Object [] { doc, baos } );
-            }
-            else {
-		try {
-			DOMSource domSource = new DOMSource(doc);
-			StringWriter writer = new StringWriter();
-			StreamResult result = new StreamResult(writer);
-			TransformerFactory tf = TransformerFactory.newInstance();
-			Transformer transformer = tf.newTransformer();
-			transformer.transform(domSource, result);
-			return writer.toString().getBytes();
-		    }
-                catch (Exception e) {
-                    // We don't have another parser
-                    throw new IOException("No appropriate API (JAXP/Xerces) to serialize XML document: " + domImpl);
-                }
-            }
-        }
-        catch (ClassNotFoundException cnfe) {
-            throw new IOException(cnfe.toString());
+            DOMSource domSource = new DOMSource(doc);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            StreamResult result = new StreamResult(output);
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.transform(domSource, result);
+            return output.toByteArray();
         }
         catch (Exception e) {
-            // We may get some other errors, but the bottom line is that
-            // the steps being executed no longer work
-            throw new IOException(e.toString());
+            throw new IOException("Unable to serialize XML document: " + e);
         }
-
-        byte bytes[] = baos.toByteArray();
-
-        return bytes;
     }
 
 

--- a/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/util/registry/build.xml
+++ b/main/xmerge/java/xmerge/src/main/java/org/openoffice/xmerge/util/registry/build.xml
@@ -45,15 +45,9 @@
     <!-- define how to handle CLASSPATH environment -->
     <property name="build.sysclasspath" value="ignore"/>
 
-    <property environment="env"/>
-    <property name="env.XML_APIS_JAR" value="${solar.jar}/xml-apis.jar"/>
-    <property name="env.XERCES_JAR" value="${solar.jar}/xercesImpl.jar"/>
-
     <!-- classpath settings for javac tasks -->
     <path id="classpath">
         <pathelement location="${build.class}"/>
-        <pathelement location="${env.XML_APIS_JAR}"/>
-        <pathelement location="${env.XERCES_JAR}"/>
     </path>
 
     <!-- set whether we want to compile with or without deprecation -->

--- a/main/xmerge/util/build.xml
+++ b/main/xmerge/util/build.xml
@@ -31,8 +31,6 @@
     <property name="javadoc.dir" location="${WORKDIR}/Ant/xmerge-javadoc"/>
 
     <path id="main.classpath">
-<!--        <pathelement location="${OUTDIR}/bin/xml-apis.jar"/> -->
-<!--        <pathelement location="${OUTDIR}/bin/xercesImpl.jar"/> -->
         <pathelement location="${OUTDIR}/bin/unoil.jar"/>
         <pathelement location="${OUTDIR}/bin/ridl.jar"/>
         <pathelement location="${OUTDIR}/bin/jurt.jar"/>

--- a/main/xmerge/util/xmerge.mf
+++ b/main/xmerge/util/xmerge.mf
@@ -1,8 +1,6 @@
 Manifest-Version: 1.0
 Main-Class: org.openoffice.xmerge.test.Driver
-Class-Path: xml-apis.jar xercesImpl.jar serializer.jar
 Specification-Title: Apache OpenOffice XMerge Framework
 Specification-Vendor: Apache OpenOffice
 Specification-Version: 0.6.0
 Implementation-Version: #IMPL-VERSION#
-

--- a/main/xmerge/workben/build.xml
+++ b/main/xmerge/workben/build.xml
@@ -45,15 +45,9 @@
     <!-- define how to handle CLASSPATH environment -->
     <property name="build.sysclasspath" value="ignore"/>
 
-    <property environment="env"/>
-    <property name="env.XML_APIS_JAR" value="${solar.jar}/xml-apis.jar"/>
-    <property name="env.XERCES_JAR" value="${solar.jar}/xercesImpl.jar"/>
-
     <!-- classpath settings for javac tasks -->
     <path id="classpath">
         <pathelement location="${build.class}"/>
-        <pathelement location="${env.XML_APIS_JAR}"/>
-        <pathelement location="${env.XERCES_JAR}"/>
     </path>
 
     <!-- set whether we want to compile with or without deprecation -->


### PR DESCRIPTION
Both were absorbed by java and have been obsolete for a long time.

Build tested on FreeBSD.